### PR TITLE
fix: ensure that projects are properly resolved during async calls

### DIFF
--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
@@ -9,7 +9,7 @@ export async function getNxWorkspaceConfig(
   // try and use the workspace version of nx
   try {
     let cachedWorkspaceJson = cacheJson(workspaceJsonPath).json;
-    if (!cachedWorkspaceJson) {
+    if (!cachedWorkspaceJson || hasNxProject(cachedWorkspaceJson)) {
       const workspace = (
         await getNxWorkspacePackageFileUtils()
       ).readWorkspaceConfig({
@@ -22,4 +22,19 @@ export async function getNxWorkspaceConfig(
   } catch (e) {
     return readAndCacheJsonFile(workspaceJsonPath).json;
   }
+}
+
+/**
+ * There are points in time where the async nature of the nx-workspace package is still in being resolved.
+ * This function will check if the projects are strings
+ * @param cachedWorkspaceJson
+ * @returns
+ */
+function hasNxProject(
+  cachedWorkspaceJson?: WorkspaceJsonConfiguration
+): boolean {
+  const projects = cachedWorkspaceJson?.projects ?? {};
+  return Object.entries(projects).some(
+    ([, project]) => typeof project === 'string'
+  );
 }

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
@@ -14,7 +14,7 @@ export async function getNxWorkspacePackageFileUtils(): Promise<
   );
 
   try {
-    return import(
+    const workspaceImport = import(
       /*webpackIgnore: true*/
       join(
         workspacePath,
@@ -23,9 +23,10 @@ export async function getNxWorkspacePackageFileUtils(): Promise<
         'workspace',
         'src',
         'core',
-        'file-utils'
+        'file-utils.js'
       )
     );
+    return workspaceImport;
   } catch (err) {
     getOutputChannel().appendLine(
       `Error loading @nrwl/workspace from workspace. Falling back to extension dependency`


### PR DESCRIPTION
## What it does
Ensure that workspace projects are properly resolved to the full configuration. The async nature of calling the workspace utils will cause the cache to be invalid

Fixes #1144