### PR TITLE
Fix Build form RUN_ONE_OPTIONS checkboxes

### DIFF
--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -16,14 +16,6 @@ export interface ItemsWithEnum {
   type: OptionType;
 }
 
-export enum OptionComponent {
-  Autocomplete = 'autocomplete',
-  Checkbox = 'checkBox',
-  Input = 'input',
-  Select = 'select',
-  MultiSelect = 'multiSelect'
-}
-
 export type XPrompt = string | LongFormXPrompt;
 export interface LongFormXPrompt {
   message: string;

--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -1,7 +1,6 @@
 import { Option as CliOption, OptionType } from '@angular/cli/models/interface';
 
 export interface Option extends Omit<CliOption, 'default'> {
-  component?: OptionComponent;
   tooltip?: string;
   itemTooltips?: ItemTooltips;
   items?: string[] | ItemsWithEnum;

--- a/libs/server/src/lib/utils/utils.spec.ts
+++ b/libs/server/src/lib/utils/utils.spec.ts
@@ -1,6 +1,6 @@
 import { normalizeSchema } from './utils';
 import { OptionType } from '@angular/cli/models/interface';
-import { OptionComponent, LongFormXPrompt, Option } from '@nx-console/schema';
+import { LongFormXPrompt, Option } from '@nx-console/schema';
 
 describe('utils', () => {
   describe('normalizeSchema', () => {
@@ -50,80 +50,6 @@ describe('utils', () => {
       };
       const r = await getSchema([option]);
       expect(r[0].items).toEqual(['test']);
-    });
-
-    describe('fieldType', () => {
-      it('should set field type as Autocomplete when number of enum options is greater than 10', async () => {
-        const option = {
-          ...mockOption,
-          enum: [...Array(11).keys()]
-        };
-        const r = await getSchema([option]);
-        expect(r[0].component).toBe(OptionComponent.Autocomplete);
-      });
-      it('should set field type as Select when number of enum options is less than or equal to 10', async () => {
-        const option = {
-          ...mockOption,
-          enum: [...Array(10).keys()]
-        };
-        const r = await getSchema([option]);
-        expect(r[0].component).toBe(OptionComponent.Select);
-      });
-      it('should set field type as MultiSelect when x-prompt has options and multi is true', async () => {
-        const xPrompt: LongFormXPrompt = {
-          message: '',
-          type: 'list',
-          multiselect: true
-        };
-        const option = {
-          ...mockOption,
-          'x-prompt': xPrompt
-        };
-        const r = await getSchema([option]);
-        expect(r[0].component).toBe(OptionComponent.MultiSelect);
-      });
-      it('should set field type as Select when x-prompt has long form options', async () => {
-        const xPrompt: LongFormXPrompt = {
-          "message": "This is the x-prompt message",
-          "type": "list",
-          "items": [
-            {
-              "value": "css",
-              "label": "CSS"
-            },
-            {
-              "value": "scss",
-              "label": "SASS(.scss)  [ http://sass-lang.com   ]"
-            },
-            {
-              "value": "styl",
-              "label": "Stylus(.styl)[ http://stylus-lang.com ]"
-            },
-            {
-              "value": "less",
-              "label": "LESS         [ http://lesscss.org     ]"
-            }
-          ]
-        };
-        const option = {
-          ...mockOption,
-          'x-prompt': xPrompt
-        };
-        const r = await getSchema([option]);
-        expect(r[0].component).toBe(OptionComponent.Select);
-      });
-      it('should set field type as Checkbox when option type is boolean', async () => {
-        const option = {
-          ...mockOption,
-          type: OptionType.Boolean
-        };
-        const r = await getSchema([option]);
-        expect(r[0].component).toBe(OptionComponent.Checkbox);
-      });
-      it('should set field type as Input when option has no enum and type is not boolean', async () => {
-        const r = await getSchema([mockOption]);
-        expect(r[0].component).toBe(OptionComponent.Input);
-      });
     });
 
     describe('xPrompt', () => {

--- a/libs/server/src/lib/utils/utils.ts
+++ b/libs/server/src/lib/utils/utils.ts
@@ -175,13 +175,13 @@ export async function normalizeSchema(
     const nxOption: Option = {
       ...option,
       required: isFieldRequired(requiredFields, option, xPrompt, $default),
-      ...(workspaceDefault && {default: workspaceDefault}),
-      ...($default && {$default}),
-      ...(option.enum && {items: option.enum.map(item => item.toString())}),
+      ...(workspaceDefault && { default: workspaceDefault }),
+      ...($default && { $default }),
+      ...(option.enum && { items: option.enum.map(item => item.toString()) }),
       // Strongly suspect items does not belong in the Option schema.
       //  Angular Option doesn't have the items property outside of x-prompt,
       //  but items is used in @schematics/angular - guard
-      ...(getItems(s.properties[option.name]))
+      ...getItems(s.properties[option.name])
     };
 
     if (xPrompt) {
@@ -232,18 +232,31 @@ export async function normalizeSchema(
   });
 }
 
-function isFieldRequired(requiredFields: Set<string>, nxOption: Option, xPrompt: XPrompt, $default: any): boolean {
+function isFieldRequired(
+  requiredFields: Set<string>,
+  nxOption: Option,
+  xPrompt: XPrompt,
+  $default: any
+): boolean {
   // checks schema.json requiredFields and xPrompt for required
-  return requiredFields.has(nxOption.name) ||
+  return (
+    requiredFields.has(nxOption.name) ||
     // makes xPrompt fields required so nx command can run with --no-interactive
     // - except properties with a default (also falsey, empty, null)
     // - except properties with a $default $source
     // - except boolean properties (should also have default of `true`)
-    (!!xPrompt && !nxOption.default && !$default && nxOption.type !== 'boolean');
+    (!!xPrompt && !nxOption.default && !$default && nxOption.type !== 'boolean')
+  );
 }
 
-function getItems(option: Option): {items: string[]} | undefined {
-  return option.items && {items: (option.items as ItemsWithEnum)!.enum || ((option.items as string[]).length && option.items)};
+function getItems(option: Option): { items: string[] } | undefined {
+  return (
+    option.items && {
+      items:
+        (option.items as ItemsWithEnum)!.enum ||
+        ((option.items as string[]).length && option.items)
+    }
+  );
 }
 
 function isLongFormXPrompt(xPrompt: XPrompt): xPrompt is LongFormXPrompt {

--- a/libs/server/src/lib/utils/utils.ts
+++ b/libs/server/src/lib/utils/utils.ts
@@ -6,14 +6,14 @@ import * as JSON5 from 'json5';
 import { platform } from 'os';
 import * as path from 'path';
 import {
-  OptionComponent,
   Option,
   XPrompt,
   LongFormXPrompt,
   ItemTooltips,
-  OptionItemLabelValue
+  OptionItemLabelValue,
+  ItemsWithEnum
 } from '@nx-console/schema';
-import { Option as CliOption, OptionType } from '@angular/cli/models/interface';
+import { Option as CliOption } from '@angular/cli/models/interface';
 
 export interface SchematicDefaults {
   [name: string]: string;
@@ -174,11 +174,14 @@ export async function normalizeSchema(
 
     const nxOption: Option = {
       ...option,
-      component: getFieldType(option, xPrompt, $default && $default.$source),
       required: isFieldRequired(requiredFields, option, xPrompt, $default),
       ...(workspaceDefault && {default: workspaceDefault}),
-      $default,
+      ...($default && {$default}),
       ...(option.enum && {items: option.enum.map(item => item.toString())}),
+      // Strongly suspect items does not belong in the Option schema.
+      //  Angular Option doesn't have the items property outside of x-prompt,
+      //  but items is used in @schematics/angular - guard
+      ...(getItems(s.properties[option.name]))
     };
 
     if (xPrompt) {
@@ -239,30 +242,8 @@ function isFieldRequired(requiredFields: Set<string>, nxOption: Option, xPrompt:
     (!!xPrompt && !nxOption.default && !$default && nxOption.type !== 'boolean');
 }
 
-function getFieldType(option: Option, xPrompt: XPrompt, $source: string): OptionComponent {
-  if (
-    !!xPrompt &&
-    isLongFormXPrompt(xPrompt) &&
-    xPrompt.type === 'list' &&
-    xPrompt.multiselect
-  ) {
-    return OptionComponent.MultiSelect;
-  }
-
-  // values can come from either enum or x-prompt values as string[] or LongForm items
-  const values = option.enum ||
-    (xPrompt && (xPrompt as LongFormXPrompt).items) ||
-    // Properties where $default.$source is 'projectName' also have a list of items that come from the workspace config instead
-    // Some project properties (@ngrx) do not have $default.$source, but the items are set by the project entries
-    (($source === 'projectName' || option.name === 'project') && new Array(11));
-  if (values) {
-    return values.length > 10
-      ? OptionComponent.Autocomplete
-      : OptionComponent.Select;
-  } else if (option.type === OptionType.Boolean) {
-    return OptionComponent.Checkbox;
-  }
-  return OptionComponent.Input;
+function getItems(option: Option): {items: string[]} | undefined {
+  return option.items && {items: (option.items as ItemsWithEnum)!.enum || ((option.items as string[]).length && option.items)};
 }
 
 function isLongFormXPrompt(xPrompt: XPrompt): xPrompt is LongFormXPrompt {

--- a/libs/vscode-ui/components/src/lib/field/field.component.html
+++ b/libs/vscode-ui/components/src/lib/field/field.component.html
@@ -4,7 +4,7 @@
   <span class="deprecated-warning" *ngIf="field.deprecated">(deprecated)</span>
 </div>
 
-<ng-container [ngSwitch]="field.component" [formGroup]="parentFormGroup">
+<ng-container [ngSwitch]="component" [formGroup]="parentFormGroup">
   <nx-console-autocomplete
     *ngSwitchCase="OptionComponent.Autocomplete"
     [field]="field"

--- a/libs/vscode-ui/components/src/lib/field/field.component.html
+++ b/libs/vscode-ui/components/src/lib/field/field.component.html
@@ -36,5 +36,7 @@
     [(value)]="value"
   ></nx-console-input>
 
-  <div *ngFor="let error of getErrors(field.name)" class="validation-error">{{ error }}</div>
+  <div *ngFor="let error of getErrors(field.name)" class="validation-error">
+    {{ error }}
+  </div>
 </ng-container>

--- a/libs/vscode-ui/components/src/lib/field/field.component.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.ts
@@ -1,4 +1,5 @@
 import { Option, OptionComponent } from '@nx-console/schema';
+import { OptionType } from '@angular/cli/models/interface';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -113,5 +114,31 @@ export class FieldComponent implements ControlValueAccessor, OnDestroy {
         }
       }
     }).filter(error => !!error);
+  }
+
+  get hasItems(): boolean {
+    return !!this.field.items && (this.field.items as string[]).length > 0;
+  }
+
+  get items(): string[] {
+    return this.field.items as string[];
+  }
+
+  get component(): OptionComponent {
+    if (this.field.type === OptionType.Boolean) {
+      return OptionComponent.Checkbox;
+    } else if (this.field.type === OptionType.Array && this.hasItems) {
+      return OptionComponent.MultiSelect;
+    } else {
+      if (this.hasItems) {
+        if (this.items.length > 10) {
+          return OptionComponent.Autocomplete;
+        } else {
+          return OptionComponent.Select;
+        }
+      } else {
+        return OptionComponent.Input;
+      }
+    }
   }
 }

--- a/libs/vscode-ui/components/src/lib/field/field.component.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.ts
@@ -1,4 +1,4 @@
-import { Option, OptionComponent } from '@nx-console/schema';
+import { Option } from '@nx-console/schema';
 import { OptionType } from '@angular/cli/models/interface';
 import {
   ChangeDetectionStrategy,
@@ -16,6 +16,14 @@ import {
   FormGroup
 } from '@angular/forms';
 import { Subscription } from 'rxjs';
+
+enum OptionComponent {
+  Autocomplete = 'autocomplete',
+  Checkbox = 'checkBox',
+  Input = 'input',
+  Select = 'select',
+  MultiSelect = 'multiSelect'
+}
 
 /* Wrapper for select, text input, checkbox, autocomplete */
 

--- a/libs/vscode-ui/components/src/lib/field/field.component.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.ts
@@ -82,7 +82,10 @@ export class FieldComponent implements ControlValueAccessor, OnDestroy {
     this.disabled = isDisabled;
   }
 
-  constructor(private readonly changeDetectorRef: ChangeDetectorRef, private controlContainer: ControlContainer) {
+  constructor(
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private controlContainer: ControlContainer
+  ) {
     this.valueChangeSub = this.control.valueChanges.subscribe(value => {
       this.value = value;
     });
@@ -113,15 +116,19 @@ export class FieldComponent implements ControlValueAccessor, OnDestroy {
       return [];
     }
 
-    return Object.keys(control.errors as any).map(key => {
-      if (!!control.errors) {
-        if (key === 'required') {
-          return `${fieldName.slice(0, 1).toLocaleUpperCase()}${fieldName.slice(1)} is required`;
-        } else {
-          return control.errors[key];
+    return Object.keys(control.errors as any)
+      .map(key => {
+        if (!!control.errors) {
+          if (key === 'required') {
+            return `${fieldName
+              .slice(0, 1)
+              .toLocaleUpperCase()}${fieldName.slice(1)} is required`;
+          } else {
+            return control.errors[key];
+          }
         }
-      }
-    }).filter(error => !!error);
+      })
+      .filter(error => !!error);
   }
 
   get hasItems(): boolean {

--- a/libs/vscode-ui/components/src/lib/multiple-select/multiple-select.component.spec.ts
+++ b/libs/vscode-ui/components/src/lib/multiple-select/multiple-select.component.spec.ts
@@ -1,5 +1,5 @@
 import { OptionType } from '@angular/cli/models/interface';
-import { Option, OptionComponent } from '@nx-console/schema';
+import { Option } from '@nx-console/schema';
 import { MultipleSelectComponent } from './multiple-select.component';
 
 describe('MultipleSelectComponent', () => {
@@ -8,7 +8,6 @@ describe('MultipleSelectComponent', () => {
     name: 'style',
     description: 'The file extension to be used for style files.',
     type: OptionType.String,
-    component: OptionComponent.Select,
     aliases: [],
     itemTooltips: {
       test: 'testLabel'

--- a/libs/vscode-ui/components/src/lib/select/select.component.spec.ts
+++ b/libs/vscode-ui/components/src/lib/select/select.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { OptionType } from '@angular/cli/models/interface';
-import { Option, OptionComponent } from '@nx-console/schema';
+import { Option } from '@nx-console/schema';
 import { SelectComponent } from './select.component';
 
 const initialValue = 'test';
@@ -10,7 +10,6 @@ const mockOption: Option = {
   name: 'style',
   description: 'The file extension to be used for style files.',
   type: OptionType.String,
-  component: OptionComponent.Select,
   aliases: [],
   itemTooltips: {
     test: 'testLabel'

--- a/libs/vscode-ui/components/src/lib/select/select.component.spec.ts
+++ b/libs/vscode-ui/components/src/lib/select/select.component.spec.ts
@@ -26,8 +26,9 @@ const mockOption: Option = {
 })
 class ParentFormComponent {
   field = mockOption;
-  formGroup = this.fb.group({[this.field.name]: initialValue});
-  @ViewChild(SelectComponent, {static: true}) selectComponent: SelectComponent;
+  formGroup = this.fb.group({ [this.field.name]: initialValue });
+  @ViewChild(SelectComponent, { static: true })
+  selectComponent: SelectComponent;
 
   constructor(private fb: FormBuilder) {}
 }

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
@@ -15,9 +15,7 @@
               [formControl]="filterFieldsControl"
             />
           </div>
-          <button class="run-button"
-            (click)="runCommand(taskExecForm)"
-            [disabled]="taskExecForm.form.invalid  && (taskExecForm.form.dirty || taskExecForm.form.touched)">
+          <button class="run-button" (click)="runCommand(taskExecForm)">
             Run
           </button>
         </div>

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
@@ -36,10 +36,6 @@ $offset-with-configurations: $offset-without-configurations +
   &:hover {
     opacity: 0.8;
   }
-  &[disabled] {
-    background-color: $button-secondary-color;
-    opacity: 0.6;
-  }
 }
 
 .scroll-container,

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.spec.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.spec.ts
@@ -1,7 +1,6 @@
 import { OptionType } from '@angular/cli/models/interface';
 import { NgZone } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { OptionComponent } from '@nx-console/schema';
 
 import { TaskExecutionFormComponent } from './task-execution-form.component';
 
@@ -41,7 +40,6 @@ describe('TaskExecutionFormComponent', () => {
           type: OptionType.String,
           aliases: [],
           description: 'a long form select option',
-          component: OptionComponent.Select,
           items: {
             type: OptionType.String,
             enum: ['css', 'scss', 'styl', 'less']

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.spec.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.spec.ts
@@ -12,7 +12,14 @@ describe('TaskExecutionFormComponent', () => {
     TestBed.configureTestingModule({
       declarations: [TaskExecutionFormComponent],
       providers: [
-        { provide: NgZone, useValue: { run(fn: Function): any { return fn(); } }}
+        {
+          provide: NgZone,
+          useValue: {
+            run(fn: Function): any {
+              return fn();
+            }
+          }
+        }
       ]
     }).compileComponents();
   }));
@@ -47,7 +54,9 @@ describe('TaskExecutionFormComponent', () => {
         }
       ]
     });
-    expect(formGroup.controls['long-form-x-prompt-without-enum'].validator).not.toBeUndefined();
+    expect(
+      formGroup.controls['long-form-x-prompt-without-enum'].validator
+    ).not.toBeUndefined();
     // TODO: get tests working on this vscode-ui-component target and finish testing this
   });
 });

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -255,13 +255,10 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
             !validValueSet.has(control.value) &&
             // multiselect values are Array, check if all values are in Set
             control.value.length &&
-            !control.value.every((value: Value) =>
-              validValueSet.has(value)
-            )
+            !control.value.every((value: Value) => validValueSet.has(value))
           ) {
             return {
-              enum:
-                'Please select a value from the auto-completable list'
+              enum: 'Please select a value from the auto-completable list'
             };
           }
 

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -341,7 +341,9 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
     dryRun?: boolean;
   }) {
     const flags = this.serializeArgs(form.value, architect);
-    flags.push('--no-interactive');
+    if (architect.command === 'generate') {
+      flags.push('--no-interactive');
+    }
     if (dryRun) {
       flags.push('--dry-run');
     }

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -40,6 +40,7 @@ import {
   TaskExecutionMessage,
   ItemsWithEnum
 } from '@nx-console/schema';
+import { Value } from '@angular/cli/models/interface';
 
 declare global {
   interface Window {
@@ -249,9 +250,18 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
             (schema.items as string[])
         );
         validators.push(control => {
-          if (control.value && !validValueSet.has(control.value)) {
+          if (
+            control.value &&
+            !validValueSet.has(control.value) &&
+            // multiselect values are Array, check if all values are in Set
+            control.value.length &&
+            !control.value.every((value: Value) =>
+              validValueSet.has(value)
+            )
+          ) {
             return {
-              enum: 'Please select a value from the auto-completable list'
+              enum:
+                'Please select a value from the auto-completable list'
             };
           }
 

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.stories.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.stories.ts
@@ -1,5 +1,5 @@
 import { OptionType } from '@angular/cli/models/interface';
-import { OptionComponent, TaskExecutionSchema } from '@nx-console/schema';
+import { TaskExecutionSchema } from '@nx-console/schema';
 import { TaskExecutionFormComponent } from './task-execution-form.component';
 import { TASK_EXECUTION_SCHEMA } from './task-execution-form.schema';
 import { VscodeUiFeatureTaskExecutionFormModule } from './vscode-ui-feature-task-execution-form.module';
@@ -64,7 +64,6 @@ const initialSchema: TaskExecutionSchema = {
       required: true,
       aliases: ['a'],
       hidden: false,
-      component: OptionComponent.Input,
       tooltip: 'What application will the new domain libraries be under?',
       itemTooltips: {}
     },
@@ -80,7 +79,6 @@ const initialSchema: TaskExecutionSchema = {
       },
       aliases: ['l'],
       hidden: false,
-      component: OptionComponent.MultiSelect,
       tooltip: 'Which library types do you want to generate?',
       itemTooltips: {
         'data-access': 'data-access - for state management and services',
@@ -100,7 +98,6 @@ const initialSchema: TaskExecutionSchema = {
       required: false,
       aliases: ['s'],
       hidden: false,
-      component: OptionComponent.Select,
       tooltip: 'Which stylesheet format would you like to use?',
       itemTooltips: {
         css: 'CSS',
@@ -117,7 +114,6 @@ const initialSchema: TaskExecutionSchema = {
       required: false,
       aliases: [],
       hidden: false,
-      component: OptionComponent.Checkbox,
       tooltip: 'Add a cypress e2e app?',
       itemTooltips: {}
     },
@@ -129,7 +125,6 @@ const initialSchema: TaskExecutionSchema = {
       default: cssColorNames[5],
       aliases: [],
       hidden: false,
-      component: OptionComponent.Autocomplete,
       items: cssColorNames
     }
   ],

--- a/libs/vscode-ui/styles/src/lib/_variables.scss
+++ b/libs/vscode-ui/styles/src/lib/_variables.scss
@@ -9,10 +9,6 @@ $button-primary-color: var(
   --vscode-statusBarItem-remoteBackground,
   #45bc98
 );
-$button-secondary-color: var(
-  --vscode-button-secondaryBackground,
-  #236754
-);
 $scroll-bar-width: 12px;
 
 $primary-text-color: var(--vscode-settings-headerForeground);


### PR DESCRIPTION
* Fixes #1004 The Build form RUN_ONE_OPTIONS were not showing because those options didn't have the `component` property. I removed the `component` property that was recently added to TaskExecutionSchema Options in #986. The functionality to determine which component to show in the form belongs in the vscode-ui-components, so that's where I moved it.
* Actually, let's not disable the Run button when the Form is invalid. The Build form doesn't do a good job of populating workspace defaults on the project. Fields such as main and index are required in the schema, but these are configured and read from the workspace config.
* One run Generate commands with --no-interactive. (ng build was failing because it does not support the --no-interactive flag)