### PR TITLE
fix: remove loading item from projects view

### DIFF
--- a/libs/vscode/nx-project-view/src/lib/nx-project-tree-provider.ts
+++ b/libs/vscode/nx-project-view/src/lib/nx-project-tree-provider.ts
@@ -18,8 +18,6 @@ import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
  * Provides data for the "Projects" tree view
  */
 export class NxProjectTreeProvider extends AbstractTreeProvider<NxProjectTreeItem> {
-  loading = true;
-
   constructor(
     context: ExtensionContext,
     private readonly cliTaskProvider: CliTaskProvider
@@ -86,13 +84,6 @@ export class NxProjectTreeProvider extends AbstractTreeProvider<NxProjectTreeIte
   }
 
   getChildren(parent?: NxProjectTreeItem): ProviderResult<NxProjectTreeItem[]> {
-    if (this.loading) {
-      setTimeout(() => {
-        this.loading = false;
-        this.refresh();
-      });
-      return [this.createNxProjectTreeItem({ project: 'Loading' }, 'Loading')];
-    }
     if (!parent) {
       const projects = this.cliTaskProvider.getProjectEntries();
       return projects.map(


### PR DESCRIPTION
## What it does
This removes the loading item from the projects view. This was causing some issues with some users where items were trying to be used before all the projects were loaded.

Initially this was added in this extension as a way to show that projects were loading (duh :joy:) because the parser used originally was terribly slow, and the vscode ui froze. With the quicker parser, we don't freeze the UI anymore, and this loading item is not needed. 

Potentially fixes #1126