### PR TITLE
fix: show description when running workspace generators/schematics

### DIFF
--- a/libs/server/src/lib/utils/get-generators.ts
+++ b/libs/server/src/lib/utils/get-generators.ts
@@ -76,7 +76,8 @@ async function readWorkspaceGeneratorsCollection(
         .filter((f) => basename(f) === 'schema.json')
         .map(async (f) => {
           const schemaJson = await readAndCacheJsonFile(f, '');
-          const name = schemaJson.json.id || schemaJson.json.$id;
+          const name =
+            schemaJson.json.title || schemaJson.json.id || schemaJson.json.$id;
           const type: GeneratorType =
             schemaJson.json['x-type'] ?? GeneratorType.Other;
           return {
@@ -87,7 +88,7 @@ async function readWorkspaceGeneratorsCollection(
               name,
               collection: collectionName,
               options: await normalizeSchema(schemaJson.json),
-              description: '',
+              description: schemaJson.json.description ?? '',
               type,
             },
           } as CollectionInfo;


### PR DESCRIPTION
## What it does
Shows the description and title when trying to run a workspace generator/schematic

fixes #1224
