### PR TITLE
fix: resolve schema paths rather than joining

### DIFF
--- a/libs/server/src/lib/utils/get-generators.ts
+++ b/libs/server/src/lib/utils/get-generators.ts
@@ -72,7 +72,10 @@ async function readWorkspaceGeneratorsCollection(
       collectionName,
       collectionPath,
       collectionDir,
-      {},
+      {
+        path: collectionPath,
+        json: {},
+      },
       collection.json
     );
   } else {


### PR DESCRIPTION
## What it does
This resolves individual schema.json file paths to the builder/executor path mentioned in the package.json. Before we did a join to get the paths, and it didnt properly resolve to the correct location 

Fixes #1174
