### PR TITLE
refactor: removed json5 and strip-json-comments from dependencies and used jsonc-parser instead

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -40,8 +40,7 @@
     "*"
   ],
   "dependencies": {
-    "jsonc-parser": "^2.1.1",
-    "json5": "2.1.1"
+    "jsonc-parser": "^3.0.0"
   },
   "contributes": {
     "menus": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "dependencies": {
     "@ngrx/component-store": "11.0.0",
-    "jsonc-parser": "^2.1.1",
-    "strip-json-comments": "^3.1.1"
+    "jsonc-parser": "^3.0.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.1102.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10232,15 +10232,10 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@3.0.0:
+jsonc-parser@3.0.0, jsonc-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
   integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
-
-jsonc-parser@^2.1.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.3.1.tgz#59549150b133f2efacca48fe9ce1ec0659af2342"
-  integrity sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==
 
 jsonfile@^2.1.0:
   version "2.4.0"


### PR DESCRIPTION
- Updated `jsonc-parser` to 3.0.0
- Removed `strip-json-comments' from dependencies
- Removed `json5` from `apps/vscode/src/package.json`
- Replaced the `readAndParseJson` function by a faster implementation similar to the one at https://github.com/nrwl/nx/blob/4f429e0eab7f9294184166cef202688d434e21a8/packages/tao/src/utils/json.ts#L35