### PR TITLE
feat: include typescript plugin for imports

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -51,6 +51,7 @@ import {
   WorkspaceJsonSchema,
   ProjectJsonSchema,
 } from '@nx-console/vscode/json-schema';
+import { enableTypeScriptPlugin } from './typescript-plugin';
 
 let runTargetTreeView: TreeView<RunTargetTreeItem>;
 let nxProjectTreeView: TreeView<NxProjectTreeItem>;
@@ -132,6 +133,9 @@ export async function activate(c: ExtensionContext) {
     new WorkspaceCodeLensProvider(context);
     new WorkspaceJsonSchema(context);
     new ProjectJsonSchema(context);
+
+    // TODO(cammisuli): add config to disable this
+    // await enableTypeScriptPlugin();
 
     getTelemetry().extensionActivated((Date.now() - startTime) / 1000);
   } catch (e) {

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -134,8 +134,7 @@ export async function activate(c: ExtensionContext) {
     new WorkspaceJsonSchema(context);
     new ProjectJsonSchema(context);
 
-    // TODO(cammisuli): add config to disable this
-    // await enableTypeScriptPlugin();
+    await enableTypeScriptPlugin(context);
 
     getTelemetry().extensionActivated((Date.now() - startTime) / 1000);
   } catch (e) {

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -41,9 +41,16 @@
     "onView:nx-console"
   ],
   "dependencies": {
-    "jsonc-parser": "^3.0.0"
+    "jsonc-parser": "^3.0.0",
+    "@monodon/typescript-nx-imports-plugin": "~0.1.0"
   },
   "contributes": {
+    "typescriptServerPlugins": [
+      {
+        "enableForWorkspaceTypeScriptVersions": true,
+        "name": "@monodon/typescript-nx-imports-plugin"
+      }
+    ],
     "menus": {
       "explorer/context": [
         {

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -37,12 +37,14 @@
     "Other"
   ],
   "activationEvents": [
-    "onStartupFinished",
-    "onView:nx-console"
+    "onView:nx-console",
+    "workspaceContains:workspace.json",
+    "workspaceContains:angular.json",
+    "workspaceContains:nx.json"
   ],
   "dependencies": {
     "jsonc-parser": "^3.0.0",
-    "@monodon/typescript-nx-imports-plugin": "~0.1.0"
+    "@monodon/typescript-nx-imports-plugin": "0.1.3"
   },
   "contributes": {
     "typescriptServerPlugins": [

--- a/apps/vscode/src/typescript-plugin.ts
+++ b/apps/vscode/src/typescript-plugin.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+
+export async function enableTypeScriptPlugin() {
+  const tsExtension = vscode.extensions.getExtension(
+    'vscode.typescript-language-features'
+  );
+  if (!tsExtension) {
+    return;
+  }
+
+  await tsExtension.activate();
+
+  // Get the API from the TS extension
+  if (!tsExtension.exports || !tsExtension.exports.getAPI) {
+    return;
+  }
+
+  const api = tsExtension.exports.getAPI(0);
+  if (!api) {
+    return;
+  }
+
+  api.configurePlugin('@monodon/typescript-nx-imports-plugin', {});
+}

--- a/apps/vscode/src/typescript-plugin.ts
+++ b/apps/vscode/src/typescript-plugin.ts
@@ -1,6 +1,9 @@
+import { findConfig, readAndCacheJsonFile } from '@nx-console/server';
+import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
+import { dirname, join } from 'path';
 import * as vscode from 'vscode';
 
-export async function enableTypeScriptPlugin() {
+export async function enableTypeScriptPlugin(context: vscode.ExtensionContext) {
   const tsExtension = vscode.extensions.getExtension(
     'vscode.typescript-language-features'
   );
@@ -20,5 +23,53 @@ export async function enableTypeScriptPlugin() {
     return;
   }
 
-  api.configurePlugin('@monodon/typescript-nx-imports-plugin', {});
+  vscode.workspace.onDidOpenTextDocument(
+    (document) => {
+      if (document.uri.fsPath.endsWith('.ts')) {
+        configurePlugin(api);
+      }
+    },
+    undefined,
+    context.subscriptions
+  );
+
+  configurePlugin(api);
+}
+
+async function configurePlugin(api: any) {
+  const externalFiles = await getExternalFiles();
+  // TODO(cammisuli): add config to disable this
+  api.configurePlugin('@monodon/typescript-nx-imports-plugin', {
+    externalFiles,
+  });
+}
+
+async function getExternalFiles(): Promise<
+  { mainFile: string; directory: string }[]
+> {
+  const workspaceRoot = dirname(
+    WorkspaceConfigurationStore.instance.get('nxWorkspaceJsonPath', '')
+  );
+
+  const baseTsConfig = (
+    await readAndCacheJsonFile('tsconfig.base.json', workspaceRoot)
+  ).json;
+
+  const paths = baseTsConfig.compilerOptions.paths;
+
+  const externals: { mainFile: string; directory: string }[] = [];
+
+  for (const [, value] of Object.entries<string[]>(paths)) {
+    const mainFile = join(workspaceRoot, value[0]);
+    const configFilePath = await findConfig(mainFile, 'tsconfig.lib.json');
+
+    if (!configFilePath) {
+      continue;
+    }
+
+    const directory = dirname(configFilePath);
+    externals.push({ mainFile, directory });
+  }
+
+  return externals;
 }

--- a/libs/server/src/index.ts
+++ b/libs/server/src/index.ts
@@ -17,3 +17,4 @@ export {
 } from './lib/utils/utils';
 export { watchFile } from './lib/utils/watch-file';
 export { buildProjectPath } from './lib/utils/build-project-path';
+export { findConfig } from './lib/utils/find-config';

--- a/libs/server/src/lib/utils/find-config.ts
+++ b/libs/server/src/lib/utils/find-config.ts
@@ -1,0 +1,37 @@
+import { dirname, join } from 'path';
+import * as vscode from 'vscode';
+
+export async function forEachAncestorDirectory(
+  directory: string,
+  callback: (directory: string) => Promise<string | undefined>
+): Promise<string | undefined> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await callback(directory);
+    if (result !== undefined) {
+      return result;
+    }
+
+    const parentPath = dirname(directory);
+    if (parentPath === directory) {
+      return undefined;
+    }
+
+    directory = parentPath;
+  }
+}
+
+export async function findConfig(
+  searchPath: string,
+  configName: string
+): Promise<string | undefined> {
+  return forEachAncestorDirectory(searchPath, async (ancestor) => {
+    const fileName = join(ancestor, configName);
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.file(fileName));
+      return fileName;
+    } catch (e) {
+      return undefined;
+    }
+  });
+}

--- a/libs/server/src/lib/utils/watch-file.ts
+++ b/libs/server/src/lib/utils/watch-file.ts
@@ -1,4 +1,4 @@
-import { workspace, FileSystemWatcher, GlobPattern } from 'vscode';
+import { workspace, GlobPattern, Disposable } from 'vscode';
 
 /**
  * Watch a file and execute the callback on changes.
@@ -10,9 +10,10 @@ import { workspace, FileSystemWatcher, GlobPattern } from 'vscode';
  */
 export function watchFile(
   filePath: GlobPattern,
-  callback: (...args: any[]) => unknown
+  callback: (...args: any[]) => unknown,
+  disposable?: Disposable[]
 ) {
   const filewatcher = workspace.createFileSystemWatcher(filePath);
-  filewatcher.onDidChange(callback);
+  filewatcher.onDidChange(callback, disposable);
   return filewatcher;
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "update": "nx migrate latest"
   },
   "dependencies": {
-    "@monodon/typescript-nx-imports-plugin": "0.1.2",
+    "@monodon/typescript-nx-imports-plugin": "0.1.3",
     "jsonc-parser": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "update": "nx migrate latest"
   },
   "dependencies": {
+    "@monodon/typescript-nx-imports-plugin": "0.1.2",
     "jsonc-parser": "^3.0.0"
   },
   "devDependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,7 +32,6 @@
       "@nx-console/vscode-ui/feature-task-execution-form": [
         "libs/vscode-ui/feature-task-execution-form/src/index.ts"
       ],
-      "@nx-console/vscode-ui/styles": ["libs/vscode-ui/styles/src/index.ts"],
       "@nx-console/vscode/configuration": [
         "libs/vscode/configuration/src/index.ts"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2602,10 +2602,10 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@monodon/typescript-nx-imports-plugin@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@monodon/typescript-nx-imports-plugin/-/typescript-nx-imports-plugin-0.1.2.tgz#a8a2466525e0a9544142c1b8d2ca6c47a8279d6d"
-  integrity sha512-U9S1wwr5Yn+Eua1v+bNUEWE3Q12JJr+mfdbO+9UWweILKXhpjXGt7M/mV4r2kcx8iCvgEmT7oaa86wajsV8glg==
+"@monodon/typescript-nx-imports-plugin@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@monodon/typescript-nx-imports-plugin/-/typescript-nx-imports-plugin-0.1.3.tgz#de40f7547e4a1fe1ec846719d3487b0d6e306683"
+  integrity sha512-zJ8TTKOchy4P9sQmbRK7gbK3Tr6z1tpOBexT95K9YijM6pPQGMqvaGJPMmid2RG/v7Zp+ZfEYn3dOKzNoa6AYg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18095,15 +18095,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@1.14.1, tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
-
-tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@^2.0.3, tslib@~2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2602,6 +2602,11 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
+"@monodon/typescript-nx-imports-plugin@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@monodon/typescript-nx-imports-plugin/-/typescript-nx-imports-plugin-0.1.2.tgz#a8a2466525e0a9544142c1b8d2ca6c47a8279d6d"
+  integrity sha512-U9S1wwr5Yn+Eua1v+bNUEWE3Q12JJr+mfdbO+9UWweILKXhpjXGt7M/mV4r2kcx8iCvgEmT7oaa86wajsV8glg==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -18090,15 +18095,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.14.1, tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@^2.0.3, tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## What it does
Includes the `@monodon/typescript-nx-imports-plugin` to configure the typescript language service to include references to projects outside it's own tsconfig. 