### PR TITLE
fix: use proper file paths for schemas within windows

### DIFF
--- a/libs/vscode/json-schema/src/lib/get-all-executors.ts
+++ b/libs/vscode/json-schema/src/lib/get-all-executors.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { clearJsonCache, readAndCacheJsonFile } from '@nx-console/server';
 import { dirname, join } from 'path';
+import { platform } from 'os';
 
 export interface ExecutorInfo {
   name: string;
@@ -89,9 +90,16 @@ function getBuilderPaths(
   for (const [key, value] of Object.entries<any>(
     json.builders || json.executors
   )) {
+    let path = '';
+    if (platform() === 'win32') {
+      path = `file:///${join(baseDir, value.schema).replace(/\\/g, '/')}`
+    } else {
+      path = join(baseDir, value.schema);
+    }
+
     builders.push({
       name: `${collectionName}:${key}`,
-      path: join(baseDir, value.schema).replace(/\\/g, '/'),
+      path,
     });
   }
 

--- a/libs/vscode/json-schema/src/lib/get-all-executors.ts
+++ b/libs/vscode/json-schema/src/lib/get-all-executors.ts
@@ -91,7 +91,7 @@ function getBuilderPaths(
   )) {
     builders.push({
       name: `${collectionName}:${key}`,
-      path: join(baseDir, value.schema),
+      path: join(baseDir, value.schema).replace(/\\/g, '/'),
     });
   }
 


### PR DESCRIPTION
## What it does
Fixes the absolute path for the schema files for the workspace json schema. Windows should now have the proper absolute file 
path notation `file:///c:/.../schema.json` 

##### Windows
![image](https://user-images.githubusercontent.com/4332460/122244554-fa034f00-ce92-11eb-911e-572a2c79ed66.png)

##### macOS
<img width="2160" alt="image" src="https://user-images.githubusercontent.com/4332460/122245695-f2907580-ce93-11eb-9698-7cbe947d3ad0.png">


Fixes #1083