### PR TITLE
clean up the schematic route

### DIFF
--- a/apps/nxui/src/index.html
+++ b/apps/nxui/src/index.html
@@ -9,8 +9,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="stylesheet" type="text/css" href="assets/xterm.css">
-  <!--<link href="https://fonts.googleapis.com/icon?family=Material+Icons+Extended" rel="stylesheet">-->
-  <!--<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">-->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Extended" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
 </head>
 
 <body>

--- a/libs/feature-addons/src/lib/addons/addons.component.html
+++ b/libs/feature-addons/src/lib/addons/addons.component.html
@@ -20,8 +20,6 @@
   </ul>
 </div>
 
-<div *ngIf="commandOutput$|async as commandOutput">
-  <p>Status: {{commandOutput.status}}</p>
-  <pre>{{commandOutput.stdout}}</pre>
-  <pre>{{commandOutput.stderr}}</pre>
+<div class="ui-terminal-container">
+  <ui-terminal [input]="(commandOutput$|async)?.out" #output></ui-terminal>
 </div>

--- a/libs/feature-addons/src/lib/addons/addons.component.ts
+++ b/libs/feature-addons/src/lib/addons/addons.component.ts
@@ -3,16 +3,8 @@ import { ActivatedRoute } from '@angular/router';
 import gql from 'graphql-tag';
 import { map, switchMap } from 'rxjs/operators';
 import { Apollo } from 'apollo-angular';
-import {
-  BehaviorSubject,
-  interval,
-  Observable,
-  Subscription,
-  combineLatest,
-  Subject
-} from 'rxjs';
-import { CommandRunner, Messenger } from '@nxui/utils';
-import { CommandOutput } from '@nxui/utils';
+import { Observable, Subject } from 'rxjs';
+import { CommandOutput, CommandRunner, Messenger } from '@nxui/utils';
 
 interface Addon {
   name: string;

--- a/libs/feature-addons/src/lib/feature-addons.module.ts
+++ b/libs/feature-addons/src/lib/feature-addons.module.ts
@@ -2,11 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Route, RouterModule } from '@angular/router';
 import { AddonsComponent } from './addons/addons.component';
+import { UiModule } from '@nxui/ui';
 
 export const addonsRoutes: Route[] = [{ path: '', component: AddonsComponent }];
 
 @NgModule({
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, UiModule],
   declarations: [AddonsComponent]
 })
 export class FeatureAddonsModule {}

