### PR TITLE
fix: menu scroll hides Run and Search bar header

### DIFF
--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
@@ -45,7 +45,7 @@ vscode-ui-field-tree {
   max-height: calc(100vh - #{$offset-without-configurations});
 
   .has-configurations & {
-    min-height: calc(100vh - #{$offset-without-configurations});
+    min-height: calc(100vh - #{$offset-with-configurations});
     max-height: calc(100vh - #{$offset-with-configurations});
   }
 }


### PR DESCRIPTION
fixes #1116, I copy-pasta'ed the wrong min-height for has-configurations which was causing the Search bar and Run button to be hidden when using the side menu to scrollIntoView