### PR TITLE
properly start debugging

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,6 +13,22 @@
       "group": {
         "kind": "build",
         "isDefault": true
+      },
+      "problemMatcher": {
+        "owner": "typescript",
+        "source": "ts",
+        "applyTo": "closedDocuments",
+        "fileLocation": ["relative", "${cwd}"],
+        "pattern": "$tsc",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "(.*?)"
+          },
+          "endsPattern": {
+            "regexp": "runtime.js"
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
This sets the tasks.json to "listen" to the terminal output so that it can start up the next task. This means that we can start debugging with just F5 and not have to do weird workarounds. 
