### PR TITLE
fix: remove leading / from path parsed out of the workspace path

### DIFF
--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -181,6 +181,7 @@ function getConfigValuesFromContextMenuUri(
     const projectName = (project && project.name) || undefined;
     const path = contextMenuUri.fsPath
       .replace(cliTaskProvider.getWorkspacePath(), '')
+      .replace(/^\//, '')
       .replace(/\\/g, '/');
 
     return {


### PR DESCRIPTION
Fixes #1049 

The context menu path is taken from the full file system path with the workspace path parsed out of it, which was resulting in a leading space. Generator paths should always be relative to the workspace, so removing the leading `/`.