### PR TITLE
feat: use cmd/ctrl+enter to execute generator while in the UI form

### DIFF
--- a/libs/vscode-ui/components/src/lib/field/field.component.ts
+++ b/libs/vscode-ui/components/src/lib/field/field.component.ts
@@ -125,7 +125,7 @@ export class FieldComponent implements ControlValueAccessor, OnDestroy {
     return Object.keys(this.control.errors ?? {})
       .map((key) => {
         if (this.control.errors) {
-          if (key === 'isRequired') {
+          if (key === 'required') {
             return `${fieldName
               .slice(0, 1)
               .toLocaleUpperCase()}${fieldName.slice(1)} is required`;

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.html
@@ -4,6 +4,8 @@
       taskExecForm.architect.configurations &&
       taskExecForm.architect.configurations.length > 0
     "
+    (document:keydown.meta.enter)="isMacOs && runCommand(taskExecForm)"
+    (document:keydown.control.enter)="!isMacOs && runCommand(taskExecForm)"
   >
     <div class="form-header-container" #formHeaderContainer>
       <div class="form-header">
@@ -57,7 +59,10 @@
         <form class="fields" [formGroup]="taskExecForm.form">
           <div class="title-container">
             <span class="title">
-              {{ taskExecForm.architect | formatTask: taskExecForm.form.get('configuration')?.value }}
+              {{
+                taskExecForm.architect
+                  | formatTask: taskExecForm.form.get('configuration')?.value
+              }}
             </span>
             <button
               (click)="
@@ -88,7 +93,7 @@
             <nx-console-argument-list
               [args]="runCommandArguments$ | async"
             ></nx-console-argument-list>
-            <div class ="fields-container">
+            <div class="fields-container">
               <ng-container *ngIf="defaultValues$ | async as defaultValues">
                 <nx-console-field
                   [id]="field.name + '-nx-console-field'"

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -70,6 +70,10 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
   @ViewChild('formHeaderContainer')
   formHeaderContainer: ElementRef<HTMLElement>;
 
+  get isMacOs() {
+    return navigator.userAgent.indexOf('Mac') > -1;
+  }
+
   private readonly activeFieldIdSubject = new BehaviorSubject<string>('');
   readonly activeFieldName$ = this.activeFieldIdSubject.pipe(
     distinctUntilChanged(),


### PR DESCRIPTION
## What it does
While in the UI form for generators/schematics, we can now press cmd + enter (or ctrl+enter for non macOS environments) to execute the form. 

closes #1217
