### PR TITLE
feat: lazy load the projects pane

### DIFF
--- a/apps/vscode/src/app/workspace-json-tree/workspace-json-tree-provider.ts
+++ b/apps/vscode/src/app/workspace-json-tree/workspace-json-tree-provider.ts
@@ -25,6 +25,8 @@ export let workspaceJsonTreeProvider: WorkspaceJsonTreeProvider;
 export class WorkspaceJsonTreeProvider extends AbstractTreeProvider<
   WorkspaceJsonTreeItem
 > {
+  loading = true;
+
   constructor(
     context: ExtensionContext,
     private readonly cliTaskProvider: CliTaskProvider
@@ -113,6 +115,15 @@ export class WorkspaceJsonTreeProvider extends AbstractTreeProvider<
   getChildren(
     parent?: WorkspaceJsonTreeItem
   ): ProviderResult<WorkspaceJsonTreeItem[]> {
+    if (this.loading) {
+      setTimeout(() => {
+        this.loading = false;
+        this.refresh();
+      });
+      return [
+        this.createWorkspaceJsonTreeItem({ project: 'Loading' }, 'Loading')
+      ];
+    }
     if (!parent) {
       const projects = this.cliTaskProvider.getProjectEntries();
       return projects.map(


### PR DESCRIPTION
Load the projects pane after the other 2 side panel panes so that those side panels can be used right away in large workspaces.

Before:
![blocking-projects](https://user-images.githubusercontent.com/861504/82671558-0d4ed700-9c0d-11ea-9203-598a69a6019b.gif)

After:
![lazy-load-projects](https://user-images.githubusercontent.com/861504/82671571-12138b00-9c0d-11ea-9ecd-9e94d711de5c.gif)
