### PR TITLE
fix: make sure that executors/builders and generator/schematics are combined respectively

### DIFF
--- a/libs/server/src/lib/utils/read-collections.ts
+++ b/libs/server/src/lib/utils/read-collections.ts
@@ -119,9 +119,11 @@ export async function getCollectionInfo(
     };
   };
 
-  for (const [key, schema] of Object.entries<any>(
-    executorCollectionJson.executors || executorCollectionJson.executors || {}
-  )) {
+  const executors = {
+    ...executorCollectionJson.executors,
+    ...executorCollectionJson.builders,
+  };
+  for (const [key, schema] of Object.entries<any>(executors)) {
     if (!canUse(key, schema)) {
       continue;
     }
@@ -132,11 +134,11 @@ export async function getCollectionInfo(
     collectionMap.set(collectionInfo.name, collectionInfo);
   }
 
-  for (const [key, schema] of Object.entries<any>(
-    generatorCollectionJson.generators ||
-      generatorCollectionJson.schematics ||
-      {}
-  )) {
+  const generators = {
+    ...generatorCollectionJson.generators,
+    ...generatorCollectionJson.schematics,
+  };
+  for (const [key, schema] of Object.entries<any>(generators)) {
     if (!canUse(key, schema)) {
       continue;
     }


### PR DESCRIPTION
## What it does
combines all schemas so that none are missing
