### PR TITLE
fix: run pnp.setup to patch require

### DIFF
--- a/libs/npm/src/lib/pnp-dependencies.ts
+++ b/libs/npm/src/lib/pnp-dependencies.ts
@@ -1,7 +1,9 @@
 import { join } from 'path';
 import { Uri, workspace } from 'vscode';
-
+import type { PnpApi } from '@yarnpkg/pnp';
 declare function __non_webpack_require__(importPath: string): any;
+
+let PNP_API: PnpApi;
 
 async function getPnpFile(workspacePath: string) {
   const extensions = ['.cjs', '.js'];
@@ -23,7 +25,13 @@ async function pnpApi(workspacePath: string) {
     return;
   }
 
-  return __non_webpack_require__(pnpFile);
+  if (!PNP_API) {
+    const pnp = __non_webpack_require__(pnpFile);
+    pnp.setup();
+    PNP_API = pnp;
+  }
+
+  return PNP_API;
 }
 
 export async function isWorkspaceInPnp(workspacePath: string) {
@@ -38,13 +46,23 @@ export async function isWorkspaceInPnp(workspacePath: string) {
 export async function pnpDependencies(workspacePath: string) {
   const pnp = await pnpApi(workspacePath);
 
+  if (!pnp) {
+    return [];
+  }
+
+  pnp.resolveRequest;
+
   const dependencies = [];
   for (const locator of pnp.getDependencyTreeRoots()) {
     const pkg = pnp.getPackageInformation(locator);
-    for (const [name, reference] of pkg.packageDependencies) {
+    if (!pkg?.packageDependencies) {
+      continue;
+    }
+    for (const [name, reference] of pkg?.packageDependencies) {
       // Unmet peer dependencies
       if (reference === null) continue;
-      if (reference.startsWith('workspace:')) continue;
+      if (!Array.isArray(reference) && reference.startsWith('workspace:'))
+        continue;
 
       const path = await pnpDependencyPath(workspacePath, name);
       if (path) {
@@ -61,12 +79,15 @@ export async function pnpDependencyPath(
 ) {
   try {
     const pnp = await pnpApi(workspacePath);
-    let path: string = pnp.resolveToUnqualified(
-      dependencyName,
-      workspacePath + '/'
-    );
+
+    if (!pnp) {
+      return;
+    }
+
+    let path: string =
+      pnp.resolveToUnqualified(dependencyName, workspacePath + '/') ?? '';
     if (path.includes('__virtual__')) {
-      path = pnp.resolveVirtual(path);
+      path = pnp.resolveVirtual?.(path) ?? '';
     }
 
     return path;

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-package.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import * as NxWorkspaceFileUtils from '@nrwl/workspace/src/core/file-utils';
 import { getOutputChannel } from '@nx-console/server';
 import { platform } from 'os';
+import { workspaceDependencyPath } from '@nx-console/npm';
 
 declare function __non_webpack_require__(importPath: string): any;
 
@@ -17,18 +18,24 @@ export async function getNxWorkspacePackageFileUtils(): Promise<
     ''
   );
 
-  let importPath = join(
+  const nrwlWorkspaceDepPath = await workspaceDependencyPath(
     workspacePath,
-    'node_modules',
-    '@nrwl',
-    'workspace',
-    'src',
-    'core',
-    'file-utils.js'
+    '@nrwl/workspace'
   );
 
   return new Promise((res) => {
     try {
+      if (!nrwlWorkspaceDepPath) {
+        throw '@nrwl/workspace not found';
+      }
+
+      let importPath = join(
+        nrwlWorkspaceDepPath,
+        'src',
+        'core',
+        'file-utils.js'
+      );
+
       if (platform() === 'win32') {
         importPath = importPath.replace(/\\/g, '/');
       }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/vscode": "1.50.0",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
+    "@yarnpkg/pnp": "^3.1.1-rc.12",
     "cypress": "6.5.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,6 +4368,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
   integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
 
+"@types/node@^13.7.0":
+  version "13.13.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
+  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
+
 "@types/node@^14.0.10":
   version "14.17.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.10.tgz#93f4b095af275a0427114579c10ec7aa696729d7"
@@ -4982,6 +4987,14 @@
     "@yarnpkg/libzip" "^2.2.3-rc.5"
     tslib "^1.13.0"
 
+"@yarnpkg/fslib@^2.6.1-rc.7":
+  version "2.6.1-rc.7"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/fslib/-/fslib-2.6.1-rc.7.tgz#4a294b228ccaf27fdcf032cc9b9d7f151b335972"
+  integrity sha512-Cizefd9njl2mu7j0NIabaTzHuPL3dY7ow4hqZM36NcZxlcfsXeZ0krYJkgRBoy861DO65XrAbwGZuyyUdRV8tw==
+  dependencies:
+    "@yarnpkg/libzip" "^2.2.3-rc.7"
+    tslib "^1.13.0"
+
 "@yarnpkg/libzip@2.2.3-rc.5", "@yarnpkg/libzip@^2.2.3-rc.5":
   version "2.2.3-rc.5"
   resolved "https://registry.yarnpkg.com/@yarnpkg/libzip/-/libzip-2.2.3-rc.5.tgz#2de9e361e64d6e646a685f711f34633f5c751770"
@@ -4989,6 +5002,22 @@
   dependencies:
     "@types/emscripten" "^1.38.0"
     tslib "^1.13.0"
+
+"@yarnpkg/libzip@^2.2.3-rc.7":
+  version "2.2.3-rc.7"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/libzip/-/libzip-2.2.3-rc.7.tgz#30930f7729e91ef981f24813c222e8472a5b8b85"
+  integrity sha512-pVJjXi9bhGepcoeVZKfL51RIV7XKIYMGCHahry62T7pvT8a9jIGqU/JRaJh8XWChNVkKfexAysq6Ho+hXRPR/g==
+  dependencies:
+    "@types/emscripten" "^1.38.0"
+    tslib "^1.13.0"
+
+"@yarnpkg/pnp@^3.1.1-rc.12":
+  version "3.1.1-rc.12"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/pnp/-/pnp-3.1.1-rc.12.tgz#dbad80c7931b58317ddd0609d62171c25f487809"
+  integrity sha512-/g1of0OViM3HA8KHD6k+dhYnHuCItpXUdPo7o7cwyOqomD1PaD4Xr0Cr7GMV89d9Vg9+QKxCJY+j0RYyDR5qzA==
+  dependencies:
+    "@types/node" "^13.7.0"
+    "@yarnpkg/fslib" "^2.6.1-rc.7"
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
## What it does
This calls `pnp.setup()` so that it can patch the node `require` so that we can load the `@nrwl/workspace` package from yarn 2+