### PR TITLE
fix: fixed CI Node Setup and Caching

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -23,17 +23,13 @@ jobs:
 
   agents:
     runs-on: ubuntu-latest
-    name: Agent
+    name: Agent ${{ matrix.agent }}
     timeout-minutes: 15
     strategy:
       matrix:
         agent: [1, 2, 3]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ env.node_version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.node_version }}
       - uses: ./.github/workflows/setup
         with:
           node_version: ${{ env.node_version }}

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -6,23 +6,17 @@ inputs:
     required: true
     default: '14'
 runs:
-  using: 'composite'
+  using: composite
   steps:
+    - name: Use Node.js ${{ inputs.node_version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ inputs.node_version }}
+        check-latest: true
+        cache: yarn
+    - run: yarn install --frozen-lockfile
+      shell: bash
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
       uses: nrwl/nx-set-shas@v2
       with:
         main-branch-name: 'master'
-    - uses: actions/setup-node@v1
-      with:
-        node-version: ${{ inputs.node_version }}
-    - uses: actions/cache@v2
-      id: workspace-cache
-      with:
-        path: |
-          node_modules
-          !node_modules/.cache
-        key: ${{ runner.os }}-node-${{ inputs.node_version }}-workspace-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-node-${{ inputs.node_version }}-workspace-
-    - run: yarn install --frozen-lockfile
-      shell: bash


### PR DESCRIPTION
The `setup` action should use `actions/setup-node` **v2**. It supports caching internally so there is no need for the extra `actions/cache` step. 

Also the Agents are currently running the `actions/setup-node` step twice.