### PR TITLE
fix: affected commands no longer clear flags first time through

### DIFF
--- a/libs/vscode/tasks/src/lib/nx-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/nx-task-commands.ts
@@ -252,21 +252,7 @@ async function promptForAffectedFlags(target: string) {
   const telemetry = getTelemetry();
   telemetry.featureUsed('affected-cli');
 
-  let positional: string | undefined;
-  let command: string;
-
-  switch (target) {
-    case 'apps':
-    case 'libs':
-    case 'dep-graph':
-      command = `affected:${target}`;
-      break;
-    default:
-      command = 'affected';
-      positional = `--target=${target}`;
-      await selectFlags(`affected ${positional}`, AFFECTED_OPTIONS, 'nx');
-  }
-  const flags = await selectFlags(command, AFFECTED_OPTIONS, 'nx');
+  const { positional, command, flags } = await selectAffectedFlags(target);
 
   if (flags !== undefined) {
     const task = NxTask.create(
@@ -278,6 +264,39 @@ async function promptForAffectedFlags(target: string) {
       cliTaskProvider.getWorkspacePath()
     );
     tasks.executeTask(task);
+  }
+}
+
+/**
+ *
+ */
+async function selectAffectedFlags(target: string): Promise<{
+  command: string;
+  flags: string[] | undefined;
+  positional?: string;
+}> {
+  switch (target) {
+    case 'apps':
+    case 'libs':
+    case 'dep-graph': {
+      const command = `affected:${target}`;
+      return {
+        command,
+        flags: await selectFlags(command, AFFECTED_OPTIONS, 'nx'),
+      };
+    }
+    default: {
+      const positional = `--target=${target}`;
+      return {
+        command: 'affected',
+        positional,
+        flags: await selectFlags(
+          `affected ${positional}`,
+          AFFECTED_OPTIONS,
+          'nx'
+        ),
+      };
+    }
   }
 }
 

--- a/libs/vscode/tasks/src/lib/select-flags.ts
+++ b/libs/vscode/tasks/src/lib/select-flags.ts
@@ -2,6 +2,11 @@ import { Option } from '@nx-console/schema';
 import { QuickPickItem, window } from 'vscode';
 import { CliTaskFlagQuickPickItem } from './cli-task-flag-quick-pick-item';
 
+/**
+ * Returns undefined if the user wants to cancel the command.
+ * Returns an empty array to run the command without flags.
+ * Returns an array populated with flags if the user provides them.
+ */
 export async function selectFlags(
   command: string,
   options: Option[],
@@ -83,7 +88,7 @@ function promptForFlagValue(flagToSet: CliTaskFlagQuickPickItem) {
   } else if (flagToSet.option.enum && flagToSet.option.enum.length) {
     return window.showQuickPick([...flagToSet.option.enum.map(String)], {
       placeHolder,
-      canPickMany: flagToSet.option.type === 'array'
+      canPickMany: flagToSet.option.type === 'array',
     });
   } else {
     return window.showInputBox({


### PR DESCRIPTION
Fixed issue where the first time we prompted users for flags after the user selects flags for affected commands via the quick pick.

Fixes: #1191