### PR TITLE
fix: add positional to taskDefinitions

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -535,6 +535,10 @@
             "type": "string",
             "description": "The Angular CLI command to run on the selected project"
           },
+          "positional": {
+            "type": "string",
+            "description": "The project to run the command against"
+          },
           "flags": {
             "type": "array",
             "description": "An array of flags to pass to the CLI"
@@ -555,6 +559,10 @@
           "command": {
             "type": "string",
             "description": "The NX CLI command to run on the selected project"
+          },
+          "positional": {
+            "type": "string",
+            "description": "The project to run the command against"
           },
           "flags": {
             "type": "array",


### PR DESCRIPTION
fixes #992 task already active:
The tasks are keying off the properties in the taskDefinition, so adding the positional property makes `nx serve frontend` and `nx server api` different tasks. Same for ng tasks. This also works for flags, which were already in the taskDefinition, so `nx serve app` and `nx serve app --prod` are also different tasks.
