### PR TITLE
style: migrate division syntax

### DIFF
--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.scss
@@ -40,7 +40,7 @@ $offset-with-configurations: $offset-without-configurations +
 .scroll-container,
 vscode-ui-field-tree {
   box-sizing: border-box;
-  padding-top: $host-padding-top / 2;
+  padding-top: $host-padding-top * 0.5;
   min-height: calc(100vh - #{$offset-without-configurations});
   max-height: calc(100vh - #{$offset-without-configurations});
 


### PR DESCRIPTION
Minor fix, removes warnings. Instead of using `math.div`, uses multiplier.
https://sass-lang.com/documentation/breaking-changes/slash-div

Thanks!