### PR TITLE
chore: updated husky and prettier tooling and configured pre-push hook like in nrwl/nx

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn pretty-quick --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,211 +4,182 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [17.11.2](https://github.com/nrwl/nx-console/compare/v17.11.1...v17.11.2) (2021-09-27)
 
-
 ### Bug Fixes
 
-* use proper file schema for importing on windows ([#1149](https://github.com/nrwl/nx-console/issues/1149)) ([0470a33](https://github.com/nrwl/nx-console/commits/0470a33f7c69e24d4327616593497d08ca76373d))
+- use proper file schema for importing on windows ([#1149](https://github.com/nrwl/nx-console/issues/1149)) ([0470a33](https://github.com/nrwl/nx-console/commits/0470a33f7c69e24d4327616593497d08ca76373d))
 
 ### [17.11.1](https://github.com/nrwl/nx-console/compare/v17.11.0...v17.11.1) (2021-09-27)
 
-
 ### Bug Fixes
 
-* ensure that projects are properly resolved during async calls ([#1145](https://github.com/nrwl/nx-console/issues/1145)) ([35c40b5](https://github.com/nrwl/nx-console/commits/35c40b50a316c7ce905316af36e789cdf03d7cd1))
+- ensure that projects are properly resolved during async calls ([#1145](https://github.com/nrwl/nx-console/issues/1145)) ([35c40b5](https://github.com/nrwl/nx-console/commits/35c40b50a316c7ce905316af36e789cdf03d7cd1))
 
 ## [17.11.0](https://github.com/nrwl/nx-console/compare/v17.10.0...v17.11.0) (2021-09-24)
 
-
 ### Features
 
-* sort projects in project view ([#1137](https://github.com/nrwl/nx-console/issues/1137)) ([7cc9ebe](https://github.com/nrwl/nx-console/commits/7cc9ebe257999d39cea9cffee0d925e6a693d83a))
-* use vscode settings for shell execution ([#1134](https://github.com/nrwl/nx-console/issues/1134)) ([fc4caea](https://github.com/nrwl/nx-console/commits/fc4caeaf3c17c95f1f305d13f6dd062acff5f47c))
-
+- sort projects in project view ([#1137](https://github.com/nrwl/nx-console/issues/1137)) ([7cc9ebe](https://github.com/nrwl/nx-console/commits/7cc9ebe257999d39cea9cffee0d925e6a693d83a))
+- use vscode settings for shell execution ([#1134](https://github.com/nrwl/nx-console/issues/1134)) ([fc4caea](https://github.com/nrwl/nx-console/commits/fc4caeaf3c17c95f1f305d13f6dd062acff5f47c))
 
 ### Performance Improvements
 
-* decrease activation time ([#1131](https://github.com/nrwl/nx-console/issues/1131)) ([6a23cea](https://github.com/nrwl/nx-console/commits/6a23ceaff7c4211e36c591892a8510a067f07d4f))
+- decrease activation time ([#1131](https://github.com/nrwl/nx-console/issues/1131)) ([6a23cea](https://github.com/nrwl/nx-console/commits/6a23ceaff7c4211e36c591892a8510a067f07d4f))
 
 ## [17.10.0](https://github.com/nrwl/nx-console/compare/v17.9.0...v17.10.0) (2021-09-03)
 
-
 ### Features
 
-* Add commands to add applications and libraries directly ([#1128](https://github.com/nrwl/nx-console/issues/1128)) ([b908c11](https://github.com/nrwl/nx-console/commits/b908c11aa3b2de1fd35ec52ba243803d2cdaeb34))
-
+- Add commands to add applications and libraries directly ([#1128](https://github.com/nrwl/nx-console/issues/1128)) ([b908c11](https://github.com/nrwl/nx-console/commits/b908c11aa3b2de1fd35ec52ba243803d2cdaeb34))
 
 ### Bug Fixes
 
-* remove loading item from projects view ([#1129](https://github.com/nrwl/nx-console/issues/1129)) ([7ad5f60](https://github.com/nrwl/nx-console/commits/7ad5f60cdba5a0f766592aed5b718ba82c3e0881))
-* use proper workspace json path when verifying workspaces ([#1130](https://github.com/nrwl/nx-console/issues/1130)) ([f2365be](https://github.com/nrwl/nx-console/commits/f2365bed33a10e6734fe96e35df01552763905a1))
+- remove loading item from projects view ([#1129](https://github.com/nrwl/nx-console/issues/1129)) ([7ad5f60](https://github.com/nrwl/nx-console/commits/7ad5f60cdba5a0f766592aed5b718ba82c3e0881))
+- use proper workspace json path when verifying workspaces ([#1130](https://github.com/nrwl/nx-console/issues/1130)) ([f2365be](https://github.com/nrwl/nx-console/commits/f2365bed33a10e6734fe96e35df01552763905a1))
 
 ## [17.9.0](https://github.com/nrwl/nx-console/compare/v17.8.0...v17.9.0) (2021-08-27)
 
-
 ### Features
 
-* support nx.json extends property ([#1124](https://github.com/nrwl/nx-console/issues/1124)) ([507ce24](https://github.com/nrwl/nx-console/commits/507ce24ce3085b933c9da1aa92b35d0c34b0b0c2))
-
+- support nx.json extends property ([#1124](https://github.com/nrwl/nx-console/issues/1124)) ([507ce24](https://github.com/nrwl/nx-console/commits/507ce24ce3085b933c9da1aa92b35d0c34b0b0c2))
 
 ### Performance Improvements
 
-* add onview activation event ([7ac82c0](https://github.com/nrwl/nx-console/commits/7ac82c0106877c01167cc1a20bb740c6feec7c5f))
-* use `onStartupFinished` and target es2020 ([0cef34a](https://github.com/nrwl/nx-console/commits/0cef34aab5d57796f69c5e1a0ddfd4ab9bb74265))
+- add onview activation event ([7ac82c0](https://github.com/nrwl/nx-console/commits/7ac82c0106877c01167cc1a20bb740c6feec7c5f))
+- use `onStartupFinished` and target es2020 ([0cef34a](https://github.com/nrwl/nx-console/commits/0cef34aab5d57796f69c5e1a0ddfd4ab9bb74265))
 
 ## [17.8.0](https://github.com/nrwl/nx-console/compare/v17.7.0...v17.8.0) (2021-08-06)
 
-
 ### Features
 
-* welcome view and getting started walkthrough ([#1069](https://github.com/nrwl/nx-console/issues/1069)) ([7281905](https://github.com/nrwl/nx-console/commits/7281905c7c4625426c291dd6618fb9043cf829f0))
-
+- welcome view and getting started walkthrough ([#1069](https://github.com/nrwl/nx-console/issues/1069)) ([7281905](https://github.com/nrwl/nx-console/commits/7281905c7c4625426c291dd6618fb9043cf829f0))
 
 ### Bug Fixes
 
-* configurations tabs overflow ([#1118](https://github.com/nrwl/nx-console/issues/1118)) ([2c8bd85](https://github.com/nrwl/nx-console/commits/2c8bd85487e03c75aa8afc377eff909ee1c39032))
-* menu scroll hides Run and Search bar header ([#1117](https://github.com/nrwl/nx-console/issues/1117)) ([1f1f888](https://github.com/nrwl/nx-console/commits/1f1f8889650fe2eddfc756888a56eadacbff5279))
+- configurations tabs overflow ([#1118](https://github.com/nrwl/nx-console/issues/1118)) ([2c8bd85](https://github.com/nrwl/nx-console/commits/2c8bd85487e03c75aa8afc377eff909ee1c39032))
+- menu scroll hides Run and Search bar header ([#1117](https://github.com/nrwl/nx-console/issues/1117)) ([1f1f888](https://github.com/nrwl/nx-console/commits/1f1f8889650fe2eddfc756888a56eadacbff5279))
 
 ## [17.7.0](https://github.com/nrwl/nx-console/compare/v17.6.1...v17.7.0) (2021-07-30)
 
-
 ### Features
 
-* support dep-graph watch option ([#1106](https://github.com/nrwl/nx-console/issues/1106)) ([5e78c4d](https://github.com/nrwl/nx-console/commits/5e78c4d3f98c6c567cc5584d39cd54562f102135))
-
+- support dep-graph watch option ([#1106](https://github.com/nrwl/nx-console/issues/1106)) ([5e78c4d](https://github.com/nrwl/nx-console/commits/5e78c4d3f98c6c567cc5584d39cd54562f102135))
 
 ### Bug Fixes
 
-* add min-height to scroll container so at least 100vh ([#1110](https://github.com/nrwl/nx-console/issues/1110)) ([2ce72a8](https://github.com/nrwl/nx-console/commits/2ce72a811765e8866091ed45b8f2a67a137a0731))
-* ensure project path is not just a partial match ([#1108](https://github.com/nrwl/nx-console/issues/1108)) ([7e7705a](https://github.com/nrwl/nx-console/commits/7e7705a17307405af61f81fc70566df7d50aec70))
-* include path with project but not directory ([#1112](https://github.com/nrwl/nx-console/issues/1112)) ([6cb987d](https://github.com/nrwl/nx-console/commits/6cb987da18bb4bf4a3953fc3937a6d2d405d583d))
-* json schema update for $id ([#1107](https://github.com/nrwl/nx-console/issues/1107)) ([d97db50](https://github.com/nrwl/nx-console/commits/d97db50e2e3efc35e9bc77845dc9742b44b6b30c))
-* load workspace file utils directly ([#1113](https://github.com/nrwl/nx-console/issues/1113)) ([a351990](https://github.com/nrwl/nx-console/commits/a35199082992b4bfc081abde169092d51e3924a1))
-* support angular.json (v2) having split project.json files ([#1105](https://github.com/nrwl/nx-console/issues/1105)) ([22b685c](https://github.com/nrwl/nx-console/commits/22b685c5c931b1efc60b0f97aa46fe42d052c078))
+- add min-height to scroll container so at least 100vh ([#1110](https://github.com/nrwl/nx-console/issues/1110)) ([2ce72a8](https://github.com/nrwl/nx-console/commits/2ce72a811765e8866091ed45b8f2a67a137a0731))
+- ensure project path is not just a partial match ([#1108](https://github.com/nrwl/nx-console/issues/1108)) ([7e7705a](https://github.com/nrwl/nx-console/commits/7e7705a17307405af61f81fc70566df7d50aec70))
+- include path with project but not directory ([#1112](https://github.com/nrwl/nx-console/issues/1112)) ([6cb987d](https://github.com/nrwl/nx-console/commits/6cb987da18bb4bf4a3953fc3937a6d2d405d583d))
+- json schema update for $id ([#1107](https://github.com/nrwl/nx-console/issues/1107)) ([d97db50](https://github.com/nrwl/nx-console/commits/d97db50e2e3efc35e9bc77845dc9742b44b6b30c))
+- load workspace file utils directly ([#1113](https://github.com/nrwl/nx-console/issues/1113)) ([a351990](https://github.com/nrwl/nx-console/commits/a35199082992b4bfc081abde169092d51e3924a1))
+- support angular.json (v2) having split project.json files ([#1105](https://github.com/nrwl/nx-console/issues/1105)) ([22b685c](https://github.com/nrwl/nx-console/commits/22b685c5c931b1efc60b0f97aa46fe42d052c078))
 
 ### [17.6.1](https://github.com/nrwl/nx-console/compare/v17.6.0...v17.6.1) (2021-06-28)
 
-
 ### Bug Fixes
 
-* read and combine both schematics and generators ([#1103](https://github.com/nrwl/nx-console/issues/1103)) ([b275bdc](https://github.com/nrwl/nx-console/commits/b275bdcefb19319d61d0f9e611d9367391103f5c))
+- read and combine both schematics and generators ([#1103](https://github.com/nrwl/nx-console/issues/1103)) ([b275bdc](https://github.com/nrwl/nx-console/commits/b275bdcefb19319d61d0f9e611d9367391103f5c))
 
 ## [17.6.0](https://github.com/nrwl/nx-console/compare/v17.5.2...v17.6.0) (2021-06-25)
 
-
 ### Features
 
-* support for project.json schema ([#1101](https://github.com/nrwl/nx-console/issues/1101)) ([6341a77](https://github.com/nrwl/nx-console/commits/6341a775a0fa342d52b4ff8c5458d7a01e37ca9d))
-* support split nx projects ([#1102](https://github.com/nrwl/nx-console/issues/1102)) ([2f58b00](https://github.com/nrwl/nx-console/commits/2f58b0028c8e0b1bb685618fd1a61644da4cffc9))
+- support for project.json schema ([#1101](https://github.com/nrwl/nx-console/issues/1101)) ([6341a77](https://github.com/nrwl/nx-console/commits/6341a775a0fa342d52b4ff8c5458d7a01e37ca9d))
+- support split nx projects ([#1102](https://github.com/nrwl/nx-console/issues/1102)) ([2f58b00](https://github.com/nrwl/nx-console/commits/2f58b0028c8e0b1bb685618fd1a61644da4cffc9))
 
 ### [17.5.2](https://github.com/nrwl/nx-console/compare/v17.5.1...v17.5.2) (2021-06-22)
 
-
 ### Bug Fixes
 
-* read package.json dependencies when getting builders/executors ([#1100](https://github.com/nrwl/nx-console/issues/1100)) ([187f1f2](https://github.com/nrwl/nx-console/commits/187f1f2f4b6c9bdd3f2026516289fbfb7c75535d))
+- read package.json dependencies when getting builders/executors ([#1100](https://github.com/nrwl/nx-console/issues/1100)) ([187f1f2](https://github.com/nrwl/nx-console/commits/187f1f2f4b6c9bdd3f2026516289fbfb7c75535d))
 
 ### [17.5.1](https://github.com/nrwl/nx-console/compare/v17.5.0...v17.5.1) (2021-06-16)
 
-
 ### Bug Fixes
 
-* use proper file paths for schemas within windows ([#1085](https://github.com/nrwl/nx-console/issues/1085)) ([ed9d0c7](https://github.com/nrwl/nx-console/commits/ed9d0c7dd259c86bc9310417577098f97ae25b5f))
+- use proper file paths for schemas within windows ([#1085](https://github.com/nrwl/nx-console/issues/1085)) ([ed9d0c7](https://github.com/nrwl/nx-console/commits/ed9d0c7dd259c86bc9310417577098f97ae25b5f))
 
 ## [17.5.0](https://github.com/nrwl/nx-console/compare/v17.4.1...v17.5.0) (2021-06-14)
 
-
 ### Features
 
-* add json schema support for configurations, and also provide descriptions ([#1078](https://github.com/nrwl/nx-console/issues/1078)) ([e9e1d15](https://github.com/nrwl/nx-console/commits/e9e1d15f6773e811d1de3ef0e6036cd68f2faf1b))
-* provide json schema for workspace.json ([#1077](https://github.com/nrwl/nx-console/issues/1077)) ([ae35ec5](https://github.com/nrwl/nx-console/commits/ae35ec5dd85a38ce44de2797911dffe7806e2a3b))
-
+- add json schema support for configurations, and also provide descriptions ([#1078](https://github.com/nrwl/nx-console/issues/1078)) ([e9e1d15](https://github.com/nrwl/nx-console/commits/e9e1d15f6773e811d1de3ef0e6036cd68f2faf1b))
+- provide json schema for workspace.json ([#1077](https://github.com/nrwl/nx-console/issues/1077)) ([ae35ec5](https://github.com/nrwl/nx-console/commits/ae35ec5dd85a38ce44de2797911dffe7806e2a3b))
 
 ### Bug Fixes
 
-* nx generator schemas form ([#1081](https://github.com/nrwl/nx-console/issues/1081)) ([c43f9cc](https://github.com/nrwl/nx-console/commits/c43f9cc0fbfacb43a6fe170aa9faaedd88dbf046))
-* strip appsDir and libsDir from path if app|application or lib|library ([#1082](https://github.com/nrwl/nx-console/issues/1082)) ([7db8b08](https://github.com/nrwl/nx-console/commits/7db8b084e2842cd39b17e393066cb0377c0944d9))
+- nx generator schemas form ([#1081](https://github.com/nrwl/nx-console/issues/1081)) ([c43f9cc](https://github.com/nrwl/nx-console/commits/c43f9cc0fbfacb43a6fe170aa9faaedd88dbf046))
+- strip appsDir and libsDir from path if app|application or lib|library ([#1082](https://github.com/nrwl/nx-console/issues/1082)) ([7db8b08](https://github.com/nrwl/nx-console/commits/7db8b084e2842cd39b17e393066cb0377c0944d9))
 
 ### [17.4.1](https://github.com/nrwl/nx-console/compare/v17.4.0...v17.4.1) (2021-05-28)
 
-
 ### Bug Fixes
 
-* don't show ng menus for nx workspaces ([#1076](https://github.com/nrwl/nx-console/issues/1076)) ([152fc20](https://github.com/nrwl/nx-console/commits/152fc20430444c6d65a4e1ce6fc3e465d582aaa4))
+- don't show ng menus for nx workspaces ([#1076](https://github.com/nrwl/nx-console/issues/1076)) ([152fc20](https://github.com/nrwl/nx-console/commits/152fc20430444c6d65a4e1ce6fc3e465d582aaa4))
 
 ## [17.4.0](https://github.com/nrwl/nx-console/compare/v17.3.1...v17.4.0) (2021-05-28)
 
-
 ### Features
 
-* workspace codelens ([#1075](https://github.com/nrwl/nx-console/issues/1075)) ([3e18e99](https://github.com/nrwl/nx-console/commits/3e18e994f489708e86c4dacd8a618322390da728))
-
+- workspace codelens ([#1075](https://github.com/nrwl/nx-console/issues/1075)) ([3e18e99](https://github.com/nrwl/nx-console/commits/3e18e994f489708e86c4dacd8a618322390da728))
 
 ### Bug Fixes
 
-* only reads and normalizes selected schematic options ([#1074](https://github.com/nrwl/nx-console/issues/1074)) ([d2c4bd4](https://github.com/nrwl/nx-console/commits/d2c4bd42d290d934920c445cac6481abd28e09fc))
+- only reads and normalizes selected schematic options ([#1074](https://github.com/nrwl/nx-console/issues/1074)) ([d2c4bd4](https://github.com/nrwl/nx-console/commits/d2c4bd42d290d934920c445cac6481abd28e09fc))
 
 ### [17.3.1](https://github.com/nrwl/nx-console/compare/v17.3.0...v17.3.1) (2021-05-14)
 
-
 ### Features
 
-* load workspace defaults into Run executor form ([#1068](https://github.com/nrwl/nx-console/issues/1068)) ([3bb13fe](https://github.com/nrwl/nx-console/commits/3bb13fe299d39a4c4c4cdf698c3b0e9bd9732562))
-
+- load workspace defaults into Run executor form ([#1068](https://github.com/nrwl/nx-console/issues/1068)) ([3bb13fe](https://github.com/nrwl/nx-console/commits/3bb13fe299d39a4c4c4cdf698c3b0e9bd9732562))
 
 ### Bug Fixes
 
-* add positional to taskDefinitions, fixes task already active ([#1071](https://github.com/nrwl/nx-console/issues/1071)) ([a1afd23](https://github.com/nrwl/nx-console/commits/a1afd23ef23c7bf6f40115661aa3d0800c639740))
+- add positional to taskDefinitions, fixes task already active ([#1071](https://github.com/nrwl/nx-console/issues/1071)) ([a1afd23](https://github.com/nrwl/nx-console/commits/a1afd23ef23c7bf6f40115661aa3d0800c639740))
 
 ## [17.3.0](https://github.com/nrwl/nx-console/compare/v17.2.0...v17.3.0) (2021-05-06)
 
-
 ### Features
 
-* nx run in command palette and context menu ([#1065](https://github.com/nrwl/nx-console/issues/1065)) ([9b5fd5c](https://github.com/nrwl/nx-console/commits/9b5fd5c39d3fde32bb996fe1e4180cdb19955f9c))
-* Populates form with workspace defaults for build, e2e, lint, serve, and test targets ([#1067](https://github.com/nrwl/nx-console/issues/1067)) ([fc68c64](https://github.com/nrwl/nx-console/commits/fc68c644767912c9f97be771dd4a059d994b3098))
-* run-many prompts for projects ([#1064](https://github.com/nrwl/nx-console/issues/1064)) ([977bdf2](https://github.com/nrwl/nx-console/commits/977bdf261316be44e421cfcf088d710693e71a2a))
-* shows argument list and highlights changed and invalid fields in menu ([#1059](https://github.com/nrwl/nx-console/issues/1059)) ([7d8e8e1](https://github.com/nrwl/nx-console/commits/7d8e8e1c91968792cd67d0564375b74c48af31f2))
-
+- nx run in command palette and context menu ([#1065](https://github.com/nrwl/nx-console/issues/1065)) ([9b5fd5c](https://github.com/nrwl/nx-console/commits/9b5fd5c39d3fde32bb996fe1e4180cdb19955f9c))
+- Populates form with workspace defaults for build, e2e, lint, serve, and test targets ([#1067](https://github.com/nrwl/nx-console/issues/1067)) ([fc68c64](https://github.com/nrwl/nx-console/commits/fc68c644767912c9f97be771dd4a059d994b3098))
+- run-many prompts for projects ([#1064](https://github.com/nrwl/nx-console/issues/1064)) ([977bdf2](https://github.com/nrwl/nx-console/commits/977bdf261316be44e421cfcf088d710693e71a2a))
+- shows argument list and highlights changed and invalid fields in menu ([#1059](https://github.com/nrwl/nx-console/issues/1059)) ([7d8e8e1](https://github.com/nrwl/nx-console/commits/7d8e8e1c91968792cd67d0564375b74c48af31f2))
 
 ### Bug Fixes
 
-* enable generate from context menu setting take effect immediately ([#1066](https://github.com/nrwl/nx-console/issues/1066)) ([c3f2b92](https://github.com/nrwl/nx-console/commits/c3f2b923b64d5f5b502c018d368f4c551f57e47a))
+- enable generate from context menu setting take effect immediately ([#1066](https://github.com/nrwl/nx-console/issues/1066)) ([c3f2b92](https://github.com/nrwl/nx-console/commits/c3f2b923b64d5f5b502c018d368f4c551f57e47a))
 
 ## [17.2.0](https://github.com/nrwl/nx-console/compare/v17.1.0...v17.2.0) (2021-04-16)
 
-
 ### Features
 
-* updates form components to support long form items plus specs  ([#1062](https://github.com/nrwl/nx-console/issues/1062)) ([0373a56](https://github.com/nrwl/nx-console/commits/0373a56df680764b6ed34850c8e5eebeae02ed8b)), closes [#984](https://github.com/nrwl/nx-console/issues/984)
-
+- updates form components to support long form items plus specs ([#1062](https://github.com/nrwl/nx-console/issues/1062)) ([0373a56](https://github.com/nrwl/nx-console/commits/0373a56df680764b6ed34850c8e5eebeae02ed8b)), closes [#984](https://github.com/nrwl/nx-console/issues/984)
 
 ### Bug Fixes
 
-* refresh projects view clears cache ([#1058](https://github.com/nrwl/nx-console/issues/1058)) ([4741999](https://github.com/nrwl/nx-console/commits/474199904a5982928343bbeb73bdd256658b4dda))
-* replace \ with / in path in workspace before remove leading / ([#1063](https://github.com/nrwl/nx-console/issues/1063)) ([a4f96ca](https://github.com/nrwl/nx-console/commits/a4f96ca7ba9da58c4d488043092ac110170a6a6f))
+- refresh projects view clears cache ([#1058](https://github.com/nrwl/nx-console/issues/1058)) ([4741999](https://github.com/nrwl/nx-console/commits/474199904a5982928343bbeb73bdd256658b4dda))
+- replace \ with / in path in workspace before remove leading / ([#1063](https://github.com/nrwl/nx-console/issues/1063)) ([a4f96ca](https://github.com/nrwl/nx-console/commits/a4f96ca7ba9da58c4d488043092ac110170a6a6f))
 
 ## [17.1.0](https://github.com/nrwl/nx-console/compare/v17.0.3...v17.1.0) (2021-03-27)
 
-
 ### Features
 
-* allow filtering in the nx project tree view ([#1050](https://github.com/nrwl/nx-console/issues/1050)) ([cfcc306](https://github.com/nrwl/nx-console/commits/cfcc3065b9149a977d1747b1322f8a94bf69d2d3))
-* light and dark mode icons ([#1046](https://github.com/nrwl/nx-console/issues/1046)) ([7613fa0](https://github.com/nrwl/nx-console/commits/7613fa05c44263f5c7dee24daf0b219f2e6db382))
-* load custom workspace path on extension load ([#1052](https://github.com/nrwl/nx-console/issues/1052)) ([51d5a7a](https://github.com/nrwl/nx-console/commits/51d5a7a4c87f992c551fe26c90936a0af7f9ee38))
-* only execute dry run if Generate form is valid ([#1053](https://github.com/nrwl/nx-console/issues/1053)) ([82d561b](https://github.com/nrwl/nx-console/commits/82d561b76f95702212eccf0fbd2871e5235ed3b0))
-
+- allow filtering in the nx project tree view ([#1050](https://github.com/nrwl/nx-console/issues/1050)) ([cfcc306](https://github.com/nrwl/nx-console/commits/cfcc3065b9149a977d1747b1322f8a94bf69d2d3))
+- light and dark mode icons ([#1046](https://github.com/nrwl/nx-console/issues/1046)) ([7613fa0](https://github.com/nrwl/nx-console/commits/7613fa05c44263f5c7dee24daf0b219f2e6db382))
+- load custom workspace path on extension load ([#1052](https://github.com/nrwl/nx-console/issues/1052)) ([51d5a7a](https://github.com/nrwl/nx-console/commits/51d5a7a4c87f992c551fe26c90936a0af7f9ee38))
+- only execute dry run if Generate form is valid ([#1053](https://github.com/nrwl/nx-console/issues/1053)) ([82d561b](https://github.com/nrwl/nx-console/commits/82d561b76f95702212eccf0fbd2871e5235ed3b0))
 
 ### Bug Fixes
 
-* remove leading / from path parsed out of the workspace path ([#1054](https://github.com/nrwl/nx-console/issues/1054)) ([2e6449b](https://github.com/nrwl/nx-console/commits/2e6449bc23d5a4c52a5bede26d5c41ab52c47817))
+- remove leading / from path parsed out of the workspace path ([#1054](https://github.com/nrwl/nx-console/issues/1054)) ([2e6449b](https://github.com/nrwl/nx-console/commits/2e6449bc23d5a4c52a5bede26d5c41ab52c47817))
 
 ## [17.0.3](https://github.com/nrwl/nx-console/compare/v17.0.0...v17.0.3) (2021-03-13)
 
 ### Bug Fixes
 
-* unit tests on vscode-ui libs ([#1035](https://github.com/nrwl/nx-console/issues/1035)) ([715b6e3](https://github.com/nrwl/nx-console/commits/715b6e39c3a538d9962e0eef9ac0b6bb5bfa0ede))
-* support directory as path alias from context menu ([#1036](https://github.com/nrwl/nx-console/issues/1036)) ([945ed7b](https://github.com/nrwl/nx-console/commits/945ed7bb1cd6c5daabdf172443f78e44918b9cac))
+- unit tests on vscode-ui libs ([#1035](https://github.com/nrwl/nx-console/issues/1035)) ([715b6e3](https://github.com/nrwl/nx-console/commits/715b6e39c3a538d9962e0eef9ac0b6bb5bfa0ede))
+- support directory as path alias from context menu ([#1036](https://github.com/nrwl/nx-console/issues/1036)) ([945ed7b](https://github.com/nrwl/nx-console/commits/945ed7bb1cd6c5daabdf172443f78e44918b9cac))
 
 ### Performance Improvements
 
-* increase performance of nx console ([#1038](https://github.com/nrwl/nx-console/issues/1038)) ([e8f3258](https://github.com/nrwl/nx-console/commits/e8f32583a7be03e7d6557e38a3e4123e2cf370b1))
+- increase performance of nx console ([#1038](https://github.com/nrwl/nx-console/issues/1038)) ([e8f3258](https://github.com/nrwl/nx-console/commits/e8f32583a7be03e7d6557e38a3e4123e2cf370b1))

--- a/apps/vscode/webpack.config.js
+++ b/apps/vscode/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = function transformWebpack(config) {
-  let stats = config.stats || {}
+  let stats = config.stats || {};
   stats.warnings = false;
   config.stats = stats;
 

--- a/libs/server/src/lib/telemetry/index.ts
+++ b/libs/server/src/lib/telemetry/index.ts
@@ -1,2 +1,2 @@
 export * from './telemetry';
-export * from './init'
+export * from './init';

--- a/libs/server/src/lib/telemetry/user.ts
+++ b/libs/server/src/lib/telemetry/user.ts
@@ -1,4 +1,4 @@
-import {Store} from "../stores/store";
+import { Store } from '../stores/store';
 
 export type UserState = 'untracked' | 'tracked';
 

--- a/libs/server/src/lib/utils/telemetry.ts
+++ b/libs/server/src/lib/utils/telemetry.ts
@@ -1,4 +1,3 @@
-
 import * as ua from 'universal-analytics';
 import uuidv4 = require('uuid/v4');
 

--- a/libs/vscode-ui/components/src/lib/field-items/field-items.pipe.spec.ts
+++ b/libs/vscode-ui/components/src/lib/field-items/field-items.pipe.spec.ts
@@ -27,7 +27,7 @@ describe('FieldItemsPipe', () => {
       aliases: [],
       description: 'The file extension to be used for style files.',
       default: 'scss',
-      items: ['css', 'scss', 'styl', 'less']
+      items: ['css', 'scss', 'styl', 'less'],
     };
     expect(getOptionItems(field2)).toEqual(field2.items);
   });

--- a/libs/vscode-ui/components/src/lib/field-tree/field-tree.component.ts
+++ b/libs/vscode-ui/components/src/lib/field-tree/field-tree.component.ts
@@ -19,8 +19,12 @@ export class FieldTreeComponent implements OnChanges {
   @Input() fields: Array<Option>;
   @Input() activeFieldName: string;
   @Input() filteredFields: Set<string>;
-  @Input() validFields: {[name: string]: string[] | string | number | boolean};
-  @Input() invalidFields: {[name: string]: string[] | string | number | boolean};
+  @Input() validFields: {
+    [name: string]: string[] | string | number | boolean;
+  };
+  @Input() invalidFields: {
+    [name: string]: string[] | string | number | boolean;
+  };
 
   userSelectedField?: string;
 

--- a/libs/vscode-ui/components/src/lib/field/field.component.spec.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.spec.ts
@@ -23,10 +23,7 @@ const mockOption: Option = {
 @Component({
   template: `
     <form *ngIf="formGroup" [formGroup]="formGroup">
-      <nx-console-field
-        #control
-        [field]="field"
-      ></nx-console-field>
+      <nx-console-field #control [field]="field"></nx-console-field>
     </form>
   `,
 })
@@ -79,7 +76,9 @@ describe('FieldComponent', () => {
 
   it('should show correct component for field', () => {
     expect(parent.fieldComponent.component).toEqual(OptionComponent.Checkbox);
-    expect(fixture.debugElement.query(By.css('nx-console-checkbox'))).toBeDefined();
+    expect(
+      fixture.debugElement.query(By.css('nx-console-checkbox'))
+    ).toBeDefined();
 
     parent.field = {
       name: 'style',
@@ -93,7 +92,9 @@ describe('FieldComponent', () => {
     };
     fixture.detectChanges();
     expect(parent.fieldComponent.component).toEqual(OptionComponent.Select);
-    expect(fixture.debugElement.query(By.css('nx-console-select'))).toBeDefined();
+    expect(
+      fixture.debugElement.query(By.css('nx-console-select'))
+    ).toBeDefined();
 
     parent.field = {
       name: 'style',
@@ -103,11 +104,27 @@ describe('FieldComponent', () => {
       itemTooltips: {
         test: 'testLabel',
       },
-      items: ['test', 'some', 'other', 'values', 'but', 'it', 'is', 'a', 'really', 'long', 'list'],
+      items: [
+        'test',
+        'some',
+        'other',
+        'values',
+        'but',
+        'it',
+        'is',
+        'a',
+        'really',
+        'long',
+        'list',
+      ],
     };
     fixture.detectChanges();
-    expect(parent.fieldComponent.component).toEqual(OptionComponent.Autocomplete);
-    expect(fixture.debugElement.query(By.css('nx-console-autocomplete'))).toBeDefined();
+    expect(parent.fieldComponent.component).toEqual(
+      OptionComponent.Autocomplete
+    );
+    expect(
+      fixture.debugElement.query(By.css('nx-console-autocomplete'))
+    ).toBeDefined();
 
     parent.field = {
       name: 'style',
@@ -123,8 +140,12 @@ describe('FieldComponent', () => {
       },
     };
     fixture.detectChanges();
-    expect(parent.fieldComponent.component).toEqual(OptionComponent.MultiSelect);
-    expect(fixture.debugElement.query(By.css('nx-console-multiple-select'))).toBeDefined();
+    expect(parent.fieldComponent.component).toEqual(
+      OptionComponent.MultiSelect
+    );
+    expect(
+      fixture.debugElement.query(By.css('nx-console-multiple-select'))
+    ).toBeDefined();
 
     parent.field = {
       name: 'style',
@@ -134,6 +155,8 @@ describe('FieldComponent', () => {
     };
     fixture.detectChanges();
     expect(parent.fieldComponent.component).toEqual(OptionComponent.Input);
-    expect(fixture.debugElement.query(By.css('nx-console-input'))).toBeDefined();
+    expect(
+      fixture.debugElement.query(By.css('nx-console-input'))
+    ).toBeDefined();
   });
 });

--- a/libs/vscode-ui/components/src/lib/multiple-select/multiple-select.component.spec.ts
+++ b/libs/vscode-ui/components/src/lib/multiple-select/multiple-select.component.spec.ts
@@ -55,7 +55,11 @@ describe('MultipleSelectComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [ParentFormComponent, MultipleSelectComponent, FieldItemsPipe],
+        declarations: [
+          ParentFormComponent,
+          MultipleSelectComponent,
+          FieldItemsPipe,
+        ],
         imports: [ReactiveFormsModule],
       }).compileComponents();
     })

--- a/libs/vscode-ui/components/src/lib/select/select.component.spec.ts
+++ b/libs/vscode-ui/components/src/lib/select/select.component.spec.ts
@@ -99,6 +99,9 @@ describe('SelectComponent', () => {
     };
     parent.field = longForm;
     fixture.detectChanges();
-    expect(fixture.debugElement.queryAll(By.css('#option-items-with-enum option')).length).toEqual(4);
+    expect(
+      fixture.debugElement.queryAll(By.css('#option-items-with-enum option'))
+        .length
+    ).toEqual(4);
   });
 });

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.pipe.spec.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.pipe.spec.ts
@@ -38,14 +38,17 @@ describe('FormatTaskPipe', () => {
 
   it('should optionally include configuration flag', () => {
     expect(
-      pipe.transform({
-        name: '',
-        cliName: 'nx',
-        description: '',
-        options: [],
-        command: 'build',
-        positional: 'the-project',
-      }, 'production')
+      pipe.transform(
+        {
+          name: '',
+          cliName: 'nx',
+          description: '',
+          options: [],
+          command: 'build',
+          positional: 'the-project',
+        },
+        'production'
+      )
     ).toEqual('nx build the-project --prod');
-  })
+  });
 });

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.ts
@@ -3,7 +3,10 @@ import {
   WORKSPACE_GENERATOR_NAME_REGEX,
 } from '@nx-console/schema';
 
-export const formatTask = (architect: TaskExecutionSchema, configuration?: string): string => {
+export const formatTask = (
+  architect: TaskExecutionSchema,
+  configuration?: string
+): string => {
   const positionals = architect.positional?.match(
     WORKSPACE_GENERATOR_NAME_REGEX
   );
@@ -17,7 +20,9 @@ export const formatTask = (architect: TaskExecutionSchema, configuration?: strin
   }
 
   return configuration
-    ? `${architect.cliName} ${architect.command} ${architect.positional} ${getConfigurationFlag(configuration)}`
+    ? `${architect.cliName} ${architect.command} ${
+        architect.positional
+      } ${getConfigurationFlag(configuration)}`
     : `${architect.cliName} ${architect.command} ${architect.positional}`;
 };
 
@@ -29,4 +34,4 @@ export const getConfigurationFlag = (configuration?: string): string => {
   } else {
     return `-c=${configuration}`;
   }
-}
+};

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
@@ -57,7 +57,10 @@
         <form class="fields" [formGroup]="taskExecForm.form">
           <div class="title-container">
             <span class="title">
-              {{ taskExecForm.architect | formatTask: taskExecForm.form.get('configuration')?.value }}
+              {{
+                taskExecForm.architect
+                  | formatTask: taskExecForm.form.get('configuration')?.value
+              }}
             </span>
             <button
               (click)="
@@ -75,7 +78,7 @@
             <nx-console-argument-list
               [args]="runCommandArguments$ | async"
             ></nx-console-argument-list>
-            <div class ="fields-container">
+            <div class="fields-container">
               <ng-container *ngIf="defaultValues$ | async as defaultValues">
                 <nx-console-field
                   [id]="field.name + '-nx-console-field'"

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -44,7 +44,7 @@ import { TASK_EXECUTION_SCHEMA } from './task-execution-form.schema';
 import {
   TaskExecutionSchema,
   TaskExecutionMessage,
-  ItemsWithEnum
+  ItemsWithEnum,
 } from '@nx-console/schema';
 import { OptionType, Value } from '@angular/cli/models/interface';
 
@@ -131,8 +131,9 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
 
   readonly filterFieldsControl = new FormControl('');
 
-  private readonly filterValue$ = (this.filterFieldsControl
-    .valueChanges as Observable<string>).pipe(
+  private readonly filterValue$ = (
+    this.filterFieldsControl.valueChanges as Observable<string>
+  ).pipe(
     startWith(''),
     map((filterValue) => filterValue.toLowerCase()),
     distinctUntilChanged()
@@ -340,7 +341,8 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
         defaultValues[field.name] = field.default.map((item) => String(item));
       } else {
         defaultValues[field.name] =
-          String(field.default) || (field.type === OptionType.Boolean ? 'false' : '');
+          String(field.default) ||
+          (field.type === OptionType.Boolean ? 'false' : '');
       }
     });
 
@@ -370,10 +372,7 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
     const configuration = form.get('configuration')?.value;
     const args = this.serializeArgs(form.value, architect, configuration);
     const flags = configuration
-      ? [
-          getConfigurationFlag(configuration),
-          ...args,
-        ]
+      ? [getConfigurationFlag(configuration), ...args]
       : args;
     if (architect.command === 'generate') {
       flags.push('--no-interactive');
@@ -413,21 +412,26 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
                 control.valid &&
                 // touched is not working with checkbox, so ignore touched and just check !== defaultValue
                 // control.touched &&
-                ((option.type !== OptionType.Array && control.value !== defaultValues[option.name]) ||
+                ((option.type !== OptionType.Array &&
+                  control.value !== defaultValues[option.name]) ||
                   (option.type === OptionType.Array &&
                     control.value &&
-                    control.value.join(',') !== ((defaultValues[option.name] || []) as string[]).join(',')
-                  )
-                )) ||
+                    control.value.join(',') !==
+                      ((defaultValues[option.name] || []) as string[]).join(
+                        ','
+                      )))) ||
               // ** INVALID fields **
               // invalid and touched (checkbox is always valid as true/false)
               (!valid && control.touched && control.invalid)
             );
           })
-          .reduce((options, option) => ({
-            ...options,
-            [option.name]: form.controls[option.name].value,
-          }), {});
+          .reduce(
+            (options, option) => ({
+              ...options,
+              [option.name]: form.controls[option.name].value,
+            }),
+            {}
+          );
       })
     );
   }
@@ -450,7 +454,8 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
       if (!defaultValues[f.name] && !value[f.name]) return;
       if (
         Array.isArray(defaultValues[f.name]) &&
-        (defaultValues[f.name] as string[]).join(',') === value[f.name].join(',')
+        (defaultValues[f.name] as string[]).join(',') ===
+          value[f.name].join(',')
       )
         return;
 

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.stories.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.stories.ts
@@ -86,8 +86,7 @@ const initialSchema: TaskExecutionSchema = {
         shell:
           'shell - for wrapping different libraries and exposing them as a single library. Also, for routing.',
         ui: 'ui - for dumb components',
-        util:
-          'util - for model files, constants, validators, pipes and any other miscellaneous items, e.g. shared functions.',
+        util: 'util - for model files, constants, validators, pipes and any other miscellaneous items, e.g. shared functions.',
       },
     },
     {

--- a/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
+++ b/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
@@ -66,7 +66,7 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
       }
     }
 
-    CHANGE_WORKSPACE.description = "Current: " + dirname(workspaceJsonPath);
+    CHANGE_WORKSPACE.description = 'Current: ' + dirname(workspaceJsonPath);
 
     return [
       ...ROUTE_LIST.map(

--- a/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
+++ b/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
@@ -18,7 +18,7 @@ export async function revealNxProject(
     const workspaceRootDir = dirname(workspaceJsonPath);
     workspaceJsonPath = join(
       workspaceRootDir,
-      (rawWorkspace.projects[projectName] as unknown) as string,
+      rawWorkspace.projects[projectName] as unknown as string,
       'project.json'
     );
   }

--- a/libs/vscode/tasks/src/lib/select-flags.ts
+++ b/libs/vscode/tasks/src/lib/select-flags.ts
@@ -83,7 +83,7 @@ function promptForFlagValue(flagToSet: CliTaskFlagQuickPickItem) {
   } else if (flagToSet.option.enum && flagToSet.option.enum.length) {
     return window.showQuickPick([...flagToSet.option.enum.map(String)], {
       placeHolder,
-      canPickMany: flagToSet.option.type === 'array'
+      canPickMany: flagToSet.option.type === 'array',
     });
   } else {
     return window.showInputBox({

--- a/libs/vscode/verify/src/lib/verify-node-modules.ts
+++ b/libs/vscode/verify/src/lib/verify-node-modules.ts
@@ -2,9 +2,9 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { window } from 'vscode';
 
-export function verifyNodeModules(
-  workspacePath: string
-): { validNodeModules: boolean } {
+export function verifyNodeModules(workspacePath: string): {
+  validNodeModules: boolean;
+} {
   if (!existsSync(join(workspacePath, 'node_modules'))) {
     window.showErrorMessage(
       'Could not execute task since node_modules directory is missing. Run npm install at: ' +

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -75,7 +75,7 @@ module.exports = {
       vscode: `node ${join('tools', 'scripts', 'vscode-yarn.js')}`,
     },
     lint: {
-      default: "nx run-many --all --parallel --target=lint"
-    }
+      default: 'nx run-many --all --parallel --target=lint',
+    },
   },
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "package": "nps prepare.and.package.vscode",
     "release": "standard-version",
     "postinstall": "node ./tools/scripts/postinstall.js && node ./decorate-angular-cli.js",
-    "update": "nx migrate latest"
+    "update": "nx migrate latest",
+    "prepare": "is-ci || husky install"
   },
   "dependencies": {
     "jsonc-parser": "^3.0.0"
@@ -71,16 +72,17 @@
     "copy-webpack-plugin": "^9.0.1",
     "cypress": "6.5.0",
     "eslint": "7.10.0",
-    "eslint-config-prettier": "8.1.0",
-    "husky": "^3.0.9",
+    "eslint-config-prettier": "8.3.0",
+    "husky": "^7.0.2",
+    "is-ci": "^3.0.0",
     "jest": "27.0.3",
     "jest-preset-angular": "9.0.3",
     "ngx-build-plus": "11.0.0",
     "nps": "5.9.3",
     "nps-utils": "1.7.0",
     "ovsx": "^0.2.0",
-    "prettier": "2.3.2",
-    "pretty-quick": "^1.11.1",
+    "prettier": "^2.4.1",
+    "pretty-quick": "^3.1.1",
     "rxjs": "6.5.5",
     "shelljs": "0.8.3",
     "shx": "^0.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4123,6 +4123,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/minimatch@^3.0.3":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
+  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
 "@types/minimist@^1.2.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
@@ -5255,10 +5260,10 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-array-differ@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
-  integrity sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==
+array-differ@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
+  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -7184,7 +7189,7 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
-cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
+cosmiconfig@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -8580,10 +8585,10 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
-  integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
+eslint-config-prettier@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
 eslint-scope@5.1.1, eslint-scope@^5.1.0, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -8782,19 +8787,6 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
-  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -8808,7 +8800,7 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^4.0.2:
+execa@^4.0.0, execa@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -10417,22 +10409,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^3.0.9:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
-  integrity sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==
-  dependencies:
-    chalk "^2.4.2"
-    ci-info "^2.0.0"
-    cosmiconfig "^5.2.1"
-    execa "^1.0.0"
-    get-stdin "^7.0.0"
-    opencollective-postinstall "^2.0.2"
-    pkg-dir "^4.2.0"
-    please-upgrade-node "^3.2.0"
-    read-pkg "^5.2.0"
-    run-node "^1.0.0"
-    slash "^3.0.0"
+husky@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.2.tgz#21900da0f30199acca43a46c043c4ad84ae88dff"
+  integrity sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
@@ -10483,11 +10463,6 @@ ignore-walk@^3.0.3:
   integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
   dependencies:
     minimatch "^3.0.4"
-
-ignore@^3.3.7:
-  version "3.3.10"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
-  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
@@ -13017,10 +12992,10 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-mri@^1.1.0:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.6.tgz#49952e1044db21dbf90f6cd92bc9c9a777d415a6"
-  integrity sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==
+mri@^1.1.5:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -13055,14 +13030,15 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-multimatch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-3.0.0.tgz#0e2534cc6bc238d9ab67e1b9cd5fcd85a6dbf70b"
-  integrity sha512-22foS/gqQfANZ3o+W7ST2x25ueHDVNWl/b9OlGcLpy/iKxjCpvcNCM51YCenUi7Mt/jAjjqv8JwZRs8YP5sRjA==
+multimatch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
+  integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
   dependencies:
-    array-differ "^2.0.3"
-    array-union "^1.0.2"
-    arrify "^1.0.1"
+    "@types/minimatch" "^3.0.3"
+    array-differ "^3.0.0"
+    array-union "^2.1.0"
+    arrify "^2.0.1"
     minimatch "^3.0.4"
 
 mute-stream@0.0.8, mute-stream@~0.0.4:
@@ -13649,11 +13625,6 @@ open@^7.0.2, open@^7.0.3, open@^7.4.2:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
-
-opencollective-postinstall@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 opn-cli@^3.1.0:
   version "3.1.0"
@@ -14284,13 +14255,6 @@ pkg-up@3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
-
-please-upgrade-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"
@@ -15076,10 +15040,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
-  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 prettier@~2.2.1:
   version "2.2.1"
@@ -15132,17 +15096,17 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-pretty-quick@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.11.1.tgz#462ffa2b93d24c05b7a0c3a001e08601a0c55ee4"
-  integrity sha512-kSXCkcETfak7EQXz6WOkCeCqpbC4GIzrN/vaneTGMP/fAtD8NerA9bPhCUqHAks1geo7biZNl5uEMPceeneLuA==
+pretty-quick@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-3.1.1.tgz#93ca4e2dd38cc4e970e3f54a0ead317a25454688"
+  integrity sha512-ZYLGiMoV2jcaas3vTJrLvKAYsxDoXQBUn8OSTxkl67Fyov9lyXivJTl0+2WVh+y6EovGcw7Lm5ThYpH+Sh3XxQ==
   dependencies:
-    chalk "^2.3.0"
-    execa "^0.8.0"
-    find-up "^2.1.0"
-    ignore "^3.3.7"
-    mri "^1.1.0"
-    multimatch "^3.0.0"
+    chalk "^3.0.0"
+    execa "^4.0.0"
+    find-up "^4.1.0"
+    ignore "^5.1.4"
+    mri "^1.1.5"
+    multimatch "^4.0.0"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"
@@ -16241,11 +16205,6 @@ run-async@^2.4.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
-run-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
-  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -16447,11 +16406,6 @@ selfsigned@^1.10.8:
   integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
   dependencies:
     node-forge "^0.10.0"
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
updated `prettier` to 2.4.1 which supports `typescript` 4.3 syntaxes
updated `husky` to 7.0.2
updated `pretty-quick` to 3.0.0

added a pre-push hook like in `nrwl/nx` which checks if everything is formatted before pushing

I also formatted everything in the repo with the current prettier version. 