### PR TITLE
feat: disable pinch zooming

### DIFF
--- a/apps/nxui/src/main.ts
+++ b/apps/nxui/src/main.ts
@@ -3,6 +3,30 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import { WebFrame } from 'electron';
+
+/**
+ * @jeffbcross: The following disables pinch zooming,
+ * because pinching to zoom is awkward on a desktop app.
+ * **Scaling is still supported** (i.e. Cmd + and Cmd -)
+ *
+ * Setting the zoom limit must be done in the renderer thread using webFrame.
+ * Since this same app is used in two contexts: browser or electron,
+ * it is wrapped in a conditional to make sure it's node. It's also
+ * using global['require'] to access `require` so that webpack doesn't try to
+ * resolve the import.
+ */
+declare var global: any;
+let webFrame: WebFrame;
+if (typeof global !== 'undefined' && global['require']) {
+  try {
+    webFrame = global['require']('electron').webFrame;
+    webFrame.setZoomLevel(0);
+    webFrame.setVisualZoomLevelLimits(1, 1);
+  } catch (e) {
+    console.error('Could not get ahold of webFrame to prevent zooming.');
+  }
+}
 
 if (environment.production) {
   enableProdMode();


### PR DESCRIPTION
Disables users from pinching to zoom, because this only makes the viewport larger than the available screen area, which makes for an awkward experience. However, users are still able to scale the UI using standard keyboard shortcuts, which is different from zooming.

Here is the bad way, with pinch zooming. Notice how the view is cropped:

<img width="1401" alt="screen shot 2018-07-19 at 10 03 22 pm" src="https://user-images.githubusercontent.com/463703/42984179-21436318-8ba0-11e8-98df-24a7d964e09a.png">

And here is the better, scaling (it's ugly now, but at least all content is in the viewport, similar to experience with typical IDEs):

<img width="1403" alt="screen shot 2018-07-19 at 10 06 19 pm" src="https://user-images.githubusercontent.com/463703/42984175-1b7be4b4-8ba0-11e8-902e-825520078deb.png">
