### PR TITLE
chore: change to workspace v2 names

### DIFF
--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -42,7 +42,7 @@ export interface TaskExecutionSchema {
   cliName: 'nx' | 'ng';
   builder?: string;
   description: string;
-  configurations?: ArchitectConfiguration[];
+  configurations?: TargetConfiguration[];
   options: Option[];
   contextValues?: Record<string, string | number | boolean | undefined>;
 }
@@ -64,7 +64,7 @@ export interface DefaultValue {
   defaultValue: string | undefined;
 }
 
-export interface ArchitectConfiguration {
+export interface TargetConfiguration {
   name: string;
   defaultValues: DefaultValue[];
 }
@@ -73,16 +73,17 @@ export interface Project {
   name: string;
   root: string;
   projectType: string;
-  architect: Architect[];
+  targets: Targets[];
 }
 
-export interface Architect {
+export interface Targets {
   name: string;
   project: string;
   builder: string;
   description: string;
-  configurations: ArchitectConfiguration[];
+  configurations: TargetConfiguration[];
   options: CliOption[];
 }
 
-export const WORKSPACE_GENERATOR_NAME_REGEX = /^workspace-(schematic|generator):(.+)/;
+export const WORKSPACE_GENERATOR_NAME_REGEX =
+  /^workspace-(schematic|generator):(.+)/;

--- a/libs/server/src/index.ts
+++ b/libs/server/src/index.ts
@@ -15,6 +15,7 @@ export {
   cacheJson,
   clearJsonCache,
   toLegacyWorkspaceFormat,
+  toWorkspaceFormat,
   listOfUnnestedNpmPackages,
 } from './lib/utils/utils';
 export { watchFile } from './lib/utils/watch-file';

--- a/libs/server/src/lib/utils/read-projects.ts
+++ b/libs/server/src/lib/utils/read-projects.ts
@@ -1,11 +1,12 @@
 import {
-  Architect,
+  Targets,
   Project,
   Option,
   DefaultValue,
-  ArchitectConfiguration,
+  TargetConfiguration,
 } from '@nx-console/schema';
 import * as path from 'path';
+import { TargetConfiguration as NxTargetConfiguration } from '@nrwl/devkit';
 
 import {
   getPrimitiveValue,
@@ -13,45 +14,32 @@ import {
   readAndCacheJsonFile,
 } from '../utils/utils';
 
-export function readProjects(json: any): Project[] {
-  return Object.entries(json)
-    .map(
-      ([key, value]: [string, any]): Project => ({
-        name: key,
-        root: value.root,
-        projectType: value.projectType,
-        architect: readArchitect(key, value.architect),
-      })
-    )
-    .sort((a, b) => a.root.localeCompare(b.root));
-}
-
-export function readArchitectDef(
-  architectName: string,
-  architectDef: any,
+export function readTargetDef(
+  targetName: string,
+  targetsDef: NxTargetConfiguration,
   project: string
-): Architect {
-  const configurations: ArchitectConfiguration[] = architectDef.configurations
-    ? Object.keys(architectDef.configurations).map((name) => ({
+): Targets {
+  const configurations: TargetConfiguration[] = targetsDef.configurations
+    ? Object.keys(targetsDef.configurations).map((name) => ({
         name,
-        defaultValues: readDefaultValues(architectDef.configurations, name),
+        defaultValues: readDefaultValues(targetsDef.configurations, name),
       }))
     : [];
 
   return {
     options: [],
     configurations,
-    name: architectName,
+    name: targetName,
     project,
-    description: architectDef.description || '',
-    builder: architectDef.builder,
+    description: (targetsDef as any).description ?? '',
+    builder: targetsDef.executor,
   };
 }
 
-export function readArchitect(project: string, architect: any): Architect[] {
-  if (!architect) return [];
-  return Object.entries(architect).map(([key, value]: [string, any]) => {
-    return readArchitectDef(key, value, project);
+export function readTargets(project: string, targets: any): Targets[] {
+  if (!targets) return [];
+  return Object.entries(targets).map(([key, value]: [string, any]) => {
+    return readTargetDef(key, value, project);
   });
 }
 

--- a/libs/server/src/lib/utils/read-schematic-collections.ts
+++ b/libs/server/src/lib/utils/read-schematic-collections.ts
@@ -9,6 +9,7 @@ import {
   normalizeSchema,
   readAndCacheJsonFile,
   toLegacyWorkspaceFormat,
+  toWorkspaceFormat,
 } from './utils';
 
 export async function readAllSchematicCollections(
@@ -50,8 +51,8 @@ async function checkAndReadWorkspaceCollection(
 
 function readWorkspaceJsonDefaults(workspaceJsonPath: string): any {
   const defaults =
-    toLegacyWorkspaceFormat(readAndCacheJsonFile(workspaceJsonPath).json)
-      .schematics || {};
+    toWorkspaceFormat(readAndCacheJsonFile(workspaceJsonPath).json)
+      .generators || {};
   const collectionDefaults = Object.keys(defaults).reduce(
     (collectionDefaultsMap: any, key) => {
       if (key.includes(':')) {

--- a/libs/server/src/lib/utils/utils.ts
+++ b/libs/server/src/lib/utils/utils.ts
@@ -1,6 +1,7 @@
 import { schema } from '@angular-devkit/core';
 import { standardFormats } from '@angular-devkit/schematics/src/formats';
 import { parseJsonSchemaToOptions } from '@angular/cli/utilities/json-schema';
+import type { WorkspaceJsonConfiguration } from '@nrwl/devkit';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { platform } from 'os';
 import * as path from 'path';
@@ -354,7 +355,7 @@ function renameProperty(obj: any, from: string, to: string) {
   delete obj[from];
 }
 
-export function toLegacyWorkspaceFormat(w: any) {
+export function toLegacyWorkspaceFormat(w: WorkspaceJsonConfiguration) {
   Object.values(w.projects || {}).forEach((project: any) => {
     if (project.targets) {
       renameProperty(project, 'targets', 'architect');
@@ -371,6 +372,27 @@ export function toLegacyWorkspaceFormat(w: any) {
 
   if (w.generators) {
     renameProperty(w, 'generators', 'schematics');
+  }
+  return w;
+}
+
+export function toWorkspaceFormat(w: any): WorkspaceJsonConfiguration {
+  Object.values(w.projects || {}).forEach((project: any) => {
+    if (project.architect) {
+      renameProperty(project, 'architect', 'targets');
+    }
+    if (project.schematics) {
+      renameProperty(project, 'schematics', 'generators');
+    }
+    Object.values(project.targets || {}).forEach((target: any) => {
+      if (target.builder) {
+        renameProperty(target, 'builder', 'executor');
+      }
+    });
+  });
+
+  if (w.schematics) {
+    renameProperty(w, 'schematics', 'generators');
   }
   return w;
 }

--- a/libs/vscode/nx-project-view/src/lib/nx-project-tree-provider.ts
+++ b/libs/vscode/nx-project-view/src/lib/nx-project-tree-provider.ts
@@ -26,18 +26,18 @@ export class NxProjectTreeProvider extends AbstractTreeProvider<NxProjectTreeIte
   ) {
     super();
 
-    ([
-      ['editWorkspaceJson', this.editWorkspaceJson],
-      ['revealInExplorer', this.revealInExplorer],
-      ['runTask', this.runTask],
-      ['refreshNxProjectsTree', this.refreshNxProjectsTree],
-    ] as [string, (item: NxProjectTreeItem) => Promise<unknown>][]).forEach(
-      ([commandSuffix, callback]) => {
-        context.subscriptions.push(
-          commands.registerCommand(`nxConsole.${commandSuffix}`, callback, this)
-        );
-      }
-    );
+    (
+      [
+        ['editWorkspaceJson', this.editWorkspaceJson],
+        ['revealInExplorer', this.revealInExplorer],
+        ['runTask', this.runTask],
+        ['refreshNxProjectsTree', this.refreshNxProjectsTree],
+      ] as [string, (item: NxProjectTreeItem) => Promise<unknown>][]
+    ).forEach(([commandSuffix, callback]) => {
+      context.subscriptions.push(
+        commands.registerCommand(`nxConsole.${commandSuffix}`, callback, this)
+      );
+    });
   }
 
   getParent(element: NxProjectTreeItem): NxProjectTreeItem | null | undefined {
@@ -70,9 +70,8 @@ export class NxProjectTreeProvider extends AbstractTreeProvider<NxProjectTreeIte
         : TreeItemCollapsibleState.None
     );
     if (!workspaceJsonLabel.target) {
-      const projectDef = this.cliTaskProvider.getProjects()[
-        workspaceJsonLabel.project
-      ];
+      const projectDef =
+        this.cliTaskProvider.getProjects()[workspaceJsonLabel.project];
       if (projectDef) {
         item.resourceUri = Uri.file(
           join(this.cliTaskProvider.getWorkspacePath(), projectDef.root)
@@ -101,7 +100,7 @@ export class NxProjectTreeProvider extends AbstractTreeProvider<NxProjectTreeIte
           this.createNxProjectTreeItem(
             { project: name },
             name,
-            Boolean(def.architect)
+            Boolean(def.targets)
           )
       );
     }
@@ -115,25 +114,25 @@ export class NxProjectTreeProvider extends AbstractTreeProvider<NxProjectTreeIte
     }
 
     if (!target) {
-      if (projectDef.architect) {
-        return Object.keys(projectDef.architect).map(
+      if (projectDef.targets) {
+        return Object.keys(projectDef.targets).map(
           (name): NxProjectTreeItem =>
             this.createNxProjectTreeItem(
               { target: { name }, project },
               name,
-              Boolean(projectDef.architect?.[name].configurations)
+              Boolean(projectDef.targets?.[name].configurations)
             )
         );
       }
     } else {
       const { configuration } = target;
 
-      if (configuration || !projectDef.architect) {
+      if (configuration || !projectDef.targets) {
         return;
       }
 
-      const configurations = projectDef.architect
-        ? projectDef.architect[target.name].configurations
+      const configurations = projectDef.targets
+        ? projectDef.targets[target.name].configurations
         : undefined;
       if (!configurations) {
         return;

--- a/libs/vscode/nx-workspace/src/lib/find-workspace-json-target.ts
+++ b/libs/vscode/nx-workspace/src/lib/find-workspace-json-target.ts
@@ -1,5 +1,11 @@
 import { TextDocument } from 'vscode';
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
+import {
+  isObjectLiteralExpression,
+  isPropertyAssignment,
+  isStringLiteral,
+  parseJsonText,
+} from 'typescript';
 
 export interface ProjectLocations {
   [projectName: string]: {
@@ -16,7 +22,7 @@ export interface ProjectTargetLocation {
 
 export function getProjectLocations(document: TextDocument, projectName = '') {
   const projectLocations: ProjectLocations = {};
-  const json = typescript.parseJsonText('workspace.json', document.getText());
+  const json = parseJsonText('workspace.json', document.getText());
   const statement = json.statements[0];
   const projects = getProperties(statement.expression)?.find(
     (property) => getPropertyName(property) === 'projects'
@@ -48,18 +54,15 @@ export function getProjectLocations(document: TextDocument, projectName = '') {
 function getProperties(
   objectLiteral: typescript.Node
 ): typescript.NodeArray<typescript.ObjectLiteralElementLike> | undefined {
-  if (typescript.isObjectLiteralExpression(objectLiteral)) {
+  if (isObjectLiteralExpression(objectLiteral)) {
     return objectLiteral.properties;
-  } else if (typescript.isPropertyAssignment(objectLiteral)) {
+  } else if (isPropertyAssignment(objectLiteral)) {
     return getProperties(objectLiteral.initializer);
   }
 }
 
 function getPropertyName(property: typescript.ObjectLiteralElementLike) {
-  if (
-    typescript.isPropertyAssignment(property) &&
-    typescript.isStringLiteral(property.name)
-  ) {
+  if (isPropertyAssignment(property) && isStringLiteral(property.name)) {
     return property.name.text;
   }
 }

--- a/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
@@ -1,19 +1,20 @@
 import {
-  readAndCacheJsonFile,
   fileExistsSync,
-  toLegacyWorkspaceFormat,
   getOutputChannel,
   getTelemetry,
   cacheJson,
+  readAndCacheJsonFile,
+  toWorkspaceFormat,
 } from '@nx-console/server';
 import { window } from 'vscode';
 import { dirname, join } from 'path';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
 import { getNxWorkspacePackageFileUtils } from './get-nx-workspace-package';
+import { WorkspaceJsonConfiguration } from '@nrwl/devkit';
 
 export function verifyWorkspace(): {
   validWorkspaceJson: boolean;
-  json?: any;
+  json: WorkspaceJsonConfiguration;
   workspaceType: 'ng' | 'nx';
   configurationFilePath: string;
 } {
@@ -29,8 +30,7 @@ export function verifyWorkspace(): {
       readNxWorkspaceConfig(workspacePath, workspaceJsonPath);
       return {
         validWorkspaceJson: true,
-        // TODO(cammisuli): change all instances to use the new version - basically reverse this to the new format
-        json: toLegacyWorkspaceFormat(
+        json: toWorkspaceFormat(
           /**
            * We would get the value from the `readWorkspaceConfig` call if that was successful.
            * Otherwise, we manually read the workspace.json file
@@ -44,9 +44,7 @@ export function verifyWorkspace(): {
       readNxWorkspaceConfig(workspacePath, angularJsonPath);
       return {
         validWorkspaceJson: true,
-        json: toLegacyWorkspaceFormat(
-          readAndCacheJsonFile(angularJsonPath).json
-        ),
+        json: toWorkspaceFormat(readAndCacheJsonFile(angularJsonPath).json),
         workspaceType: 'ng',
         configurationFilePath: angularJsonPath,
       };
@@ -73,6 +71,10 @@ export function verifyWorkspace(): {
     return {
       validWorkspaceJson: false,
       workspaceType: 'nx',
+      json: {
+        projects: {},
+        version: 2,
+      },
       configurationFilePath: '',
     };
   }

--- a/libs/vscode/tasks/src/lib/cli-task-definition.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-definition.ts
@@ -3,29 +3,3 @@ export interface CliTaskDefinition {
   command: string;
   flags: Array<string>;
 }
-
-export interface ArchitectDef {
-  builder: string;
-  configurations?: {
-    [configuration: string]: any;
-  };
-}
-
-export interface ProjectDef {
-  root: string;
-  architect?: {
-    [architectName: string]: ArchitectDef;
-  };
-}
-
-export interface NamedProject extends ProjectDef {
-  name: string;
-}
-
-export interface Projects {
-  [projectName: string]: ProjectDef | undefined;
-}
-
-export interface WorkspaceJson {
-  projects: Projects;
-}

--- a/libs/vscode/tasks/src/lib/cli-task-provider.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-provider.ts
@@ -11,16 +11,11 @@ import { getTelemetry } from '@nx-console/server';
 import { verifyWorkspace } from '@nx-console/vscode/nx-workspace';
 import { verifyNodeModules } from '@nx-console/vscode/verify';
 import { CliTask } from './cli-task';
-import {
-  CliTaskDefinition,
-  NamedProject,
-  ProjectDef,
-  Projects,
-  WorkspaceJson,
-} from './cli-task-definition';
+import { CliTaskDefinition } from './cli-task-definition';
 import { NxTask } from './nx-task';
 import { WORKSPACE_GENERATOR_NAME_REGEX } from '@nx-console/schema';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
+import { WorkspaceJsonConfiguration } from '@nrwl/devkit';
 
 export let cliTaskProvider: CliTaskProvider;
 
@@ -120,7 +115,7 @@ export class CliTaskProvider implements TaskProvider {
     });
   }
 
-  getProjects(json?: WorkspaceJson): Projects {
+  getProjects(json?: WorkspaceJsonConfiguration) {
     if (json) {
       return json.projects;
     } else {
@@ -137,14 +132,11 @@ export class CliTaskProvider implements TaskProvider {
     return Object.keys(this.getProjects() || {});
   }
 
-  getProjectEntries(json?: WorkspaceJson): [string, ProjectDef][] {
-    return Object.entries(this.getProjects(json) || {}) as [
-      string,
-      ProjectDef
-    ][];
+  getProjectEntries(json?: WorkspaceJsonConfiguration) {
+    return Object.entries(this.getProjects(json) || {});
   }
 
-  projectForPath(selectedPath: string): NamedProject | null {
+  projectForPath(selectedPath: string) {
     if (!this.getWorkspaceJsonPath()) return null;
 
     const entry = this.getProjectEntries().find(([, def]) => {

--- a/libs/vscode/tasks/src/lib/cli-task-quick-pick-item.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-quick-pick-item.ts
@@ -1,10 +1,10 @@
-import { ArchitectDef } from './cli-task-definition';
+import { TargetConfiguration } from '@nrwl/devkit';
 import { QuickPickItem } from 'vscode';
 
 export class CliTaskQuickPickItem implements QuickPickItem {
   constructor(
     readonly projectName: string,
-    readonly architectDef: ArchitectDef,
+    readonly targetDef: TargetConfiguration,
     readonly command: string,
     readonly label: string
   ) {}

--- a/libs/vscode/tasks/src/lib/nx-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/nx-task-commands.ts
@@ -2,7 +2,6 @@ import { Option } from '@nx-console/schema';
 import { OptionType } from '@angular/cli/models/interface';
 import { commands, ExtensionContext, window, tasks } from 'vscode';
 
-import { ProjectDef } from './cli-task-definition';
 import { CliTaskProvider } from './cli-task-provider';
 import { selectFlags } from './select-flags';
 import { verifyWorkspace } from '@nx-console/vscode/nx-workspace';
@@ -23,18 +22,11 @@ export function registerNxCommands(
       }
       promptForAffectedFlags(target);
     }),
-    ...[
-      'apps',
-      'build',
-      'dep-graph',
-      'e2e',
-      'libs',
-      'lint',
-      'test',
-    ].map((command) =>
-      commands.registerCommand(`nx.affected.${command}`, () =>
-        promptForAffectedFlags(command)
-      )
+    ...['apps', 'build', 'dep-graph', 'e2e', 'libs', 'lint', 'test'].map(
+      (command) =>
+        commands.registerCommand(`nx.affected.${command}`, () =>
+          promptForAffectedFlags(command)
+        )
     )
   );
 
@@ -64,15 +56,15 @@ async function promptForTarget(): Promise<string | undefined> {
 
   const validTargets = Array.from(
     new Set(
-      Object.entries<ProjectDef>(json.projects)
-        .map(([, project]) => Object.keys(project.architect || {}))
+      Object.entries(json.projects)
+        .map(([, project]) => Object.keys(project.targets || {}))
         .flat()
     )
   ).sort();
 
   if (!validTargets.length) {
     window.showErrorMessage(
-      'None of your workspace projects have an architect command'
+      'None of your workspace projects have an architect or targets command'
     );
     return;
   }
@@ -348,8 +340,8 @@ function validProjectsForTarget(target: string): string[] | undefined {
 
   return Array.from(
     new Set(
-      Object.entries<ProjectDef>(json.projects)
-        .filter(([, project]) => project.architect && project.architect[target])
+      Object.entries(json.projects)
+        .filter(([, project]) => project.targets && project.targets[target])
         .map(([project]) => project)
     )
   ).sort();

--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -3,7 +3,7 @@ import {
   getOutputChannel,
   getTelemetry,
   readAndCacheJsonFile,
-  readArchitectDef,
+  readTargetDef,
   selectSchematic,
 } from '@nx-console/server';
 import { verifyWorkspace } from '@nx-console/vscode/nx-workspace';
@@ -52,9 +52,9 @@ export async function getTaskExecutionSchema(
         }
         return {
           // TODO: Verify architect package is in node_modules
-          ...readArchitectDef(
+          ...readTargetDef(
             command,
-            selectedProject.architectDef,
+            selectedProject.targetDef,
             selectedProject.projectName
           ),
           options,
@@ -66,24 +66,22 @@ export async function getTaskExecutionSchema(
       case 'Run': {
         const runnableItems = cliTaskProvider
           .getProjectEntries()
-          .filter(([, { architect }]) => Boolean(architect))
-          .flatMap(([project, { architect }]) => ({ project, architect }))
-          .flatMap(({ project, architect }) => [
-            ...Object.entries(architect || {}).map(
-              ([architectName, architectDef]) => ({
-                project,
-                architectName,
-                architectDef,
-              })
-            ),
+          .filter(([, { targets }]) => Boolean(targets))
+          .flatMap(([project, { targets }]) => ({ project, targets }))
+          .flatMap(({ project, targets }) => [
+            ...Object.entries(targets || {}).map(([targetName, targetDef]) => ({
+              project,
+              targetName,
+              targetDef,
+            })),
           ])
           .map(
-            ({ project, architectName, architectDef }) =>
+            ({ project, targetName, targetDef }) =>
               new CliTaskQuickPickItem(
                 project,
-                architectDef,
-                architectName,
-                `${project}:${architectName}`
+                targetDef,
+                targetName,
+                `${project}:${targetName}`
               )
           );
 
@@ -102,9 +100,9 @@ export async function getTaskExecutionSchema(
           }
 
           return {
-            ...readArchitectDef(
+            ...readTargetDef(
               selection.command,
-              selection.architectDef,
+              selection.targetDef,
               selection.projectName
             ),
             command: 'run',

--- a/workspace.json
+++ b/workspace.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "defaultProject": "vscode-ui",
   "cli": {
     "warnings": {
@@ -9,7 +9,7 @@
     "packageManager": "yarn",
     "defaultCollection": "@nrwl/angular"
   },
-  "schematics": {
+  "generators": {
     "@nrwl/schematics:component": {
       "styleext": "scss"
     },
@@ -40,15 +40,15 @@
       "root": "libs/schema",
       "sourceRoot": "libs/schema/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/schema/**/*.ts"]
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/schema",
@@ -64,9 +64,9 @@
       "root": "libs/server",
       "sourceRoot": "libs/server/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "libs/server/jest.config.js",
             "passWithNoTests": true
@@ -74,7 +74,7 @@
           "outputs": ["coverage/libs/server"]
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/server",
@@ -91,10 +91,10 @@
       "sourceRoot": "apps/vscode/src",
       "projectType": "application",
       "prefix": "vscode",
-      "schematics": {},
-      "architect": {
+      "generators": {},
+      "targets": {
         "build": {
-          "builder": "@nrwl/node:build",
+          "executor": "@nrwl/node:build",
           "options": {
             "externalDependencies": ["vscode", "tslint"],
             "webpackConfig": "apps/vscode/webpack.config.js",
@@ -135,7 +135,7 @@
           "outputs": ["{options.outputPath}"]
         },
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["apps/vscode/**/*.ts"]
           }
@@ -146,15 +146,15 @@
       "root": "libs/vscode/configuration",
       "sourceRoot": "libs/vscode/configuration/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/configuration/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/configuration"],
           "options": {
             "jestConfig": "libs/vscode/configuration/jest.config.js",
@@ -162,7 +162,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/configuration",
@@ -178,15 +178,15 @@
       "root": "libs/vscode/json-schema",
       "sourceRoot": "libs/vscode/json-schema/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/json-schema/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/json-schema"],
           "options": {
             "jestConfig": "libs/vscode/json-schema/jest.config.js",
@@ -194,7 +194,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/json-schema",
@@ -210,15 +210,15 @@
       "root": "libs/vscode/nx-commands-view",
       "sourceRoot": "libs/vscode/nx-commands-view/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/nx-commands-view/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/nx-commands-view"],
           "options": {
             "jestConfig": "libs/vscode/nx-commands-view/jest.config.js",
@@ -226,7 +226,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/nx-commands-view",
@@ -242,15 +242,15 @@
       "root": "libs/vscode/nx-project-view",
       "sourceRoot": "libs/vscode/nx-project-view/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/nx-project-view/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/nx-project-view"],
           "options": {
             "jestConfig": "libs/vscode/nx-project-view/jest.config.js",
@@ -258,7 +258,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/nx-project-view",
@@ -274,15 +274,15 @@
       "root": "libs/vscode/nx-run-target-view",
       "sourceRoot": "libs/vscode/nx-run-target-view/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/nx-run-target-view/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/nx-run-target-view"],
           "options": {
             "jestConfig": "libs/vscode/nx-run-target-view/jest.config.js",
@@ -290,7 +290,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/nx-run-target-view",
@@ -306,15 +306,15 @@
       "root": "libs/vscode/nx-workspace",
       "sourceRoot": "libs/vscode/nx-workspace/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/nx-workspace/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/nx-workspace"],
           "options": {
             "jestConfig": "libs/vscode/nx-workspace/jest.config.js",
@@ -322,7 +322,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/nx-workspace",
@@ -338,15 +338,15 @@
       "root": "libs/vscode/tasks",
       "sourceRoot": "libs/vscode/tasks/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/tasks/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/tasks"],
           "options": {
             "jestConfig": "libs/vscode/tasks/jest.config.js",
@@ -354,7 +354,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/tasks",
@@ -368,16 +368,16 @@
     },
     "vscode-ui": {
       "projectType": "application",
-      "schematics": {
+      "generators": {
         "@nrwl/workspace:component": {
           "style": "scss"
         }
       },
       "root": "apps/vscode-ui",
       "sourceRoot": "apps/vscode-ui/src",
-      "architect": {
+      "targets": {
         "build": {
-          "builder": "ngx-build-plus:browser",
+          "executor": "ngx-build-plus:browser",
           "options": {
             "extraWebpackConfig": "apps/vscode-ui/webpack.dev.js",
             "outputPath": "dist/apps/vscode/assets/public",
@@ -414,7 +414,7 @@
           "outputs": ["{options.outputPath}"]
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "executor": "@angular-devkit/build-angular:dev-server",
           "options": {
             "browserTarget": "vscode-ui:build"
           },
@@ -425,13 +425,13 @@
           }
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "executor": "@angular-devkit/build-angular:extract-i18n",
           "options": {
             "browserTarget": "vscode-ui:build"
           }
         },
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": [
               "apps/vscode-ui/src/**/*.ts",
@@ -440,7 +440,7 @@
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "apps/vscode-ui/jest.config.js",
             "passWithNoTests": true
@@ -454,9 +454,9 @@
       "root": "libs/vscode-ui/argument-list",
       "sourceRoot": "libs/vscode-ui/argument-list/src",
       "prefix": "nx-console",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": [
               "libs/vscode-ui/argument-list/src/**/*.ts",
@@ -465,7 +465,7 @@
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode-ui/argument-list"],
           "options": {
             "jestConfig": "libs/vscode-ui/argument-list/jest.config.js",
@@ -478,9 +478,9 @@
       "projectType": "library",
       "root": "libs/vscode-ui/components",
       "sourceRoot": "libs/vscode-ui/components/src",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": [
               "libs/vscode-ui/components/src/**/*.ts",
@@ -489,7 +489,7 @@
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "libs/vscode-ui/components/jest.config.js",
             "passWithNoTests": true
@@ -502,9 +502,9 @@
       "projectType": "library",
       "root": "libs/vscode-ui/feature-task-execution-form",
       "sourceRoot": "libs/vscode-ui/feature-task-execution-form/src",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": [
               "libs/vscode-ui/feature-task-execution-form/src/**/*.ts",
@@ -513,7 +513,7 @@
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "options": {
             "jestConfig": "libs/vscode-ui/feature-task-execution-form/jest.config.js",
             "passWithNoTests": true
@@ -521,7 +521,7 @@
           "outputs": ["coverage/libs/vscode-ui/feature-task-execution-form"]
         },
         "storybook": {
-          "builder": "@nrwl/storybook:storybook",
+          "executor": "@nrwl/storybook:storybook",
           "options": {
             "uiFramework": "@storybook/angular",
             "port": 4400,
@@ -536,7 +536,7 @@
           }
         },
         "build-storybook": {
-          "builder": "@nrwl/storybook:build",
+          "executor": "@nrwl/storybook:build",
           "options": {
             "uiFramework": "@storybook/angular",
             "outputPath": "dist/storybook/vscode-ui-feature-task-execution-form",
@@ -552,15 +552,15 @@
           "outputs": ["{options.outputPath}"]
         }
       },
-      "schematics": {}
+      "generators": {}
     },
     "vscode-ui-feature-task-execution-form-e2e": {
       "root": "apps/vscode-ui-feature-task-execution-form-e2e",
       "sourceRoot": "apps/vscode-ui-feature-task-execution-form-e2e/src",
       "projectType": "application",
-      "architect": {
+      "targets": {
         "e2e": {
-          "builder": "@nrwl/cypress:cypress",
+          "executor": "@nrwl/cypress:cypress",
           "options": {
             "cypressConfig": "apps/vscode-ui-feature-task-execution-form-e2e/cypress.json",
             "tsConfig": "apps/vscode-ui-feature-task-execution-form-e2e/tsconfig.e2e.json",
@@ -573,7 +573,7 @@
           }
         },
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": [
               "apps/vscode-ui-feature-task-execution-form-e2e/src/**/*.ts",
@@ -587,22 +587,22 @@
       "projectType": "library",
       "root": "libs/vscode-ui/styles",
       "sourceRoot": "libs/vscode-ui/styles/src",
-      "architect": {},
-      "schematics": {}
+      "targets": {},
+      "generators": {}
     },
     "vscode-verify": {
       "root": "libs/vscode/verify",
       "sourceRoot": "libs/vscode/verify/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/verify/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/verify"],
           "options": {
             "jestConfig": "libs/vscode/verify/jest.config.js",
@@ -610,7 +610,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/verify",
@@ -626,15 +626,15 @@
       "root": "libs/vscode/webview",
       "sourceRoot": "libs/vscode/webview/src",
       "projectType": "library",
-      "architect": {
+      "targets": {
         "lint": {
-          "builder": "@nrwl/linter:eslint",
+          "executor": "@nrwl/linter:eslint",
           "options": {
             "lintFilePatterns": ["libs/vscode/webview/**/*.ts"]
           }
         },
         "test": {
-          "builder": "@nrwl/jest:jest",
+          "executor": "@nrwl/jest:jest",
           "outputs": ["coverage/libs/vscode/webview"],
           "options": {
             "jestConfig": "libs/vscode/webview/jest.config.js",
@@ -642,7 +642,7 @@
           }
         },
         "build": {
-          "builder": "@nrwl/node:package",
+          "executor": "@nrwl/node:package",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/libs/vscode/webview",


### PR DESCRIPTION
## What it does
This changes all mentions of the older workspace names (architect, builders, etc) to the newer one (targets, executors, etc)
