### PR TITLE
fix: enable generate from context menu setting take effect immediately

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -231,12 +231,6 @@ async function setWorkspace(workspaceJsonPath: string) {
 
   const isNxWorkspace = existsSync(join(workspaceJsonPath, '..', 'nx.json'));
   const isAngularWorkspace = workspaceJsonPath.endsWith('angular.json');
-  const enableGenerateFromContextMenuSetting = GlobalConfigurationStore.instance.get(
-    'enableGenerateFromContextMenu'
-  );
-  const isGenerateFromContextMenuEnabled =
-    enableGenerateFromContextMenuSetting &&
-    (isNxWorkspace || isAngularWorkspace);
 
   commands.executeCommand(
     'setContext',
@@ -244,11 +238,6 @@ async function setWorkspace(workspaceJsonPath: string) {
     isAngularWorkspace
   );
   commands.executeCommand('setContext', 'isNxWorkspace', isNxWorkspace);
-  commands.executeCommand(
-    'setContext',
-    'isGenerateFromContextMenuEnabled',
-    isGenerateFromContextMenuEnabled
-  );
 
   registerWorkspaceFileWatcher(context, workspaceJsonPath);
 

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -47,7 +47,7 @@
     "menus": {
       "explorer/context": [
         {
-          "when": "isGenerateFromContextMenuEnabled",
+          "when": "isAngularWorkspace && config.nxConsole.enableGenerateFromContextMenu || isNxWorkspace && config.nxConsole.enableGenerateFromContextMenu",
           "command": "nx.generate.ui.fileexplorer",
           "group": "explorerContext"
         }


### PR DESCRIPTION
With how the ["when" clause](https://code.visualstudio.com/api/references/when-clause-contexts) context for `isGenerateFromContextMenuEnabled` is just getting set on activate, this setting isn't applying immediately like other VS Code settings do. Seems like you have to reload the window to get the setting to work. 

But the "when" clause can read from the `config` settings in order to toggle it on/off in your current VS Code session, so this change should fix that.


