### PR TITLE
fix: fallback to built in nx utils if required function doesnt exist

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -146,7 +146,7 @@ export async function activate(c: ExtensionContext) {
     getOutputChannel().appendLine(
       'Nx Console encountered an error when activating'
     );
-    getOutputChannel().appendLine(JSON.stringify(e));
+    getOutputChannel().appendLine(e.stack);
     getTelemetry().exception(e.message);
   }
 }

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
@@ -33,12 +33,19 @@ export async function getNxWorkspacePackageFileUtils(): Promise<
         importPath = importPath.replace(/\\/g, '/');
       }
       const imported = __non_webpack_require__(importPath);
+
+      if (!('readWorkspaceConfig' in imported)) {
+        throw new Error(
+          'Workspace tools does not have `readWorkspaceConfig` function. Use built in @nrwl/workspace package'
+        );
+      }
+
       return res(imported);
     } catch (error) {
       getOutputChannel().appendLine(
         `
     Error loading @nrwl/workspace from workspace. Falling back to extension dependency
-    Error: ${error}
+    ${error}
           `
       );
       return res(NxWorkspaceFileUtils);


### PR DESCRIPTION
## What it does
This PR checks to see if a required function exists on a local version of Nx. If it doesn't, then we fallback to the one that's include with Nx Console.
