### PR TITLE
Fixes opening new terminal on workspace generator dry run

### DIFF
--- a/apps/vscode/src/app/cli-task/cli-task-provider.ts
+++ b/apps/vscode/src/app/cli-task/cli-task-provider.ts
@@ -18,6 +18,8 @@ import {
   Projects,
   WorkspaceJson
 } from './cli-task-definition';
+import { NxTask } from './nx-task';
+import { WORKSPACE_GENERATOR_NAME_REGEX } from '@nx-console/schema';
 
 export let cliTaskProvider: CliTaskProvider;
 
@@ -88,7 +90,26 @@ export class CliTaskProvider implements TaskProvider {
       return;
     }
 
-    const task = this.createTask(definition);
+    let task;
+    const positionals = definition.positional.match(
+      WORKSPACE_GENERATOR_NAME_REGEX
+    );
+    if (
+      definition.command === 'generate' &&
+      positionals &&
+      positionals.length > 2
+    ) {
+      task = NxTask.create(
+        {
+          command: `workspace-${positionals[1]}`,
+          positional: positionals[2],
+          flags: definition.flags
+        },
+        cliTaskProvider.getWorkspacePath()
+      );
+    } else {
+      task = this.createTask(definition);
+    }
 
     const telemetry = getTelemetry();
     telemetry.featureUsed(definition.command);

--- a/apps/vscode/src/app/webview.ts
+++ b/apps/vscode/src/app/webview.ts
@@ -6,15 +6,13 @@ import {
   Uri,
   ViewColumn,
   WebviewPanel,
-  window,
-  tasks
+  window
 } from 'vscode';
 
 import { CliTaskProvider } from './cli-task/cli-task-provider';
 import { getTaskExecutionSchema } from './workspace-tree/get-task-execution-schema';
 import { WorkspaceTreeItem } from './workspace-tree/workspace-tree-item';
 import { getTelemetry } from './telemetry';
-import { NxTask } from './cli-task/nx-task';
 import { TaskExecutionSchema, TaskExecutionMessage } from '@nx-console/schema';
 
 let webviewPanel: WebviewPanel | undefined;
@@ -92,30 +90,8 @@ export function createWebViewPanel(
 
     webviewPanel.webview.html = getIframeHtml(context, schema);
 
-    webviewPanel.webview.onDidReceiveMessage(
-      (message: TaskExecutionMessage) => {
-        if (
-          message.command === 'generate' &&
-          message.positional.startsWith('workspace-schematic:')
-        ) {
-          tasks.executeTask(
-            NxTask.create(
-              {
-                command: 'workspace-schematic',
-                positional: message.positional.replace(
-                  'workspace-schematic:',
-                  ''
-                ),
-                flags: message.flags
-              },
-              cliTaskProvider.getWorkspacePath()
-            )
-          );
-          return;
-        }
-
-        cliTaskProvider.executeTask(message);
-      }
+    webviewPanel.webview.onDidReceiveMessage((message: TaskExecutionMessage) =>
+      cliTaskProvider.executeTask(message)
     );
   }
 

--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -93,3 +93,5 @@ export interface Architect {
   configurations: ArchitectConfiguration[];
   options: CliOption[];
 }
+
+export const WORKSPACE_GENERATOR_NAME_REGEX = /^workspace-(schematic|generator):(.+)/;

--- a/libs/vscode-ui/components/src/lib/format-task/format-task.pipe.spec.ts
+++ b/libs/vscode-ui/components/src/lib/format-task/format-task.pipe.spec.ts
@@ -1,0 +1,38 @@
+import { FormatTaskPipe } from './format-task.pipe';
+
+describe('FormatTaskPipe', () => {
+  const pipe = new FormatTaskPipe();
+
+  it('should reformat workspace generator commands', () => {
+    expect(
+      pipe.transform({
+        name: '',
+        cliName: 'ng',
+        description: '',
+        options: [],
+        command: 'generate',
+        positional: 'workspace-schematic:xyz-name'
+      })
+    ).toEqual('nx workspace-schematic xyz-name');
+    expect(
+      pipe.transform({
+        name: '',
+        cliName: 'ng',
+        description: '',
+        options: [],
+        command: 'generate',
+        positional: 'workspace-generator:xyz-name'
+      })
+    ).toEqual('nx workspace-generator xyz-name');
+    expect(
+      pipe.transform({
+        name: '',
+        cliName: 'ng',
+        description: '',
+        options: [],
+        command: 'generate',
+        positional: '@nrwl/angular:library'
+      })
+    ).toEqual('ng generate @nrwl/angular:library');
+  });
+});

--- a/libs/vscode-ui/components/src/lib/format-task/format-task.pipe.ts
+++ b/libs/vscode-ui/components/src/lib/format-task/format-task.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {
+  TaskExecutionSchema,
+  WORKSPACE_GENERATOR_NAME_REGEX
+} from '@nx-console/schema';
+
+@Pipe({
+  name: 'formatTask'
+})
+export class FormatTaskPipe implements PipeTransform {
+  transform(architect: TaskExecutionSchema): string {
+    const positionals = architect.positional.match(
+      WORKSPACE_GENERATOR_NAME_REGEX
+    );
+    if (architect.command === 'generate' && positionals && positionals.length) {
+      architect = {
+        ...architect,
+        cliName: 'nx',
+        command: `workspace-${positionals[1]}`,
+        positional: positionals[2]
+      };
+    }
+    return `${architect.cliName} ${architect.command} ${architect.positional}`;
+  }
+}

--- a/libs/vscode-ui/components/src/lib/vscode-ui-components.module.ts
+++ b/libs/vscode-ui/components/src/lib/vscode-ui-components.module.ts
@@ -8,6 +8,7 @@ import { CheckboxComponent } from './checkbox/checkbox.component';
 import { FieldComponent } from './field/field.component';
 import { FieldTreeComponent } from './field-tree/field-tree.component';
 import { MultipleSelectComponent } from './multiple-select/multiple-select.component';
+import { FormatTaskPipe } from './format-task/format-task.pipe';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule],
@@ -18,7 +19,8 @@ import { MultipleSelectComponent } from './multiple-select/multiple-select.compo
     CheckboxComponent,
     FieldComponent,
     FieldTreeComponent,
