### PR TITLE
feat: support nx.json extends property

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -49,22 +49,22 @@
         {
           "when": "!isNxWorkspace && isAngularWorkspace && config.nxConsole.enableGenerateFromContextMenu",
           "command": "ng.generate.ui.fileexplorer",
-          "group": "explorerContext"
+          "group": "2_workspace"
         },
         {
           "when": "!isNxWorkspace && isAngularWorkspace && config.nxConsole.enableGenerateFromContextMenu",
           "command": "ng.run.fileexplorer",
-          "group": "explorerContext"
+          "group": "2_workspace"
         },
         {
           "when": "isNxWorkspace && config.nxConsole.enableGenerateFromContextMenu",
           "command": "nx.generate.ui.fileexplorer",
-          "group": "explorerContext"
+          "group": "2_workspace"
         },
         {
           "when": "isNxWorkspace && config.nxConsole.enableGenerateFromContextMenu",
           "command": "nx.run.fileexplorer",
-          "group": "explorerContext"
+          "group": "2_workspace"
         }
       ],
       "view/title": [

--- a/libs/vscode/nx-workspace/src/index.ts
+++ b/libs/vscode/nx-workspace/src/index.ts
@@ -2,3 +2,5 @@ export * from './lib/find-workspace-json-target';
 export * from './lib/reveal-workspace-json';
 export * from './lib/workspace-codelens-provider';
 export * from './lib/verify-workspace';
+export * from './lib/get-nx-config';
+export * from './lib/get-nx-workspace-config';

--- a/libs/vscode/nx-workspace/src/lib/get-nx-config.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-config.ts
@@ -1,0 +1,21 @@
+import { cacheJson, readAndCacheJsonFile } from '@nx-console/server';
+import { NxJsonConfiguration } from '@nrwl/devkit';
+import { join } from 'path';
+import { getNxWorkspacePackageFileUtils } from './get-nx-workspace-package';
+
+export function getNxConfig(baseDir: string): NxJsonConfiguration {
+  try {
+    let cachedNxJson = cacheJson('nx.json', baseDir).json;
+
+    if (!cachedNxJson) {
+      const nxJson = (getNxWorkspacePackageFileUtils() as any).readNxJson(
+        join(baseDir, 'nx.json')
+      );
+
+      cachedNxJson = cacheJson('nx.json', baseDir, nxJson).json;
+    }
+    return cachedNxJson;
+  } catch (e) {
+    return readAndCacheJsonFile('nx.json', baseDir).json;
+  }
+}

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
@@ -1,0 +1,23 @@
+import { readAndCacheJsonFile, cacheJson } from '@nx-console/server';
+import { getNxWorkspacePackageFileUtils } from './get-nx-workspace-package';
+import type { WorkspaceJsonConfiguration } from '@nrwl/devkit';
+
+export function getNxWorkspaceConfig(
+  basedir: string,
+  workspaceJsonPath: string
+): WorkspaceJsonConfiguration {
+  // try and use the workspace version of nx
+  try {
+    let cachedWorkspaceJson = cacheJson(workspaceJsonPath).json;
+    if (!cachedWorkspaceJson) {
+      const workspace = getNxWorkspacePackageFileUtils().readWorkspaceConfig({
+        format: 'nx',
+        path: basedir,
+      } as any);
+      cachedWorkspaceJson = cacheJson(workspaceJsonPath, '', workspace).json;
+    }
+    return cachedWorkspaceJson;
+  } catch (e) {
+    return readAndCacheJsonFile(workspaceJsonPath).json;
+  }
+}

--- a/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
@@ -2,15 +2,13 @@ import {
   fileExistsSync,
   getOutputChannel,
   getTelemetry,
-  cacheJson,
-  readAndCacheJsonFile,
   toWorkspaceFormat,
 } from '@nx-console/server';
 import { window } from 'vscode';
 import { dirname, join } from 'path';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
-import { getNxWorkspacePackageFileUtils } from './get-nx-workspace-package';
-import { WorkspaceJsonConfiguration, NxJsonConfiguration } from '@nrwl/devkit';
+import { WorkspaceJsonConfiguration } from '@nrwl/devkit';
+import { getNxWorkspaceConfig } from './get-nx-workspace-config';
 
 export function verifyWorkspace(): {
   validWorkspaceJson: boolean;
@@ -27,24 +25,21 @@ export function verifyWorkspace(): {
 
   try {
     if (fileExistsSync(workspaceJsonPath)) {
-      readNxWorkspaceConfig(workspacePath, workspaceJsonPath);
       return {
         validWorkspaceJson: true,
+        // TODO(cammisuli): change all instances to use the new version - basically reverse this to the new format
         json: toWorkspaceFormat(
-          /**
-           * We would get the value from the `readWorkspaceConfig` call if that was successful.
-           * Otherwise, we manually read the workspace.json file
-           */
-          readAndCacheJsonFile(workspaceJsonPath).json
+          getNxWorkspaceConfig(workspacePath, angularJsonPath)
         ),
         workspaceType: 'nx',
         configurationFilePath: workspaceJsonPath,
       };
     } else if (fileExistsSync(angularJsonPath)) {
-      readNxWorkspaceConfig(workspacePath, angularJsonPath);
       return {
         validWorkspaceJson: true,
-        json: toWorkspaceFormat(readAndCacheJsonFile(angularJsonPath).json),
+        json: toWorkspaceFormat(
+          getNxWorkspaceConfig(workspacePath, angularJsonPath)
+        ),
         workspaceType: 'ng',
         configurationFilePath: angularJsonPath,
       };
@@ -77,53 +72,5 @@ export function verifyWorkspace(): {
       },
       configurationFilePath: '',
     };
-  }
-}
-
-export function readNxWorkspaceConfig(
-  basedir: string,
-  workspaceJsonPath: string
-) {
-  // try and use the workspace version of nx
-  try {
-    const cachedWorkspaceJson = cacheJson(workspaceJsonPath).json;
-    if (!cachedWorkspaceJson) {
-      const workspace = getNxWorkspacePackageFileUtils().readWorkspaceConfig({
-        format: 'nx',
-        path: basedir,
-      } as any);
-      cacheJson(workspaceJsonPath, '', workspace);
-    }
-  } catch (e) {
-    // noop - will use the old way
-  }
-}
-
-export function getNxConfig(baseDir: string): NxJsonConfiguration {
-  const nxConfig = readAndCacheJsonFile('nx.json', baseDir).json;
-
-  return {
-    ...readNxJsonExtends(nxConfig, baseDir),
-    ...nxConfig,
-  };
-}
-
-function readNxJsonExtends(nxJson: { extends?: string }, baseDir: string) {
-  if (nxJson.extends) {
-    let extendsPath = nxJson.extends;
-    try {
-      if (extendsPath.startsWith('.')) {
-        extendsPath = join(baseDir, extendsPath);
-      }
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      return readAndCacheJsonFile(require(extendsPath)).json;
-    } catch (e) {
-      getOutputChannel().appendLine(
-        `Unable to resolve nx.json extends. Error: ${e.message}`
-      );
-      return null;
-    }
-  } else {
-    return null;
   }
 }

--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -2,11 +2,10 @@ import { Option, TaskExecutionSchema } from '@nx-console/schema';
 import {
   getOutputChannel,
   getTelemetry,
-  readAndCacheJsonFile,
   readTargetDef,
   selectSchematic,
 } from '@nx-console/server';
-import { verifyWorkspace } from '@nx-console/vscode/nx-workspace';
+import { getNxConfig, verifyWorkspace } from '@nx-console/vscode/nx-workspace';
 import { verifyBuilderDefinition } from '@nx-console/vscode/verify';
 import { Uri, window } from 'vscode';
 import { WorkspaceRouteTitle } from '@nx-console/vscode/nx-run-target-view';
@@ -187,10 +186,9 @@ function getConfigValuesFromContextMenuUri(
       .replace(workspacePath, '')
       .replace(/\\/g, '/')
       .replace(/^\//, '');
-
-    const nxConfig = readAndCacheJsonFile('nx.json', workspacePath);
-    const appsDir = nxConfig.json.workspaceLayout?.appsDir ?? 'apps';
-    const libsDir = nxConfig.json.workspaceLayout?.libsDir ?? 'libs';
+    const nxConfig = getNxConfig(workspacePath);
+    const appsDir = nxConfig.workspaceLayout?.appsDir ?? 'apps';
+    const libsDir = nxConfig.workspaceLayout?.libsDir ?? 'libs';
     if (
       (appsDir && schematic.name === 'application') ||
       schematic.name === 'app'


### PR DESCRIPTION
## What it does
This pr introduces support to read the nx.json file with a util file from a local install of Nx. This allows us to use the newer features of nx.json (which is the extends proproperty)

- feat: add support for nx extends
- use nx package to read nxjson
