### PR TITLE
fix: include path with project but not directory

### DIFF
--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -172,7 +172,14 @@ function getConfigValuesFromContextMenuUri(
   schematic: TaskExecutionSchema,
   contextMenuUri: Uri | undefined,
   cliTaskProvider: CliTaskProvider
-): { path?: string; directory?: string; project?: string, projectName?: string } | undefined {
+):
+  | {
+      path?: string;
+      directory?: string;
+      project?: string;
+      projectName?: string;
+    }
+  | undefined {
   if (contextMenuUri) {
     const project = cliTaskProvider.projectForPath(contextMenuUri.fsPath);
     const projectName = (project && project.name) || undefined;
@@ -186,32 +193,31 @@ function getConfigValuesFromContextMenuUri(
     const nxConfig = readAndCacheJsonFile('nx.json', workspacePath);
     const appsDir = nxConfig.json.workspaceLayout?.appsDir ?? 'apps';
     const libsDir = nxConfig.json.workspaceLayout?.libsDir ?? 'libs';
-    if (appsDir && schematic.name === 'application' || schematic.name === 'app') {
-      path = path.replace(appsDir, '')
-        .replace(/^\//, '');
+    if (
+      (appsDir && schematic.name === 'application') ||
+      schematic.name === 'app'
+    ) {
+      path = path.replace(appsDir, '').replace(/^\//, '');
     }
-    if (libsDir && schematic.name === 'library' || schematic.name === 'lib') {
-      path = path.replace(libsDir, '')
-        .replace(/^\//, '');
+    if ((libsDir && schematic.name === 'library') || schematic.name === 'lib') {
+      path = path.replace(libsDir, '').replace(/^\//, '');
     }
 
-    if (projectName && schematic.options.some(isProjectOption)) {
-      return {
-        project: projectName,
-        projectName,
-      }
-    } else {
-      return {
-        path,
+    return {
+      project: projectName,
+      projectName,
+      path,
+      ...(!(projectName && schematic.options.some(isProjectOption)) && {
         directory: path,
-      };
-    }
+      }),
+    };
   }
 }
 
 function isProjectOption(option: Option) {
   return (
-    option.name === 'project' || option.name === 'projectName' ||
+    option.name === 'project' ||
+    option.name === 'projectName' ||
     (option.$default && option.$default.$source === 'projectName')
   );
 }


### PR DESCRIPTION
 fixes #1086- if project  is found from context

I did some testing with different plugins, and I found there are inconsistencies on how `directory` is handled, but it is mostly relative to the project if a `project` option is also included. I added support for `directory` from the context menu uri within the past few months, and we didn't seem to notice these issues with the context path support before directory was added.