### PR TITLE
fix: configurations tabs overflow

### DIFF
--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
@@ -188,6 +188,9 @@ nx-console-field {
 .configurations-container {
   margin-top: 24px;
   height: $configurations-offset - 24px;
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
 
   .configuration {
     margin-right: 24px;


### PR DESCRIPTION
Fixes the overflow on the configurations tabs menu when there are more configuration options than fit in the max-width of the container