### PR TITLE
fix: handle non-existing files better and return an empty object

### DIFF
--- a/libs/server/src/lib/utils/utils.ts
+++ b/libs/server/src/lib/utils/utils.ts
@@ -187,20 +187,23 @@ export async function readAndCacheJsonFile(
   }
 
   const fullFilePath = path.join(basedir, filePath);
-  const stats = await stat(fullFilePath);
-  if (fileContents[fullFilePath] || stats.isFile()) {
-    fileContents[fullFilePath] ||= await readAndParseJson(fullFilePath);
-
-    return {
-      path: fullFilePath,
-      json: fileContents[fullFilePath],
-    };
-  } else {
-    return {
-      path: fullFilePath,
-      json: {},
-    };
+  try {
+    const stats = await stat(fullFilePath);
+    if (fileContents[fullFilePath] || stats.isFile()) {
+      fileContents[fullFilePath] ||= await readAndParseJson(fullFilePath);
+      return {
+        path: fullFilePath,
+        json: fileContents[fullFilePath],
+      };
+    }
+  } catch (e) {
+    getOutputChannel().appendLine(`${fullFilePath} does not exist`);
   }
+
+  return {
+    path: fullFilePath,
+    json: {},
+  };
 }
 
 const registry = new schema.CoreSchemaRegistry(standardFormats);


### PR DESCRIPTION
## What it does
Handles the non-existing files when trying to check if it's a real file. This will now return an empty object when the file does not exist.

Fixes #1169