### PR TITLE
feat: run-many prompts for projects

### DIFF
--- a/libs/vscode/tasks/src/lib/nx-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/nx-task-commands.ts
@@ -142,11 +142,6 @@ const AFFECTED_OPTIONS: Option[] = [
 ].map((v) => ({ ...v, aliases: [] }));
 
 const RUN_MANY_OPTIONS: Option[] = [
-  {
-    name: 'projects',
-    type: OptionType.Array,
-    description: 'Projects to run',
-  },
   { name: 'all', type: OptionType.Boolean, description: 'All projects' },
   {
     name: 'parallel',
@@ -266,13 +261,22 @@ async function promptForRunMany() {
     return;
   }
 
+  let options = RUN_MANY_OPTIONS;
   const projects = validProjectsForTarget(target);
-  const projectsOption = RUN_MANY_OPTIONS.find(opt => opt.name === 'projects');
-  if (projectsOption && projects && projects.length) {
-    projectsOption.enum = projects;
+  if (projects && projects.length) {
+    options = [
+      {
+        name: 'projects',
+        type: OptionType.Array,
+        description: 'Projects to run',
+        aliases: [],
+        enum: projects,
+      },
+      ...RUN_MANY_OPTIONS,
+    ];
   }
 
-  const flags = await selectFlags('run-many', RUN_MANY_OPTIONS, 'nx', {target});
+  const flags = await selectFlags('run-many', options, 'nx', { target });
 
   if (flags !== undefined) {
     const task = NxTask.create(
@@ -340,7 +344,9 @@ function validProjectsForTarget(target: string): string[] | undefined {
   return Array.from(
     new Set(
       Object.entries<ProjectDef>(json.projects)
-        .filter(([_, project]) => project.architect && project.architect[target])
+        .filter(
+          ([_, project]) => project.architect && project.architect[target]
+        )
         .map(([project]) => project)
     )
   ).sort();

--- a/libs/vscode/tasks/src/lib/select-flags.ts
+++ b/libs/vscode/tasks/src/lib/select-flags.ts
@@ -23,7 +23,7 @@ export async function selectFlags(
 
   const flagValue = await promptForFlagValue(selection.flag);
 
-  if (flagValue) {
+  if (flagValue && flagValue.length > 0) {
     userSetFlags[selection.flag.flagName] = flagValue;
   } else {
     delete userSetFlags[selection.flag.flagName];
@@ -83,6 +83,7 @@ function promptForFlagValue(flagToSet: CliTaskFlagQuickPickItem) {
   } else if (flagToSet.option.enum && flagToSet.option.enum.length) {
     return window.showQuickPick([...flagToSet.option.enum.map(String)], {
       placeHolder,
+      canPickMany: flagToSet.option.type === 'array'
     });
   } else {
     return window.showInputBox({


### PR DESCRIPTION
* On the Nx: run-many command, when selecting projects it now prompts for selection from a quick pick list of projects with the given target instead of having the user type out the project entries.
* The target flag has also been included in the userSetFlags in order to show the target with the command being built up.
![run-many projects quickpick from target](https://user-images.githubusercontent.com/2250413/115284860-d0d47580-a112-11eb-827b-3ef2e97f2701.gif)