-    MultipleSelectComponent
+    MultipleSelectComponent,
+    FormatTaskPipe
   ],
   exports: [
     AutocompleteComponent,
@@ -27,7 +29,8 @@ import { MultipleSelectComponent } from './multiple-select/multiple-select.compo
     CheckboxComponent,
     FieldComponent,
     FieldTreeComponent,
-    MultipleSelectComponent
+    MultipleSelectComponent,
+    FormatTaskPipe
   ]
 })
 export class VscodeUiComponentsModule {}

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="(taskExecForm$ | async) as taskExecForm">
+<ng-container *ngIf="taskExecForm$ | async as taskExecForm">
   <div
     [class.has-configurations]="
       taskExecForm.architect.configurations &&
@@ -45,7 +45,7 @@
     <div class="scroll-container" #scrollContainer>
       <div
         class="form-container flags-and-fields-container fx-row"
-        *ngIf="(filteredFields$ | async) as filteredFields"
+        *ngIf="filteredFields$ | async as filteredFields"
       >
         <vscode-ui-field-tree
           [activeFieldName]="activeFieldName$ | async"
@@ -55,9 +55,7 @@
         <form class="fields fx-flex" [formGroup]="taskExecForm.form">
           <div class="title-container fx-row">
             <span class="fx-flex title">
-              {{ taskExecForm.architect.cliName }}
-              {{ taskExecForm.architect.command }}
-              {{ taskExecForm.architect.positional }}
+              {{ taskExecForm.architect | formatTask }}
               <ng-container
                 *ngIf="
                   taskExecForm.form.get('configuration')?.value as configuration
@@ -72,7 +70,7 @@
             </span>
           </div>
 
-          <ng-container *ngIf="(defaultValues$ | async) as defaultValues">
+          <ng-container *ngIf="defaultValues$ | async as defaultValues">
             <nx-console-field
               [id]="field.name + '-nx-console-field'"
               *ngFor="let field of taskExecForm.architect.options"


### PR DESCRIPTION
Dry runs on workspace generators/schematics were launching a new terminal window with each dry run when the user is filling out the properties.
* Updates the webview to pass through workspace generator/schematic commands to the CliTaskProvider which has support for deferred dry run
* Updates the Task Execution Form header to show the workspace generator/schematic command instead of `ng generate`