### PR TITLE
feat: allow filtering in the nx project tree view

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -66,13 +66,8 @@
       ],
       "view/item/context": [
         {
-          "command": "nxConsole.revealInExplorer",
-          "when": "view == nxConsoleJson && viewItem == project",
-          "group": "inline"
-        },
-        {
-          "command": "nxConsole.runTask",
-          "when": "view == nxConsoleJson && viewItem == task",
+          "command": "nxConsole.editWorkspaceJson",
+          "when": "view == nxProjects",
           "group": "inline"
         },
         {
@@ -251,20 +246,19 @@
         }
       },
       {
+        "command": "nxConsole.editWorkspaceJson",
+        "title": "Edit workspace definition",
+        "icon": "$(go-to-file)"
+      },
+      {
         "command": "nxConsole.revealInExplorer",
         "title": "Reveal in Explorer",
-        "icon": {
-          "light": "assets/folder-light.svg",
-          "dark": "assets/folder-dark.svg"
-        }
+        "icon": "$(folder)"
       },
       {
         "command": "nxConsole.runTask",
         "title": "Execute task",
-        "icon": {
-          "light": "assets/continue-light.svg",
-          "dark": "assets/continue-dark.svg"
-        }
+        "icon": "$(play)"
       },
       {
         "category": "ng",

--- a/libs/vscode/nx-project-view/src/lib/nx-project-tree-provider.ts
+++ b/libs/vscode/nx-project-view/src/lib/nx-project-tree-provider.ts
@@ -75,11 +75,6 @@ export class NxProjectTreeProvider extends AbstractTreeProvider<NxProjectTreeIte
         ? TreeItemCollapsibleState.Collapsed
         : TreeItemCollapsibleState.None
     );
-    item.command = {
-      title: 'Edit workspace definition',
-      command: 'nxConsole.editWorkspaceJson',
-      arguments: [item],
-    };
     if (!workspaceJsonLabel.target) {
       const projectDef = this.cliTaskProvider.getProjects()[
         workspaceJsonLabel.project


### PR DESCRIPTION
## What it does

This change introduces a new button in the nx projects tree view that replaces the single click to open the workspace.json file. This allows us to focus the view and start typing so that we can use the built in filter in vscode. 

**Screenshots**:
New button to open workspace.json
![Screen Shot 2021-03-24 at 9 18 04 AM](https://user-images.githubusercontent.com/4332460/112317136-2176c100-8c82-11eb-95d0-c94cfc4381e8.png)

Filter
<img width="573" alt="image" src="https://user-images.githubusercontent.com/4332460/112672119-7872c680-8e39-11eb-9010-acbd786c3e66.png">


Closes #1043


### Note
This is based off the current refactor branch, and will need to be rebased. 