### PR TITLE
chore: remove dependency zlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "universal-analytics": "0.4.20",
     "vsce": "^1.69.0",
     "vscode-codicons": "^0.0.16",
-    "zlib": "^1.0.5",
     "zone.js": "0.10.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17317,11 +17317,6 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zlib@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
-  integrity sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA=
-
 zone.js@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.10.3.tgz#3e5e4da03c607c9dcd92e37dd35687a14a140c16"


### PR DESCRIPTION
`zlib` is a native Node.js module. nx-console should not depend on https://www.npmjs.com/package/zlib