### PR TITLE
fix: remove tslint from externalDependencies

### DIFF
--- a/apps/vscode/project.json
+++ b/apps/vscode/project.json
@@ -8,7 +8,7 @@
     "build": {
       "executor": "@nrwl/node:build",
       "options": {
-        "externalDependencies": ["vscode", "tslint"],
+        "externalDependencies": ["vscode"],
         "webpackConfig": "apps/vscode/webpack.config.js",
         "outputPath": "dist/apps/vscode",
         "main": "apps/vscode/src/main.ts",


### PR DESCRIPTION
`tslint` is listed as `externalDependency` but is not used anymore