### PR TITLE
fix: revert to old logic for scanning workspaces, also fix checking for paths of undefined

### DIFF
--- a/libs/typescript-plugin/src/lib/typescript-plugin.ts
+++ b/libs/typescript-plugin/src/lib/typescript-plugin.ts
@@ -116,11 +116,18 @@ async function configurePlugin(workspaceRoot: string, api: any) {
 async function getExternalFiles(
   workspaceRoot: string
 ): Promise<{ mainFile: string; directory: string }[]> {
-  const baseTsConfig = (
-    await readAndCacheJsonFile(TSCONFIG_BASE, workspaceRoot)
-  ).json;
+  let tsconfig = (await readAndCacheJsonFile(TSCONFIG_BASE, workspaceRoot))
+    .json;
 
-  const paths = baseTsConfig.compilerOptions.paths;
+  if (!('compilerOptions' in tsconfig)) {
+    tsconfig = (await readAndCacheJsonFile('tsconfig.json', workspaceRoot))
+      .json;
+    if (!('compilerOptions' in tsconfig)) {
+      return [];
+    }
+  }
+
+  const paths = tsconfig.compilerOptions.paths ?? {};
 
   const externals: { mainFile: string; directory: string }[] = [];
 


### PR DESCRIPTION
This should potentially/hopefully fix some issues users are facing when trying to open workspaces with the latest versions. This essentially reverts to the old logic of "scanning" for a directory with workspace.json/angular.json and now nx.json. 