### PR TITLE
feat: nx run in command palette and context menu

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -166,6 +166,10 @@
           "when": "isNxWorkspace"
         },
         {
+          "command": "nx.run",
+          "when": "isNxWorkspace"
+        },
+        {
           "command": "nx.affected",
           "when": "isNxWorkspace"
         },
@@ -361,6 +365,11 @@
         "category": "Nx",
         "title": "run-many",
         "command": "nx.run-many"
+      },
+      {
+        "category": "Nx",
+        "title": "run",
+        "command": "nx.run"
       },
       {
         "category": "Nx",

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -50,6 +50,11 @@
           "when": "isGenerateFromContextMenuEnabled",
           "command": "nx.generate.ui.fileexplorer",
           "group": "explorerContext"
+        },
+        {
+          "when": "isNxWorkspace && config.nxConsole.enableGenerateFromContextMenu",
+          "command": "nx.run.fileexplorer",
+          "group": "explorerContext"
         }
       ],
       "view/title": [
@@ -79,6 +84,10 @@
       "commandPalette": [
         {
           "command": "nx.generate.ui.fileexplorer",
+          "when": "false"
+        },
+        {
+          "command": "nx.run.fileexplorer",
           "when": "false"
         },
         {
@@ -460,6 +469,11 @@
         "category": "Nx",
         "title": "Nx generate (ui)",
         "command": "nx.generate.ui.fileexplorer"
+      },
+      {
+        "category": "Nx",
+        "title": "Nx run",
+        "command": "nx.run.fileexplorer"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Adds support for `nx run` in the Command Palette
Prompts for a project then a target and supported flags (including configuration with a dropdown of the configuration options.)
![run command](https://user-images.githubusercontent.com/2250413/115458079-e3ba7900-a1ea-11eb-92f6-68aa35ebac9d.gif)
