### PR TITLE
feat: show generate ui from explorer context menu

### DIFF
--- a/apps/vscode/src/app/cli-task/cli-task-commands.ts
+++ b/apps/vscode/src/app/cli-task/cli-task-commands.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, window } from 'vscode';
+import { commands, ExtensionContext, window, Uri } from 'vscode';
 
 import { selectSchematic } from '../select-schematic';
 import { verifyWorkspace } from '../verify-workspace/verify-workspace';
@@ -61,9 +61,12 @@ export function registerCliTaskCommands(
   commands.registerCommand(`nx.generate.ui`, () =>
     selectCliCommandAndShowUi('generate', context.extensionPath)
   );
+  commands.registerCommand(`nx.generate.ui.fileexplorer`, (uri: Uri) =>
+    selectCliCommandAndShowUi('generate', context.extensionPath, uri)
+  );
 }
 
-function selectCliCommandAndShowUi(command: string, extensionPath: string) {
+function selectCliCommandAndShowUi(command: string, extensionPath: string, uri?: Uri) {
   const workspacePath = cliTaskProvider.getWorkspacePath();
   if (!workspacePath) {
     window.showErrorMessage(
@@ -84,7 +87,7 @@ function selectCliCommandAndShowUi(command: string, extensionPath: string) {
     extensionPath
   );
 
-  commands.executeCommand('nxConsole.revealWebViewPanel', workspaceTreeItem);
+  commands.executeCommand('nxConsole.revealWebViewPanel', workspaceTreeItem, uri);
 }
 
 async function selectCliCommandAndPromptForFlags(command: string) {

--- a/apps/vscode/src/app/vscode-storage.ts
+++ b/apps/vscode/src/app/vscode-storage.ts
@@ -32,7 +32,7 @@ export class VSCodeStorage implements Store {
   }
 }
 
-const ConfigKeys = ['enableTelemetry', 'useNVM'];
+const ConfigKeys = ['enableTelemetry', 'useNVM', 'enableGenerateFromContextMenu'];
 
 function isConfig(key: string): boolean {
   return ConfigKeys.includes(key);

--- a/apps/vscode/src/app/webview.ts
+++ b/apps/vscode/src/app/webview.ts
@@ -25,21 +25,23 @@ interface RevealWebViewPanelConfig {
   workspaceTreeItem: WorkspaceTreeItem;
   cliTaskProvider: CliTaskProvider;
   workspaceTreeView: TreeView<WorkspaceTreeItem>;
+  contextMenuUri?: Uri;
 }
 
 export async function revealWebViewPanel({
   context,
   cliTaskProvider,
   workspaceTreeItem,
-  workspaceTreeView
+  workspaceTreeView,
+  contextMenuUri
 }: RevealWebViewPanelConfig) {
   const { label } = workspaceTreeItem;
-
-  const schema = await getTaskExecutionSchema(cliTaskProvider, label);
+  const schema = await getTaskExecutionSchema(cliTaskProvider, label, contextMenuUri);
 
   if (!schema) {
     return;
   }
+
 
   const webViewPanel = createWebViewPanel(
     context,
@@ -57,6 +59,7 @@ export async function revealWebViewPanel({
 
   return webViewPanel;
 }
+
 
 export function createWebViewPanel(
   context: ExtensionContext,

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -6,7 +6,8 @@ import {
   tasks,
   TreeView,
   window,
-  workspace
+  workspace,
+  Uri
 } from 'vscode';
 
 import { WorkspaceJsonTreeItem } from './app/workspace-json-tree/workspace-json-tree-item';
@@ -60,7 +61,7 @@ export function activate(c: ExtensionContext) {
     context.subscriptions.push(
       commands.registerCommand(
         'nxConsole.revealWebViewPanel',
-        async (workspaceTreeItem: WorkspaceTreeItem) => {
+        async (workspaceTreeItem: WorkspaceTreeItem, contextMenuUri?: Uri) => {
           if (
             !existsSync(
               join(workspaceTreeItem.workspaceJsonPath, '..', 'node_modules')
@@ -77,7 +78,8 @@ export function activate(c: ExtensionContext) {
             workspaceTreeItem,
             context,
             cliTaskProvider,
-            workspaceTreeView
+            workspaceTreeView,
+            contextMenuUri,
           });
         }
       )
@@ -196,12 +198,17 @@ async function setWorkspace(workspaceJsonPath: string) {
 
   const isNxWorkspace = existsSync(join(workspaceJsonPath, '..', 'nx.json'));
   const isAngularWorkspace = workspaceJsonPath.endsWith('angular.json');
+  const store = VSCodeStorage.fromContext(context);
+  const enableGenerateFromContextMenuSetting = store.get('enableGenerateFromContextMenu');
+  const isGenerateFromContextMenuEnabled = enableGenerateFromContextMenuSetting && (isNxWorkspace || isAngularWorkspace);
+
   commands.executeCommand(
     'setContext',
     'isAngularWorkspace',
     isAngularWorkspace
   );
   commands.executeCommand('setContext', 'isNxWorkspace', isNxWorkspace);
+  commands.executeCommand('setContext', 'isGenerateFromContextMenuEnabled', isGenerateFromContextMenuEnabled);
 
   currentWorkspaceTreeProvider.setWorkspaceJsonPath(workspaceJsonPath);
   workspaceJsonTreeProvider.setWorkspaceJsonPathh(workspaceJsonPath);

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -45,6 +45,13 @@
   },
   "contributes": {
     "menus": {
+      "explorer/context": [
+        {
+            "when": "isGenerateFromContextMenuEnabled",
+            "command": "nx.generate.ui.fileexplorer",
+            "group": "explorerContext"
+        }
+      ],
       "view/title": [
         {
           "command": "nxConsole.refreshNxProjectsTree",
@@ -448,6 +455,11 @@
         "category": "nx",
         "title": "generate (ui)",
         "command": "nx.generate.ui"
+      },
+      {
+        "category": "nx",
+        "title": "Nx generate (ui)",
+        "command": "nx.generate.ui.fileexplorer"
       }
     ],
     "configuration": {
@@ -462,6 +474,11 @@
           "type": "boolean",
           "default": false,
           "description": "Runs tasks using Node Version Manager"
+        },
+        "nxConsole.enableGenerateFromContextMenu": {
+          "type": "boolean",
+          "default": true,
+          "description": "Shows or hides Nx Generate ui option from the file explorer context menu."
         }
       }
     },

--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -16,6 +16,7 @@ export interface TaskExecutionSchema {
   description: string;
   configurations?: ArchitectConfiguration[];
   options: Option[];
+  contextValues?: Record<string, string | number | boolean | undefined>;
 }
 
 export interface SchematicCollection {

--- a/libs/vscode-ui/components/src/lib/field/field.component.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.ts
@@ -46,6 +46,7 @@ export class FieldComponent implements ControlValueAccessor, OnDestroy {
 
   set value(value: string) {
     this._value = value;
+    this.control.setValue(value);
     this.onChange(this._value);
   }
 

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -252,7 +252,7 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
       }
       taskExecForm.addControl(
         schema.name,
-        new FormControl(defaultValues[schema.name], validators)
+        new FormControl((architect.contextValues && architect.contextValues[schema.name]) || defaultValues[schema.name], validators)
       );
     });
 
@@ -277,6 +277,7 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
       top: 0
     });
   }
+
 
   private getDefaultValuesForConfiguration(
     architect: TaskExecutionSchema,


### PR DESCRIPTION
nx generate ui can be shown by right clicking in explorer context menu
the path you click on will be used as a value for the "path" option
the "project" option will also be updated based on the path 

See discussion in #974, issues listed there has been solved. 

I have only tested on windows so far. Should we make sure it works in mac and linux as well?

Any more changes or suggestions?
