### PR TITLE
chore(repo): remove obsolete vscode postinstall

### DIFF
--- a/tools/scripts/postinstall.js
+++ b/tools/scripts/postinstall.js
@@ -1,7 +1,4 @@
-const shell = require('shelljs');
 const fs = require('fs');
-
-shell.exec('node ./node_modules/vscode/bin/install');
 
 fs.writeFileSync(
   `./node_modules/source-map-explorer/vendor/webtreemap.css`,


### PR DESCRIPTION
Removed obsolete vscode postinstall script: node ./node_modules/vscode/bin/install from tools/scripts/postinstall.js see: https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode