### PR TITLE
fix: ensure project path is not just a partial match

### DIFF
--- a/libs/vscode/tasks/src/lib/cli-task-provider.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-provider.ts
@@ -147,9 +147,17 @@ export class CliTaskProvider implements TaskProvider {
   projectForPath(selectedPath: string): NamedProject | null {
     if (!this.getWorkspaceJsonPath()) return null;
 
-    const entry = this.getProjectEntries().find(([_, def]) =>
-      selectedPath.startsWith(join(this.getWorkspacePath(), def.root))
-    );
+    const entry = this.getProjectEntries().find(([_, def]) => {
+      const fullProjectPath = join(this.getWorkspacePath(), def.root);
+      return (
+        selectedPath.startsWith(fullProjectPath) &&
+        // check that it's not a partial match
+        selectedPath
+          .replace(fullProjectPath, '')
+          .replace(/\\/g, '/')
+          .startsWith('/')
+      );
+    });
 
     return entry ? { name: entry[0], ...entry[1] } : null;
   }


### PR DESCRIPTION
Noticed that we were matching projects where the root is a partial match of another project, e.g. `/libs/my-lib-longer-name` was matched by `/libs/my-lib-long`