### PR TITLE
fix: read package.json dependencies when getting builders/executors

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,11 +1,5 @@
 const nxPreset = require('@nrwl/jest/preset');
 module.exports = {
   ...nxPreset,
-  testMatch: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
-  transform: {
-    '^.+\\.(ts|js|html)$': 'ts-jest',
-  },
-  resolver: '@nrwl/jest/plugins/resolver',
-  moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageReporters: ['html'],
+  transformIgnorePatterns: ['node_modules/(?!(@types)/)'],
 };

--- a/libs/server/jest.config.js
+++ b/libs/server/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   preset: '../../jest.preset.js',
   coverageDirectory: '../../coverage/libs/server',
-  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: { 'ts-jest': { tsConfig: '<rootDir>/tsconfig.spec.json' } },
   displayName: 'server',
 };

--- a/libs/server/src/lib/utils/utils.ts
+++ b/libs/server/src/lib/utils/utils.ts
@@ -18,6 +18,7 @@ import {
   printParseErrorCode,
   ParseError,
 } from 'jsonc-parser';
+import { getOutputChannel } from './output-channel';
 
 export interface SchematicDefaults {
   [name: string]: string;
@@ -147,10 +148,13 @@ function readAndParseJson(filePath: string) {
     const result = parseJson(content, errors);
 
     if (errors.length > 0) {
-      const { error, offset } = errors[0];
-      throw new Error(
-        `${printParseErrorCode(error)} in JSON at position ${offset}`
-      );
+      for (const { error, offset } of errors) {
+        getOutputChannel().appendLine(
+          `${printParseErrorCode(
+            error
+          )} in JSON at position ${offset} in ${filePath}`
+        );
+      }
     }
 
     return result;

--- a/libs/server/src/test-setup.ts
+++ b/libs/server/src/test-setup.ts
@@ -1,5 +1,0 @@
-module.exports = {
-  name: 'server',
-  preset: '../../jest.config.js',
-  coverageDirectory: '../../coverage/libs/server',
-};

--- a/libs/server/tsconfig.spec.json
+++ b/libs/server/tsconfig.spec.json
@@ -5,6 +5,5 @@
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "files": ["src/test-setup.ts"],
   "include": ["**/*.spec.ts", "**/*.d.ts"]
 }

--- a/libs/vscode/json-schema/src/lib/get-all-executors.ts
+++ b/libs/vscode/json-schema/src/lib/get-all-executors.ts
@@ -22,15 +22,17 @@ function readExecutorCollectionsFromNodeModules(
   workspaceJsonPath: string,
   clearPackageJsonCache: boolean
 ): ExecutorInfo[] {
-  const basedir = join(workspaceJsonPath, '..');
+  const basedir = dirname(workspaceJsonPath);
   const nodeModulesDir = join(basedir, 'node_modules');
 
   if (clearPackageJsonCache) {
     clearJsonCache('package.json', basedir);
   }
-
-  const packages: { [packageName: string]: string } =
-    readAndCacheJsonFile('package.json', basedir).json.devDependencies || {};
+  const packageJson = readAndCacheJsonFile('package.json', basedir).json;
+  const packages: { [packageName: string]: string } = {
+    ...(packageJson.devDependencies || {}),
+    ...(packageJson.dependencies || {}),
+  };
   const executorCollections = Object.keys(packages).filter((p) => {
     try {
       const packageJson = readAndCacheJsonFile(
@@ -92,7 +94,7 @@ function getBuilderPaths(
   )) {
     let path = '';
     if (platform() === 'win32') {
-      path = `file:///${join(baseDir, value.schema).replace(/\\/g, '/')}`
+      path = `file:///${join(baseDir, value.schema).replace(/\\/g, '/')}`;
     } else {
       path = join(baseDir, value.schema);
     }


### PR DESCRIPTION
## What it does
When creating the workspace.json schema, we now also read the package.json's dependencies object as well.

Also, I changed the `readAndParseJson` to output to the OutputChannel than throw errors. This should clean up some annoying popups for some users. 
