### PR TITLE
chore: missing `lint` command

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -74,5 +74,8 @@ module.exports = {
     'install-dependencies': {
       vscode: `node ${join('tools', 'scripts', 'vscode-yarn.js')}`,
     },
+    lint: {
+      default: "nx run-many --all --parallel --target=lint"
+    }
   },
 };


### PR DESCRIPTION
Adding `lint` back to scripts definition, in order to support
`nps lint` command from CONTRIBUTING doc

fixes:
```bash
$ nps lint
Scripts must resolve to strings. There is no script that can be resolved from "lint"
```
Thanks!