### PR TITLE
fix: load workspace file utils directly

### DIFF
--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
@@ -4,13 +4,21 @@ import type * as NxWorkspacePackage from '@nrwl/workspace';
 /**
  * Get the local installed version of @nrwl/workspace
  */
-export function getNxWorkspacePackage(): typeof NxWorkspacePackage {
+export function getNxWorkspacePackageFileUtils(): typeof NxWorkspacePackage {
   const workspacePath = dirname(
     WorkspaceConfigurationStore.instance.get('nxWorkspaceJsonPath', '')
   );
 
   // webpack hacks..
   return eval('require')(
-    join(workspacePath, 'node_modules', '@nrwl', 'workspace')
+    join(
+      workspacePath,
+      'node_modules',
+      '@nrwl',
+      'workspace',
+      'src',
+      'core',
+      'file-utils'
+    )
   );
 }

--- a/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
@@ -9,7 +9,7 @@ import {
 import { window } from 'vscode';
 import { dirname, join } from 'path';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
-import { getNxWorkspacePackage } from './get-nx-workspace-package';
+import { getNxWorkspacePackageFileUtils } from './get-nx-workspace-package';
 
 export function verifyWorkspace(): {
   validWorkspaceJson: boolean;
@@ -83,7 +83,7 @@ function readNxWorkspaceConfig(basedir: string, workspaceJsonPath: string) {
   try {
     const cachedWorkspaceJson = cacheJson(workspaceJsonPath).json;
     if (!cachedWorkspaceJson) {
-      const workspace = getNxWorkspacePackage().readWorkspaceConfig({
+      const workspace = getNxWorkspacePackageFileUtils().readWorkspaceConfig({
         format: 'nx',
         path: basedir,
       } as any);


### PR DESCRIPTION
## What it does
Loads the `@nrwl/workspace` file utils directly so that we don't require the main index file. When we require the main file, it'll try to load the `@angular/devkit` package. 

Fixes #1109