### PR TITLE
fix: don't show ng menus for nx workspaces

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -47,12 +47,12 @@
     "menus": {
       "explorer/context": [
         {
-          "when": "isAngularWorkspace && config.nxConsole.enableGenerateFromContextMenu",
+          "when": "!isNxWorkspace && isAngularWorkspace && config.nxConsole.enableGenerateFromContextMenu",
           "command": "ng.generate.ui.fileexplorer",
           "group": "explorerContext"
         },
         {
-          "when": "isAngularWorkspace && config.nxConsole.enableGenerateFromContextMenu",
+          "when": "!isNxWorkspace && isAngularWorkspace && config.nxConsole.enableGenerateFromContextMenu",
           "command": "ng.run.fileexplorer",
           "group": "explorerContext"
         },


### PR DESCRIPTION
whoops! don't show those ng context menus for nx workspaces. I implemented the `ng.run` command in that last PR #1075 and added the menu, but I goofed and showed both sets of menus for Nx workspaces with angular.json.