### PR TITLE
fix: add default field as argument

### DIFF
--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -252,7 +252,11 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
       }
       taskExecForm.addControl(
         schema.name,
-        new FormControl((architect.contextValues && architect.contextValues[schema.name]) || defaultValues[schema.name], validators)
+        new FormControl(
+          (architect.contextValues && architect.contextValues[schema.name]) ||
+            defaultValues[schema.name],
+          validators
+        )
       );
     });
 
@@ -277,7 +281,6 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
       top: 0
     });
   }
-
 
   private getDefaultValuesForConfiguration(
     architect: TaskExecutionSchema,
@@ -342,7 +345,6 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
 
     const args: string[] = [];
     fields.forEach(f => {
-      if (defaultValues[f.name] === value[f.name]) return;
       if (!defaultValues[f.name] && !value[f.name]) return;
       if (f.positional) {
         args.push(sanitizeWhitespace(value[f.name]));


### PR DESCRIPTION
Pass the default field as an argument so the angular CLI does not prompt you for the default again