--- a/libs/feature-generate/src/lib/feature-generate.module.ts
+++ b/libs/feature-generate/src/lib/feature-generate.module.ts
@@ -13,7 +13,14 @@ import {
 import { FlexLayoutModule } from '@angular/flex-layout';
 
 export const generateRoutes: Route[] = [
-  { path: '', pathMatch: 'full', component: SchematicsComponent }
+  {
+    path: '',
+    component: SchematicsComponent,
+    children: [
+      { path: ':collection/:schematic', component: SchematicComponent },
+      { path: '', pathMatch: 'full', component: SchematicComponent }
+    ]
+  }
 ];
 
 @NgModule({

--- a/libs/feature-generate/src/lib/schematic/schematic.component.html
+++ b/libs/feature-generate/src/lib/schematic/schematic.component.html
@@ -4,9 +4,14 @@
       {{schematic.collection}} {{schematic.name}} {{schematic.description}}
     </div>
     <ui-flags actionLabel="Generate" [prefix]="[schematic.name]" [fields]="schematic.schema" (value)="onFlagsChange($event)"
-      (action)="onGenerate()" (stop)="onStop()"></ui-flags>
+              (action)="onGenerate()" (stop)="onStop()"></ui-flags>
   </div>
-  <div class="ui-terminal-container">
-    <ui-terminal [input]="(combinedOutput$|async)?.out" #combinedOutput></ui-terminal>
+
+  <div *ngIf="!(schematic$|async)" class="ui-flags-container">
+    No Schematic Selected
+  </div>
+
+  <div *ngIf="(schematic$|async)" class="ui-terminal-container">
+    <ui-terminal [command]="command$|async" [input]="(combinedOutput$|async)?.out" #combinedOutput></ui-terminal>
   </div>
 </div>

--- a/libs/feature-generate/src/lib/schematics/schematics.component.html
+++ b/libs/feature-generate/src/lib/schematics/schematics.component.html
@@ -4,19 +4,20 @@
       <input placeholder="Filter schematics" #schematicFilter fxFlex [formControl]="schematicFilterFormControl">
       <mat-icon class="filter-icon" (click)="schematicFilter.select()">filter_list</mat-icon>
     </div>
-    <mat-selection-list class="schematic-list">
+    <mat-selection-list class="schematic-list" (selectionChange)="navigateToSelectedSchematic($event.option)">
       <ng-container *ngFor="let collection of (schematicCollections$ | async); trackBy: trackByName">
         <div class="collection-name">
           <mat-divider></mat-divider>
           <h3 matSubheader>{{ collection.name }}</h3>
           <mat-divider></mat-divider>
         </div>
-        <mat-list-option [value]="s" role="option" *ngFor="let s of collection.schematics; trackBy: trackByName">
+        <mat-list-option [value]="s" role="option" *ngFor="let s of collection.schematics; trackBy: trackByName" [selected]="isSelected(collection.name, s.name)">
           {{s.name}}
         </mat-list-option>
 
       </ng-container>
     </mat-selection-list>
   </div>
-  <nxui-schematic fxFlex [schematicDescription$]="selectedSchematic$"></nxui-schematic>
+
+  <router-outlet></router-outlet>
 </div>

--- a/libs/ui/src/lib/flags/flags.component.html
+++ b/libs/ui/src/lib/flags/flags.component.html
@@ -28,12 +28,15 @@
           {{ fieldOption(value) }}
         </option>
       </select>
+      <span *ngIf="field.defaultValue">
+        (default: {{ field.defaultValue }})
+      </span>
     </span>
     <span *ngIf="!field.enum && field.type !== 'boolean'">
       <input type="text" [formControlName]="field.name" [required]="field.required" [attr.name]="field.name">
-    </span>
-    <span *ngIf="field.defaultValue">
-      (default: {{ field.defaultValue }})
+      <span *ngIf="field.defaultValue">
+        (default: {{ field.defaultValue }})
+      </span>
     </span>
     <span *ngIf="field.required">
       *

--- a/libs/ui/src/lib/flags/flags.component.ts
+++ b/libs/ui/src/lib/flags/flags.component.ts
@@ -34,10 +34,10 @@ export class FlagsComponent {
   constructor(private readonly serializer: Serializer) {}
 
   fieldOptions(field: Field) {
-    if (field.enum) {
+    if (field.defaultValue) {
+      return field.enum;
+    } else {
       return [null, ...field.enum];
-    } else if (field.type === 'boolean') {
-      return [null, false, true];
     }
   }
 
@@ -60,7 +60,7 @@ export class FlagsComponent {
   private setForm() {
     const children = this._fields.reduce((m, f) => {
       m[f.name] = new FormControl(
-        null,
+        f.defaultValue,
         f.required ? Validators.required : null
       );
       return m;
@@ -85,7 +85,6 @@ export class FlagsComponent {
       this.configurations && value['configurations']
         ? [`--configuration=${value['configurations']}`]
         : [];
-
     this.value.next({
       commands: [
         ...this.prefix,

--- a/libs/ui/src/lib/terminal/terminal.component.html
+++ b/libs/ui/src/lib/terminal/terminal.component.html
@@ -1,3 +1,4 @@
+<div class="command">> {{command}}</div>
 <div class="terminal-container" #code>
 
 </div>

--- a/libs/ui/src/lib/terminal/terminal.component.scss
+++ b/libs/ui/src/lib/terminal/terminal.component.scss
@@ -3,3 +3,9 @@
   width: 100%;
   height: 100%;
 }
+
+.command {
+  color: white;
+  font-family: monospace;
+  padding: 3px;
+}

--- a/libs/ui/src/lib/terminal/terminal.component.ts
+++ b/libs/ui/src/lib/terminal/terminal.component.ts
@@ -3,12 +3,10 @@ import {
   Component,
   ElementRef,
   Input,
-  OnInit,
-  ViewChild,
-  OnDestroy
+  OnDestroy,
+  ViewChild
 } from '@angular/core';
 import { Terminal } from 'xterm';
-import { fit } from 'xterm/lib/addons/fit/fit';
 
 import { fromEvent } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
@@ -34,6 +32,8 @@ export class TerminalComponent implements AfterViewInit, OnDestroy {
   code: ElementRef;
 
   output: string;
+
+  @Input() command: string;
 
   @Input()
   set input(s: string) {

--- a/libs/utils/src/lib/command-runner.service.ts
+++ b/libs/utils/src/lib/command-runner.service.ts
@@ -6,7 +6,7 @@ import { Apollo } from 'apollo-angular';
 import { Injectable } from '@angular/core';
 
 export interface CommandOutput {
-  status: string;
+  status: 'success' | 'failure' | 'inprogress';
   out: string;
 }
 

--- a/libs/utils/src/lib/serializer.service.ts
+++ b/libs/utils/src/lib/serializer.service.ts
@@ -81,16 +81,27 @@ export class Serializer {
     const fields = schema.filter(
       s => value[s.name] !== undefined && value[s.name] !== null
     );
-    const args = fields.map(f => {
-      if (f.positional) {
-        return value[f.name];
-      } else if (f.type === 'boolean') {
-        return value[f.name] ? `--${f.name}` : `--no-${f.name}`;
-      } else {
-        return `--${f.name}=${value[f.name]}`;
-      }
-    });
+    const args = fields
+      .map(f => {
+        if (f.defaultValue === value[f.name]) return null;
+        if (f.positional) {
+          return value[f.name];
+        } else if (f.type === 'boolean') {
+          return value[f.name] ? `--${f.name}` : `--no-${f.name}`;
+        } else {
+          return `--${f.name}=${value[f.name]}`;
+        }
+      })
+      .filter(r => !!r);
     return args;
+  }
+
+  argsToString(args: string[]): string {
+    return args
+      .map(a => {
+        return a.indexOf(' ') > -1 ? `"${a}"` : a;
+      })
+      .join(' ');
   }
 
   private importantSchematicField(collection: string, name: string) {


### PR DESCRIPTION
1. Make SchematicComponent routable as it was before (this is to support navigation from other screens), and to enable refresh.
2. Clean up the form values (set the values to defaultValue, filter out default values when generating the command).
3. Cleaned up interaction with the terminal. The terminal is a stateful object. Which means that it should not be used to display the whole "output". There is no whole output, all we get is a delta, a series of commands. The following guidelines should be considered when interacting with the terminal:

* it should be cleared only when the user clicks on a button or a request is made to the server
* since a command can get its output in chunks, we cannot clear terminal for each chunk. We also cannot display the command itself in the terminal. 

