### PR TITLE
temp fix to rename packaged -es2015.js files to .js

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -49,6 +49,8 @@ module.exports = {
     package: {
       vscode: nps.series(
         `shx rm -rf ${join('dist', 'apps', 'vscode', '**', '*-es5.js')}`,
+        `shx mv ${join('dist', 'apps', 'vscode', 'assets', 'public', 'runtime-es2015.js')} ${join('dist', 'apps', 'vscode', 'assets', 'public', 'runtime.js')}`,
+        `shx mv ${join('dist', 'apps', 'vscode', 'assets', 'public', 'main-es2015.js')} ${join( 'dist', 'apps', 'vscode', 'assets', 'public', 'main.js')}`,
         `shx rm -rf ${join('dist', 'apps', 'vscode', '**', '*.ts')}`,
         `node ${join('tools', 'scripts', 'vscode-vsce.js')}`
       )


### PR DESCRIPTION
`ng build vscode-ui --watch --prod` generates runtime.js and main.js, which is what the [getIframHtml](https://github.com/nrwl/nx-console/blob/master/apps/vscode/src/app/webview.ts#L139) seems to expect; whereas,
`ng build vscode-ui --prod1` is generating runtime-es2015.js/runtime-es5.js and main-es2015.js/main-es5.js

Updates the package.vscode script to rename the files.