### PR TITLE
feat: use vscode settings for shell execution

### DIFF
--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -1,5 +1,5 @@
 import { CliTaskDefinition } from './cli-task-definition';
-import { Task, TaskGroup, TaskScope } from 'vscode';
+import { ShellExecution, Task, TaskGroup, TaskScope } from 'vscode';
 import { getShellExecutionForConfig } from './shell-execution';
 import { findClosestNg, findClosestNx } from '@nx-console/server';
 import { join } from 'path';

--- a/libs/vscode/tasks/src/lib/shell-execution.ts
+++ b/libs/vscode/tasks/src/lib/shell-execution.ts
@@ -14,46 +14,8 @@ export interface ShellConfig {
 export function getShellExecutionForConfig(
   config: ShellConfig
 ): ShellExecution {
-  let execution: ShellExecution;
-  if (platform() === 'win32') {
-    execution = getWin32ShellExecution(config);
-  } else {
-    execution = getUnixShellExecution(config);
-  }
-
-  return execution;
-}
-
-function getWin32ShellExecution(config: ShellConfig): ShellExecution {
   return new ShellExecution(config.displayCommand, {
     cwd: config.cwd,
-    executable:
-      'C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
-    shellArgs: [
-      `-Sta -NoLogo -NonInteractive -C "& {${config.program.replace(
-        / /g,
-        '` ' // NOTE: In powershell ` is the escape key.
-      )} ${config.args.join(' ')}}"`,
-    ],
-  });
-}
-
-let bashPath: string;
-function getUnixShellExecution(config: ShellConfig): ShellExecution {
-  if (!bashPath) {
-    try {
-      bashPath = execSync('which bash').toString().trim() || '/bin/bash';
-    } catch {
-      bashPath = '/bin/bash'; // Default to where bash is usually installed.
-    }
-  }
-  return new ShellExecution(config.displayCommand, {
-    cwd: config.cwd,
-    executable: bashPath,
-    shellArgs: [
-      '-l',
-      '-c',
-      `${config.program.replace(/ /g, '\\ ')} ${config.args.join(' ')}`,
-    ],
+    shellArgs: [config.program, ...config.args],
   });
 }


### PR DESCRIPTION
## What it does
This simplies creating the `ShellExecution` class to use defaults provided by vscode. 

More information can be found here:
https://code.visualstudio.com/docs/editor/integrated-terminal#_configuring-the-taskdebug-profile

In summary, Nx Console will now use the default terminal profile, OR the profile provided by the `terminal.integrated.automationShell.<platform>` setting` 
