### PR TITLE
fix: revert activationEvents to `onStartupFinished`

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -37,10 +37,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onView:nx-console",
-    "workspaceContains:workspace.json",
-    "workspaceContains:angular.json",
-    "workspaceContains:nx.json"
+    "onStartupFinished"
   ],
   "dependencies": {
     "jsonc-parser": "^3.0.0",


### PR DESCRIPTION
## What it does

In an effort to reduce startup costs for Nx Console, a change was made so that it only activated when workspaces contained workspace.json/angular.json/nx.json. This caused issues when users opened workspaces that contained subfoldered nx workspaces.