### PR TITLE
feat: load custom workspace path on extension load

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -165,6 +165,12 @@ function scanForWorkspace(vscodeWorkspacePath: string) {
   let currentDirectory = vscodeWorkspacePath;
 
   const { root } = parse(vscodeWorkspacePath);
+
+  const workspaceJsonPath = WorkspaceConfigurationStore.instance.get('nxWorkspaceJsonPath', '');
+  if (workspaceJsonPath) {
+    currentDirectory = dirname(workspaceJsonPath);
+  }
+
   while (currentDirectory !== root) {
     if (existsSync(join(currentDirectory, 'angular.json'))) {
       return setWorkspace(join(currentDirectory, 'angular.json'));

--- a/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
+++ b/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
@@ -2,7 +2,7 @@ import { TreeItem } from 'vscode';
 
 import { AbstractTreeProvider } from '@nx-console/server';
 import { ROUTE_LIST, RunTargetTreeItem } from './run-target-tree-item';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
 
 const SCANNING_FOR_WORKSPACE = new TreeItem(
@@ -43,7 +43,7 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
     };
   }
 
-  getParent(_: RunTargetTreeItem) {
+  getParent() {
     return null;
   }
 
@@ -65,6 +65,8 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
         return [LOCATE_YOUR_WORKSPACE];
       }
     }
+
+    CHANGE_WORKSPACE.description = "Current: " + dirname(workspaceJsonPath);
 
     return [
       ...ROUTE_LIST.map(


### PR DESCRIPTION
## What it does
Loads the custom workspace path when the extension is loaded. This path is stored per vscode workspace. 

I also show a description of what the current workspace is:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/4332460/112689677-ff7f6900-8e50-11eb-8bdf-72761da332f3.png">



Fixes: #965
