### PR TITLE
fix: use proper workspace json path when verifying workspaces

### DIFF
--- a/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
@@ -29,7 +29,7 @@ export function verifyWorkspace(): {
         validWorkspaceJson: true,
         // TODO(cammisuli): change all instances to use the new version - basically reverse this to the new format
         json: toWorkspaceFormat(
-          getNxWorkspaceConfig(workspacePath, angularJsonPath)
+          getNxWorkspaceConfig(workspacePath, workspaceJsonPath)
         ),
         workspaceType: 'nx',
         configurationFilePath: workspaceJsonPath,


### PR DESCRIPTION
## What it does
This ensures that we are using the correct workspace configuration when verifying the workspace. 
