### PR TITLE
feat: support dep-graph watch option

### DIFF
--- a/libs/vscode/tasks/src/lib/nx-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/nx-task-commands.ts
@@ -196,6 +196,11 @@ const RUN_MANY_OPTIONS: Option[] = [
 
 const DEP_GRAPH_OPTIONS: Option[] = [
   {
+    name: 'watch',
+    type: OptionType.Boolean,
+    description: 'Watch for changes to dep graph and update in-browser',
+  },
+  {
     name: 'file',
     type: OptionType.String,
     description: 'output file (e.g. --file=output.json)',


### PR DESCRIPTION
adds the --watch option for `nx dep-graph` command. I noticed the `affected:dep-graph` doesn't support any of the dep-graph options, just the affected options, we may want to address that at some point as well.