### PR TITLE
fix: handle absence of "properties" in schema

### DIFF
--- a/libs/server/src/lib/utils/utils.spec.ts
+++ b/libs/server/src/lib/utils/utils.spec.ts
@@ -24,6 +24,12 @@ describe('utils', () => {
       return r;
     };
 
+    it('should work with schema without any properties', async () => {
+      // @ts-expect-error absence of required property "properties" is needed to test failure resistance
+      const r = await normalizeSchema({})
+      expect(r).toEqual([])
+    });
+
     it('should mark fields as required if they are listed in the required array', async () => {
       const r = await getSchema({ mockOption }, ['mockOption']);
       expect(r[0].isRequired).toBeTruthy();

--- a/libs/server/src/lib/utils/utils.ts
+++ b/libs/server/src/lib/utils/utils.ts
@@ -360,7 +360,7 @@ export function toWorkspaceFormat(
 }
 
 function schemaToOptions(schema: Schema): CliOption[] {
-  return Object.keys(schema.properties).reduce<CliOption[]>(
+  return Object.keys(schema.properties || {}).reduce<CliOption[]>(
     (cliOptions, option) => {
       const currentProperty = schema.properties[option];
       const $default = currentProperty.$default;


### PR DESCRIPTION
I've encountered an issue with some old repository. It contained a schematics, that didn't have `properties` field specified in `schema.json`. Schematics itself was working properly, but `nx-console` plugin failed to even launch. This PR adds handling of a case there's no `properties` field in schema.
![image](https://user-images.githubusercontent.com/33101123/147637990-766937fc-d3a0-4037-a850-3799424fbf36.png)


@vsavkin would it be reasonable to also make `properties` field optional in the `Schema` interface in Nx repo [here](https://github.com/nrwl/nx/blob/master/packages/tao/src/shared/params.ts#L51)?