### PR TITLE
fix: add min-height to scroll container so at least 100vh

### DIFF
--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
@@ -41,9 +41,11 @@ $offset-with-configurations: $offset-without-configurations +
 vscode-ui-field-tree {
   box-sizing: border-box;
   padding-top: $host-padding-top / 2;
+  min-height: calc(100vh - #{$offset-without-configurations});
   max-height: calc(100vh - #{$offset-without-configurations});
 
   .has-configurations & {
+    min-height: calc(100vh - #{$offset-without-configurations});
     max-height: calc(100vh - #{$offset-with-configurations});
   }
 }


### PR DESCRIPTION
Quick fix for an issue with autocomplete for generators with a short list of options with an autocomplete at the bottom.

Currently- autocomplete cut off at end of original height:
![Screen Shot 2021-07-16 at 9 36 47 AM](https://user-images.githubusercontent.com/2250413/125984003-e1e25352-d49d-4c92-ab99-a47ae92398e2.png)

Fix- setting min-height of that container as well allows the autocomplete to expand:
![Screen Shot 2021-07-16 at 9 38 04 AM](https://user-images.githubusercontent.com/2250413/125984016-a67bdae5-0b7f-4b40-be70-35990b38cabf.png)

Would be great to address #985 at some point as well, but this helps.