### PR TITLE
chore: add more analytics to track workspace type

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -261,6 +261,17 @@ async function setWorkspace(workspaceJsonPath: string) {
 
   currentRunTargetTreeProvider.refresh();
   nxProjectsTreeProvider.refresh();
+
+  let workspaceType: 'nx' | 'angular' | 'angularWithNx' = 'nx';
+  if (isNxWorkspace && isAngularWorkspace) {
+    workspaceType = 'angularWithNx';
+  } else if (isNxWorkspace && !isAngularWorkspace) {
+    workspaceType = 'nx';
+  } else if (!isNxWorkspace && isAngularWorkspace) {
+    workspaceType = 'angular';
+  }
+
+  getTelemetry().record('WorkspaceType', { workspaceType });
 }
 
 function registerWorkspaceFileWatcher(

--- a/libs/server/src/lib/telemetry/record.ts
+++ b/libs/server/src/lib/telemetry/record.ts
@@ -7,7 +7,8 @@ export type TelemetryType =
   | 'CommandRun'
   | 'ExceptionOccurred'
   | 'FeatureUsed'
-  | 'UserStateChanged';
+  | 'UserStateChanged'
+  | 'WorkspaceType';
 
 export function isTelemetryRecord(evt: string): evt is TelemetryType {
   return new Set([

--- a/libs/server/src/lib/telemetry/sinks/google-analytics-sink.ts
+++ b/libs/server/src/lib/telemetry/sinks/google-analytics-sink.ts
@@ -19,6 +19,7 @@ class TelemetryParams {
 
   require(key: string) {
     const msg = `Telemetry: ${this.type} is missing ${key}`;
+    // eslint-disable-next-line no-prototype-builtins
     if (!this.data.hasOwnProperty(key)) {
       throw new Error(msg);
     }
@@ -26,6 +27,7 @@ class TelemetryParams {
 }
 
 export class GoogleAnalyticsSink implements Sink, TelemetryMessageBuilder {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   visitor = require('universal-analytics')(TRACKING_ID, {
     uid: this.user.id,
   });
@@ -78,6 +80,9 @@ export class GoogleAnalyticsSink implements Sink, TelemetryMessageBuilder {
         break;
       case 'FeatureUsed':
         this.featureUsed(params.fetch('feature'));
+        break;
+      case 'WorkspaceType':
+        this.workspaceType(params.fetch('workspaceType'));
         break;
       default:
         throw new Error(`Unknown Telemetry type: ${type}`);
@@ -157,6 +162,16 @@ export class GoogleAnalyticsSink implements Sink, TelemetryMessageBuilder {
       .event({
         ec: 'Feature',
         ea: feature,
+      })
+      .send();
+  }
+
+  workspaceType(workspaceType: string) {
+    this.visitor
+      .event({
+        ec: 'WorkspaceType',
+        ea: workspaceType,
+        ev: 1,
       })
       .send();
   }


### PR DESCRIPTION
## What it does
This PR adds more analytics to track the current workspace type, being: `'nx', 'angular', 'angularWithNx'`.
