### PR TITLE
feat: welcome view and getting started walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Nx transformed the Angular ecosystem. With it, you can get a full-stack applicat
 
 ## Why Nx Console?
 
-Professional developers use both command-line tools and user interfaces. They commit in the terminal, but resolve conflicts in VSCode or WebStorm. They use the right tool for the job.
+Developers use both command-line tools and user interfaces. They commit in the terminal, but resolve conflicts in VSCode or WebStorm. They use the right tool for the job.
 
 Nx is a command-line tool, which works great when you want to serve an application or generate a simple component. But it falls short once you start doing advanced things.
 
@@ -34,11 +34,11 @@ For VSCode users, you can install the [Nx Console VSCode Plugin](https://marketp
 
 ## True UI for Nx
 
-Nx Console is an UI for Nx. It will work for any schematic or any architect commands. Nx Console does not have a specific UI for, say, generating a component. Instead, Nx Console does what the command-line version of Nx does--it analyzes the same meta information to create the needed UI. This means that anything you can do with Nx, you can do with Nx Console. After all, Nx Console is the UI for Nx.
+Nx Console is the UI for Nx. It will work for any schematic or any architect commands. Nx Console does not have a specific UI for, say, generating a component. Instead, Nx Console does what the command-line version of Nx does--it analyzes the same meta information to create the needed UI. This means that anything you can do with Nx, you can do with Nx Console. After all, Nx Console is the UI for Nx.
 
 ## Useful for Both Experts and Beginners
 
-Even though we started building Nx Console as a tool for expert, we also aimed to make Nx Console a great tool for developers who are new to Nx. You can create projects, interact with your editor, run generators and commands, install extensions without ever touching the terminal or having to install any node packages globally. If you get a new laptop, you can install Nx Console and start building apps. Also, Nx Console highlights the properties you are likely to use for build-in generators and commands . So if you haven't used the CLI, you don't get overwhelmed.
+Even though we started building Nx Console as a tool for experts, we also aimed to make Nx Console a great tool for developers who are new to to development or Nx. You can create projects, interact with your editor, run generators and commands, install extensions without ever touching the terminal or having to install any node packages globally. Also, Nx Console highlights the properties you are likely to use for build-in generators and commands, so if you haven't used the CLI, you don't get overwhelmed.
 
 # Learn More
 

--- a/angular.json
+++ b/angular.json
@@ -137,6 +137,7 @@
               "apps/vscode/src/package.json",
               "apps/vscode/src/tree-view-icon.svg",
               "apps/vscode/src/assets",
+              "apps/vscode/src/getting-started",
               {
                 "glob": "README.md",
                 "input": "./",

--- a/apps/vscode/src/getting-started/1-generate.md
+++ b/apps/vscode/src/getting-started/1-generate.md
@@ -1,0 +1,9 @@
+## Generate
+
+The _Generate_ action allows you to choose a generator and then opens a form listing out all the options for that generator. As you make changes to the form, the generator is executed in `--dry-run` mode in a terminal so you can preview the results of running the generator in real time.
+
+### From the Command Palette
+
+You can also launch the _Generate_ action from the Command Palette (`⇧⌘P`) by selecting `nx: generate (ui)`.
+
+You can even construct the generator options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: generate`. After choosing a generator, select any of the listed options to modify the generator command. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.

--- a/apps/vscode/src/getting-started/1-generate.md
+++ b/apps/vscode/src/getting-started/1-generate.md
@@ -6,6 +6,8 @@ The `Generate` action allows you to choose a generator and then opens a form lis
 
 [See the Demo](https://youtu.be/-nUr66MWRiE)
 
+&nbsp;
+
 ## From the Command Palette
 
 You can also launch the `Generate` action from the Command Palette (`⇧⌘P`) by selecting `nx: generate (ui)`.

--- a/apps/vscode/src/getting-started/1-generate.md
+++ b/apps/vscode/src/getting-started/1-generate.md
@@ -1,9 +1,9 @@
 ## Generate
 
-The _Generate_ action allows you to choose a generator and then opens a form listing out all the options for that generator. As you make changes to the form, the generator is executed in `--dry-run` mode in a terminal so you can preview the results of running the generator in real time.
+The `Generate` action allows you to choose a generator and then opens a form listing out all the options for that generator. As you make changes to the form, the generator is executed in `--dry-run` mode in a terminal so you can preview the results of running the generator in real time.
 
 ### From the Command Palette
 
-You can also launch the _Generate_ action from the Command Palette (`⇧⌘P`) by selecting `nx: generate (ui)`.
+You can also launch the `Generate` action from the Command Palette (`⇧⌘P`) by selecting `nx: generate (ui)`.
 
 You can even construct the generator options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: generate`. After choosing a generator, select any of the listed options to modify the generator command. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.

--- a/apps/vscode/src/getting-started/1-generate.md
+++ b/apps/vscode/src/getting-started/1-generate.md
@@ -2,8 +2,14 @@
 
 The `Generate` action allows you to choose a generator and then opens a form listing out all the options for that generator. As you make changes to the form, the generator is executed in `--dry-run` mode in a terminal so you can preview the results of running the generator in real time.
 
+[See the Demo](https://youtu.be/-nUr66MWRiE)
+
 ### From the Command Palette
 
 You can also launch the `Generate` action from the Command Palette (`⇧⌘P`) by selecting `nx: generate (ui)`.
 
+[See the Demo](https://youtu.be/Sk2XjFwF8Zo)
+
 You can even construct the generator options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: generate`. After choosing a generator, select any of the listed options to modify the generator command. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.
+
+[See the Demo](https://youtu.be/q5NTTqRYq9c)

--- a/apps/vscode/src/getting-started/1-generate.md
+++ b/apps/vscode/src/getting-started/1-generate.md
@@ -1,10 +1,12 @@
-## Generate
+&nbsp;
+
+# Generate
 
 The `Generate` action allows you to choose a generator and then opens a form listing out all the options for that generator. As you make changes to the form, the generator is executed in `--dry-run` mode in a terminal so you can preview the results of running the generator in real time.
 
 [See the Demo](https://youtu.be/-nUr66MWRiE)
 
-### From the Command Palette
+## From the Command Palette
 
 You can also launch the `Generate` action from the Command Palette (`⇧⌘P`) by selecting `nx: generate (ui)`.
 

--- a/apps/vscode/src/getting-started/2-run.md
+++ b/apps/vscode/src/getting-started/2-run.md
@@ -2,6 +2,10 @@
 
 The `Run` action allows you to choose an executor command and then opens a form listing out all the options for that builder. The frequently used executor commands `build`, `serve`, `test`, `e2e` and `lint` also have their own dedicated actions.
 
+[See the Demo](https://youtu.be/rNImFxo9gYs)
+
 ### From the Command Palette
 
 You can also construct the executor command options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: test`. After choosing a project, select any of the listed options to modify the executor command options. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.
+
+[See the Demo](https://youtu.be/CsUkSyQcxwQ)

--- a/apps/vscode/src/getting-started/2-run.md
+++ b/apps/vscode/src/getting-started/2-run.md
@@ -1,10 +1,12 @@
-## Run
+&nbsp;
+
+# Run
 
 The `Run` action allows you to choose an executor command and then opens a form listing out all the options for that builder. The frequently used executor commands `build`, `serve`, `test`, `e2e` and `lint` also have their own dedicated actions.
 
 [See the Demo](https://youtu.be/rNImFxo9gYs)
 
-### From the Command Palette
+## From the Command Palette
 
 You can also construct the executor command options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: test`. After choosing a project, select any of the listed options to modify the executor command options. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.
 

--- a/apps/vscode/src/getting-started/2-run.md
+++ b/apps/vscode/src/getting-started/2-run.md
@@ -1,0 +1,7 @@
+## Run
+
+The _Run_ action allows you to choose an executor command and then opens a form listing out all the options for that builder. The frequently used executor commands build, serve, test, e2e and lint also have their own dedicated actions.
+
+### From the Command Palette
+
+You can also construct the executor command options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: test`. After choosing a project, select any of the listed options to modify the executor command options. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.

--- a/apps/vscode/src/getting-started/2-run.md
+++ b/apps/vscode/src/getting-started/2-run.md
@@ -6,6 +6,8 @@ The `Run` action allows you to choose an executor command and then opens a form 
 
 [See the Demo](https://youtu.be/rNImFxo9gYs)
 
+&nbsp;
+
 ## From the Command Palette
 
 You can also construct the executor command options while staying entirely within the Command Palette. Use `⇧⌘P` to open the Command Palette, then select `nx: test`. After choosing a project, select any of the listed options to modify the executor command options. When you're satisfied with the constructed command, choose the `Execute` command at the top of the list.

--- a/apps/vscode/src/getting-started/2-run.md
+++ b/apps/vscode/src/getting-started/2-run.md
@@ -1,6 +1,6 @@
 ## Run
 
-The _Run_ action allows you to choose an executor command and then opens a form listing out all the options for that builder. The frequently used executor commands build, serve, test, e2e and lint also have their own dedicated actions.
+The `Run` action allows you to choose an executor command and then opens a form listing out all the options for that builder. The frequently used executor commands `build`, `serve`, `test`, `e2e` and `lint` also have their own dedicated actions.
 
 ### From the Command Palette
 

--- a/apps/vscode/src/getting-started/3-common-nx-commands.md
+++ b/apps/vscode/src/getting-started/3-common-nx-commands.md
@@ -2,6 +2,8 @@
 
 You can also launch other common Nx commands with the options listed out in the Command Palette.
 
-* `dep-graph`: Graph dependencies within workspace
-* `run-many`: Run task for multiple projects
-* `affected`: Run task for affected projects
+- `dep-graph`: Graph dependencies within workspace
+- `run-many`: Run task for multiple projects
+- `affected`: Run task for affected projects
+
+[See the Demo](https://youtu.be/v6Tso0lB6S4)

--- a/apps/vscode/src/getting-started/3-common-nx-commands.md
+++ b/apps/vscode/src/getting-started/3-common-nx-commands.md
@@ -1,3 +1,7 @@
 ## Common Nx Commands
 
 You can also launch other common Nx commands with the options listed out in the Command Palette.
+
+* `dep-graph`: Graph dependencies within workspace
+* `run-many`: Run task for multiple projects
+* `affected`: Run task for affected projects

--- a/apps/vscode/src/getting-started/3-common-nx-commands.md
+++ b/apps/vscode/src/getting-started/3-common-nx-commands.md
@@ -1,4 +1,6 @@
-## Common Nx Commands
+&nbsp;
+
+# Common Nx Commands
 
 You can also launch other common Nx commands with the options listed out in the Command Palette.
 

--- a/apps/vscode/src/getting-started/3-common-nx-commands.md
+++ b/apps/vscode/src/getting-started/3-common-nx-commands.md
@@ -1,0 +1,3 @@
+## Common Nx Commands
+
+You can also launch other common Nx commands with the options listed out in the Command Palette.

--- a/apps/vscode/src/getting-started/4-projects.md
+++ b/apps/vscode/src/getting-started/4-projects.md
@@ -7,3 +7,5 @@ Clicking the ![Refresh](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1
 Clicking the ![Folder](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/folder-light.svg) Folder icon next to a project will reveal that project's folder in the VSCode Explorer pane.
 
 Clicking the ![Execute](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/continue-light.svg) Execute icon next to an executor command will execute that command without prompting for options.
+
+[See the Demo](https://youtu.be/ve_N3unDqAg)

--- a/apps/vscode/src/getting-started/4-projects.md
+++ b/apps/vscode/src/getting-started/4-projects.md
@@ -2,12 +2,12 @@
 
 # Projects
 
-Clicking on the name of any project will navigate to that project's definition in the `workspace.json` (or `angular.json`) file. Clicking on the name of any builder command will navigate to that builder command's definition in the `workspace.json` (or `angular.json`) file.
+- Clicking on the name of any project will navigate to that project's definition in the `workspace.json` (or `angular.json`) file. Clicking on the name of any builder command will navigate to that builder command's definition in the `workspace.json` (or `angular.json`) file.
 
-Clicking the ![Refresh](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/refresh-light.svg) Refresh icon next to the `PROJECTS` header will repopulate the Projects pane from the `workspace.json` (or `angular.json`) file.
+- Clicking the ![Refresh](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/refresh-light.svg) Refresh icon next to the `PROJECTS` header will repopulate the Projects pane from the `workspace.json` (or `angular.json`) file.
 
-Clicking the ![Folder](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/folder-light.svg) Folder icon next to a project will reveal that project's folder in the VSCode Explorer pane.
+- Clicking the ![Folder](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/folder-light.svg) Folder icon next to a project will reveal that project's folder in the VSCode Explorer pane.
 
-Clicking the ![Execute](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/continue-light.svg) Execute icon next to an executor command will execute that command without prompting for options.
+- Clicking the ![Execute](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/continue-light.svg) Execute icon next to an executor command will execute that command without prompting for options.
 
 [See the Demo](https://youtu.be/ve_N3unDqAg)

--- a/apps/vscode/src/getting-started/4-projects.md
+++ b/apps/vscode/src/getting-started/4-projects.md
@@ -2,8 +2,8 @@
 
 Clicking on the name of any project will navigate to that project's definition in the `workspace.json` (or `angular.json`) file. Clicking on the name of any builder command will navigate to that builder command's definition in the `workspace.json` (or `angular.json`) file.
 
-Clicking the [refresh-light.svg] icon next to the `PROJECTS` header will repopulate the Projects pane from the `workspace.json` (or `angular.json`) file.
+Clicking the ![Refresh](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/refresh-light.svg) Refresh icon next to the `PROJECTS` header will repopulate the Projects pane from the `workspace.json` (or `angular.json`) file.
 
-Clicking the [folder-light.svg] icon next to a project will reveal that project's folder in the VSCode Explorer pane.
+Clicking the ![Folder](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/folder-light.svg) Folder icon next to a project will reveal that project's folder in the VSCode Explorer pane.
 
-Clicking the [continue-light.svg] icon next to an executor command will execute that command without prompting for options.
+Clicking the ![Execute](https://raw.githubusercontent.com/nrwl/nx-console/ba40a1c4a53d48b89a05a2f0d77a4139f9de6cc2/apps/vscode/src/assets/continue-light.svg) Execute icon next to an executor command will execute that command without prompting for options.

--- a/apps/vscode/src/getting-started/4-projects.md
+++ b/apps/vscode/src/getting-started/4-projects.md
@@ -1,4 +1,6 @@
-## Projects
+&nbsp;
+
+# Projects
 
 Clicking on the name of any project will navigate to that project's definition in the `workspace.json` (or `angular.json`) file. Clicking on the name of any builder command will navigate to that builder command's definition in the `workspace.json` (or `angular.json`) file.
 

--- a/apps/vscode/src/getting-started/4-projects.md
+++ b/apps/vscode/src/getting-started/4-projects.md
@@ -1,0 +1,9 @@
+## Projects
+
+Clicking on the name of any project will navigate to that project's definition in the `workspace.json` (or `angular.json`) file. Clicking on the name of any builder command will navigate to that builder command's definition in the `workspace.json` (or `angular.json`) file.
+
+Clicking the [refresh-light.svg] icon next to the `PROJECTS` header will repopulate the Projects pane from the `workspace.json` (or `angular.json`) file.
+
+Clicking the [folder-light.svg] icon next to a project will reveal that project's folder in the VSCode Explorer pane.
+
+Clicking the [continue-light.svg] icon next to an executor command will execute that command without prompting for options.

--- a/apps/vscode/src/getting-started/5-streamlining.md
+++ b/apps/vscode/src/getting-started/5-streamlining.md
@@ -29,3 +29,5 @@ Then from the Command Palette (`⇧⌘P`) choose `Preferences: Open Keyboard Sho
 ```
 
 Now, pressing `^⌘T` will run `nx affected --target=test`.
+
+Here is more information on [VSCode tasks](https://code.visualstudio.com/docs/editor/tasks) and [keyboard shortcuts](https://code.visualstudio.com/docs/getstarted/keybindings).

--- a/apps/vscode/src/getting-started/5-streamlining.md
+++ b/apps/vscode/src/getting-started/5-streamlining.md
@@ -2,11 +2,11 @@
 
 If you find yourself running the same command many times, here are few tips to save yourself some key strokes.
 
-Rerun Last Task
+### Rerun Last Task
 
-If you want to rerun the last task with all the same options specified, bring up the Command Palette (⇧⌘P) and choose Rerun Last Task.
+If you want to rerun the last task with all the same options specified, bring up the Command Palette (`⇧⌘P`) and choose `Rerun Last Task`.
 
-Keyboard Shortcuts
+### Keyboard Shortcuts
 
 You can also set up custom tasks and assign keyboard shortcuts to them. In .vscode/tasks.json add a task like this:
 
@@ -29,5 +29,3 @@ Then from the Command Palette (`⇧⌘P`) choose `Preferences: Open Keyboard Sho
 ```
 
 Now, pressing `^⌘T` will run `nx affected --target=test`.
-
-Here is more information on [VSCode tasks](https://code.visualstudio.com/docs/editor/tasks) and [keyboard shortcuts](https://code.visualstudio.com/docs/getstarted/keybindings).

--- a/apps/vscode/src/getting-started/5-streamlining.md
+++ b/apps/vscode/src/getting-started/5-streamlining.md
@@ -1,12 +1,14 @@
-## Streamlining
+&nbsp;
+
+# Streamlining
 
 If you find yourself running the same command many times, here are few tips to save yourself some key strokes.
 
-### Rerun Last Task
+## Rerun Last Task
 
 If you want to rerun the last task with all the same options specified, bring up the Command Palette (`⇧⌘P`) and choose `Rerun Last Task`.
 
-### Keyboard Shortcuts
+## Keyboard Shortcuts
 
 You can also set up custom tasks and assign keyboard shortcuts to them. In .vscode/tasks.json add a task like this:
 

--- a/apps/vscode/src/getting-started/5-streamlining.md
+++ b/apps/vscode/src/getting-started/5-streamlining.md
@@ -8,6 +8,8 @@ If you find yourself running the same command many times, here are few tips to s
 
 If you want to rerun the last task with all the same options specified, bring up the Command Palette (`⇧⌘P`) and choose `Rerun Last Task`.
 
+&nbsp;
+
 ## Keyboard Shortcuts
 
 You can also set up custom tasks and assign keyboard shortcuts to them. In .vscode/tasks.json add a task like this:
@@ -31,5 +33,7 @@ Then from the Command Palette (`⇧⌘P`) choose `Preferences: Open Keyboard Sho
 ```
 
 Now, pressing `^⌘T` will run `nx affected --target=test`.
+
+&nbsp;
 
 Here is more information on [VSCode tasks](https://code.visualstudio.com/docs/editor/tasks) and [keyboard shortcuts](https://code.visualstudio.com/docs/getstarted/keybindings).

--- a/apps/vscode/src/getting-started/5-streamlining.md
+++ b/apps/vscode/src/getting-started/5-streamlining.md
@@ -1,0 +1,33 @@
+## Streamlining
+
+If you find yourself running the same command many times, here are few tips to save yourself some key strokes.
+
+Rerun Last Task
+
+If you want to rerun the last task with all the same options specified, bring up the Command Palette (⇧⌘P) and choose Rerun Last Task.
+
+Keyboard Shortcuts
+
+You can also set up custom tasks and assign keyboard shortcuts to them. In .vscode/tasks.json add a task like this:
+
+```json
+{
+  "label": "Test Affected",
+  "type": "shell",
+  "command": "nx affected --target=test"
+}
+```
+
+Then from the Command Palette (`⇧⌘P`) choose `Preferences: Open Keyboard Shortcuts (JSON)`. Then add the following shortcut:
+
+```json
+{
+  "key": "ctrl+cmd+t",
+  "command": "workbench.action.tasks.runTask",
+  "args": "Test Affected"
+}
+```
+
+Now, pressing `^⌘T` will run `nx affected --target=test`.
+
+Here is more information on [VSCode tasks](https://code.visualstudio.com/docs/editor/tasks) and [keyboard shortcuts](https://code.visualstudio.com/docs/getstarted/keybindings).

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -621,6 +621,16 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "nxConsole.views.welcome",
+        "contents": "Nx Console - The UI for Nx"
+      },
+      {
+        "view": "nxConsole.views.welcome",
+        "contents": "[Getting Started](https://nx.dev/latest/angular/getting-started/console#nx-console-for-vs-code)"
+      }
+    ],
     "views": {
       "nx-console": [
         {
@@ -636,7 +646,15 @@
           "id": "nxProjects",
           "name": "Projects",
           "when": "isNxWorkspace || isAngularWorkspace"
-        }
+        },
+        {
+					"id": "nxConsole.views.welcome",
+					"name": "Welcome",
+					"when": "!isNxWorkspace && !isAngularWorkspace",
+					"contextualTitle": "Nx Console Getting Started",
+					"icon": "assets/nx-console.png",
+					"visibility": "visible"
+				}
       ]
     },
     "jsonValidation": [

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -636,14 +636,13 @@
         "id": "nxConsole",
         "title": "Getting Started with Nx Console",
         "description": "Interacting with your Nx Workspace",
-        "primary": true,
         "steps": [
           {
             "id": "nxConsole.generate",
             "title": "Generate",
             "description": "",
             "media": {
-              "path": "getting-started/1-generate.md"
+              "markdown": "getting-started/1-generate.md"
             }
           },
           {
@@ -651,7 +650,7 @@
             "title": "Run",
             "description": "",
             "media": {
-              "path": "getting-started/2-run.md"
+              "markdown": "getting-started/2-run.md"
             }
           },
           {
@@ -659,7 +658,7 @@
             "title": "Common Nx Commands",
             "description": "",
             "media": {
-              "path": "getting-started/3-common-nx-commands.md"
+              "markdown": "getting-started/3-common-nx-commands.md"
             }
           },
           {
@@ -667,7 +666,7 @@
             "title": "Projects",
             "description": "",
             "media": {
-              "path": "getting-started/4-projects.md"
+              "markdown": "getting-started/4-projects.md"
             }
           },
           {
@@ -675,7 +674,7 @@
             "title": "Streamlining",
             "description": "",
             "media": {
-              "path": "getting-started/5-streamlining.md"
+              "markdown": "getting-started/5-streamlining.md"
             }
           }
         ]

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -640,7 +640,7 @@
           {
             "id": "nxConsole.generate",
             "title": "Generate",
-            "description": "",
+            "description": "Use Nx Console to scaffold different files with [Generate](command:nx.generate.ui)",
             "media": {
               "markdown": "getting-started/1-generate.md"
             }
@@ -648,7 +648,7 @@
           {
             "id": "nxConsole.run",
             "title": "Run",
-            "description": "",
+            "description": "[Run](command:nx.run) Nx commands with selected options",
             "media": {
               "markdown": "getting-started/2-run.md"
             }
@@ -656,7 +656,7 @@
           {
             "id": "nxConsole.commonNxCommands",
             "title": "Common Nx Commands",
-            "description": "",
+            "description": "Open the [dep-graph](command:nx.dep-graph), run a task for [affected](command:nx.affected) projects, or [run-many](command:nx.run-many) on selected projects",
             "media": {
               "markdown": "getting-started/3-common-nx-commands.md"
             }
@@ -664,7 +664,7 @@
           {
             "id": "nxConsole.projects",
             "title": "Projects",
-            "description": "",
+            "description": "See all the [projects](command:nxProjects.focus) in your workspace",
             "media": {
               "markdown": "getting-started/4-projects.md"
             }
@@ -672,7 +672,7 @@
           {
             "id": "nxConsole.streamlining",
             "title": "Streamlining",
-            "description": "",
+            "description": "[Rerun Last Task](command:workbench.action.tasks.reRunTask) or set up custom tasks and [keybindings](command:workbench.action.openGlobalKeybindings)",
             "media": {
               "markdown": "getting-started/5-streamlining.md"
             }

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -651,7 +651,7 @@
 						"title": "Run",
 						"description": "",
 						"media": {
-							"path": "getting-started/2-pencil-tool.md"
+							"path": "getting-started/2-run.md"
 						}
 					},
 					{

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -631,6 +631,56 @@
         "contents": "[Getting Started](https://nx.dev/latest/angular/getting-started/console#nx-console-for-vs-code)"
       }
     ],
+    "walkthroughs": [
+			{
+				"id": "nxConsole",
+				"title": "Getting Started with Nx Console",
+				"description": "Interacting with your Nx Workspace",
+				"primary": true,
+				"steps": [
+					{
+						"id": "nxConsole.generate",
+						"title": "Generate",
+						"description": "",
+						"media": {
+							"path": "getting-started/1-generate.md"
+						}
+					},
+					{
+						"id": "nxConsole.run",
+						"title": "Run",
+						"description": "",
+						"media": {
+							"path": "getting-started/2-pencil-tool.md"
+						}
+					},
+					{
+						"id": "nxConsole.commonNxCommands",
+						"title": "Common Nx Commands",
+						"description": "",
+						"media": {
+							"path": "getting-started/3-common-nx-commands.md"
+						}
+					},
+					{
+						"id": "nxConsole.projects",
+						"title": "Projects",
+						"description": "",
+						"media": {
+							"path": "getting-started/4-projects.md"
+						}
+					},
+					{
+						"id": "nxConsole.streamlining",
+						"title": "Streamlining",
+						"description": "",
+						"media": {
+							"path": "getting-started/5-streamlining.md"
+						}
+					}
+				]
+			}
+		],
     "views": {
       "nx-console": [
         {

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -683,6 +683,14 @@
     "views": {
       "nx-console": [
         {
+          "id": "nxConsole.views.welcome",
+          "name": "Welcome",
+          "when": "!isNxWorkspace && !isAngularWorkspace",
+          "contextualTitle": "Nx Console Getting Started",
+          "icon": "assets/nx-console.png",
+          "visibility": "visible"
+        },
+        {
           "id": "nxRunTarget",
           "name": "Generate & Run Target"
         },
@@ -695,14 +703,6 @@
           "id": "nxProjects",
           "name": "Projects",
           "when": "isNxWorkspace || isAngularWorkspace"
-        },
-        {
-          "id": "nxConsole.views.welcome",
-          "name": "Welcome",
-          "when": "!isNxWorkspace && !isAngularWorkspace",
-          "contextualTitle": "Nx Console Getting Started",
-          "icon": "assets/nx-console.png",
-          "visibility": "visible"
         }
       ]
     },

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -632,55 +632,55 @@
       }
     ],
     "walkthroughs": [
-			{
-				"id": "nxConsole",
-				"title": "Getting Started with Nx Console",
-				"description": "Interacting with your Nx Workspace",
-				"primary": true,
-				"steps": [
-					{
-						"id": "nxConsole.generate",
-						"title": "Generate",
-						"description": "",
-						"media": {
-							"path": "getting-started/1-generate.md"
-						}
-					},
-					{
-						"id": "nxConsole.run",
-						"title": "Run",
-						"description": "",
-						"media": {
-							"path": "getting-started/2-run.md"
-						}
-					},
-					{
-						"id": "nxConsole.commonNxCommands",
-						"title": "Common Nx Commands",
-						"description": "",
-						"media": {
-							"path": "getting-started/3-common-nx-commands.md"
-						}
-					},
-					{
-						"id": "nxConsole.projects",
-						"title": "Projects",
-						"description": "",
-						"media": {
-							"path": "getting-started/4-projects.md"
-						}
-					},
-					{
-						"id": "nxConsole.streamlining",
-						"title": "Streamlining",
-						"description": "",
-						"media": {
-							"path": "getting-started/5-streamlining.md"
-						}
-					}
-				]
-			}
-		],
+      {
+        "id": "nxConsole",
+        "title": "Getting Started with Nx Console",
+        "description": "Interacting with your Nx Workspace",
+        "primary": true,
+        "steps": [
+          {
+            "id": "nxConsole.generate",
+            "title": "Generate",
+            "description": "",
+            "media": {
+              "path": "getting-started/1-generate.md"
+            }
+          },
+          {
+            "id": "nxConsole.run",
+            "title": "Run",
+            "description": "",
+            "media": {
+              "path": "getting-started/2-run.md"
+            }
+          },
+          {
+            "id": "nxConsole.commonNxCommands",
+            "title": "Common Nx Commands",
+            "description": "",
+            "media": {
+              "path": "getting-started/3-common-nx-commands.md"
+            }
+          },
+          {
+            "id": "nxConsole.projects",
+            "title": "Projects",
+            "description": "",
+            "media": {
+              "path": "getting-started/4-projects.md"
+            }
+          },
+          {
+            "id": "nxConsole.streamlining",
+            "title": "Streamlining",
+            "description": "",
+            "media": {
+              "path": "getting-started/5-streamlining.md"
+            }
+          }
+        ]
+      }
+    ],
     "views": {
       "nx-console": [
         {
@@ -698,13 +698,13 @@
           "when": "isNxWorkspace || isAngularWorkspace"
         },
         {
-					"id": "nxConsole.views.welcome",
-					"name": "Welcome",
-					"when": "!isNxWorkspace && !isAngularWorkspace",
-					"contextualTitle": "Nx Console Getting Started",
-					"icon": "assets/nx-console.png",
-					"visibility": "visible"
-				}
+          "id": "nxConsole.views.welcome",
+          "name": "Welcome",
+          "when": "!isNxWorkspace && !isAngularWorkspace",
+          "contextualTitle": "Nx Console Getting Started",
+          "icon": "assets/nx-console.png",
+          "visibility": "visible"
+        }
       ]
     },
     "jsonValidation": [

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -628,7 +628,7 @@
       },
       {
         "view": "nxConsole.views.welcome",
-        "contents": "[Getting Started](https://nx.dev/latest/angular/getting-started/console#nx-console-for-vs-code)"
+        "contents": "[Getting Started](https://nx.dev/latest/angular/getting-started/console#nx-console-for-vscode)"
       }
     ],
     "walkthroughs": [


### PR DESCRIPTION
A recent VS Code update added experimental support for [Welcome Page walkthroughs](https://code.visualstudio.com/updates/v1_56#_welcome-page-walkthroughs).

I am only able to get the walkthrough to launch on installation in Insiders with the setting `"workbench.welcomePage.experimental.extensionContributions": true`.

But without Insiders, we still get this new button on the Welcome View to launch our walkthough:
![Screen Shot 2021-07-30 at 3 50 01 PM](https://user-images.githubusercontent.com/2250413/127711251-13a334e4-8f76-4eed-85de-ddde566d3021.png)

The walkthrough docs were copied from nx.dev, minus the videos. I could not get external links to work from within the walkthrough so wasn't able to include those.
![Screen Shot 2021-07-30 at 3 50 33 PM](https://user-images.githubusercontent.com/2250413/127711471-193f8422-01c5-4b82-99a1-fc11a69533a6.png)


(just some previous research notes:)
> I also checked out what [GitLens](https://github.com/eamodio/vscode-gitlens) is doing with their welcome and latest updates content, which is a different direction we may want to explore for a more robust solution. They store the latest installed version, and when someone has installed it for the first time they show a Welcome Page custom webview, and when someone has just updated to a new version, they show a Latest Updates custom webview.