### PR TITLE
fix: add support for "targets" alias in addition to default "architect"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
     <img src="https://raw.githubusercontent.com/nrwl/nx-console/master/static/nx-console.png" width="500"/>
 </p>
 
-
 # The UI for Nx
 
 [![License](https://img.shields.io/npm/l/@nrwl/schematics.png)](https://opensource.org/licenses/MIT)

--- a/libs/server/src/lib/utils/read-projects.ts
+++ b/libs/server/src/lib/utils/read-projects.ts
@@ -20,7 +20,7 @@ export function readProjects(json: any): Project[] {
         name: key,
         root: value.root,
         projectType: value.projectType,
-        architect: readArchitect(key, value.architect)
+        architect: readArchitect(key, value.architect || value.targets)
       })
     )
     .sort((a, b) => a.root.localeCompare(b.root));

--- a/libs/server/src/lib/utils/utils.spec.ts
+++ b/libs/server/src/lib/utils/utils.spec.ts
@@ -84,24 +84,24 @@ describe('utils', () => {
       });
       it('should set field type as Select when x-prompt has long form options', async () => {
         const xPrompt: LongFormXPrompt = {
-          "message": "This is the x-prompt message",
-          "type": "list",
-          "items": [
+          message: 'This is the x-prompt message',
+          type: 'list',
+          items: [
             {
-              "value": "css",
-              "label": "CSS"
+              value: 'css',
+              label: 'CSS'
             },
             {
-              "value": "scss",
-              "label": "SASS(.scss)  [ http://sass-lang.com   ]"
+              value: 'scss',
+              label: 'SASS(.scss)  [ http://sass-lang.com   ]'
             },
             {
-              "value": "styl",
-              "label": "Stylus(.styl)[ http://stylus-lang.com ]"
+              value: 'styl',
+              label: 'Stylus(.styl)[ http://stylus-lang.com ]'
             },
             {
-              "value": "less",
-              "label": "LESS         [ http://lesscss.org     ]"
+              value: 'less',
+              label: 'LESS         [ http://lesscss.org     ]'
             }
           ]
         };

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="taskExecForm$ | async as taskExecForm">
+<ng-container *ngIf="(taskExecForm$ | async) as taskExecForm">
   <div
     [class.has-configurations]="
       taskExecForm.architect.configurations &&
@@ -45,7 +45,7 @@
     <div class="scroll-container" #scrollContainer>
       <div
         class="form-container flags-and-fields-container fx-row"
-        *ngIf="filteredFields$ | async as filteredFields"
+        *ngIf="(filteredFields$ | async) as filteredFields"
       >
         <vscode-ui-field-tree
           [activeFieldName]="activeFieldName$ | async"
@@ -70,7 +70,7 @@
             </span>
           </div>
 
-          <ng-container *ngIf="defaultValues$ | async as defaultValues">
+          <ng-container *ngIf="(defaultValues$ | async) as defaultValues">
             <nx-console-field
               [id]="field.name + '-nx-console-field'"
               *ngFor="let field of taskExecForm.architect.options"


### PR DESCRIPTION
Angular CLI supports field "targets" as alias of "architect". Nx console doesn't support this alias, but we use it in our project.

See this change in Angular CLI's schema.json: https://github.com/angular/angular-cli/commit/e6f9ae98f5c3688b6efb9390956b0b60fbfaf228

Specifically, this snippet shows that the two fields are equal:

```jsonc
{
  "architect": {
    "type": "object",
    "additionalProperties": {
      "$ref": "#/definitions/project/definitions/target"
    }
  },
  "targets": {
    "type": "object",
    "additionalProperties": {
      "$ref": "#/definitions/project/definitions/target"
    }
  },
  // ...
  "anyOf": [
    {
      "required": ["architect"],
      "not": {
        "required": ["targets"]
      }
    },
    {
      "required": ["targets"],
      "not": {
        "required": ["architect"]
      }
    }
  ]
}
```