### PR TITLE
feat: making the contents of the run target view match the workspace

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -73,9 +73,7 @@ export async function activate(c: ExtensionContext) {
     GlobalConfigurationStore.fromContext(context);
     WorkspaceConfigurationStore.fromContext(context);
 
-    currentRunTargetTreeProvider = new RunTargetTreeProvider(
-      context.extensionPath
-    );
+    currentRunTargetTreeProvider = new RunTargetTreeProvider(context);
 
     initTelemetry(GlobalConfigurationStore.instance, environment.production);
 
@@ -320,6 +318,7 @@ function registerWorkspaceFileWatcher(
     new RelativePattern(workspaceDir, '**/{workspace,angular,project}.json'),
     () => {
       commands.executeCommand('nxConsole.refreshNxProjectsTree');
+      commands.executeCommand('nxConsole.refreshRunTargetTree');
     }
   );
 

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.ts
@@ -3,22 +3,21 @@ import {
   WORKSPACE_GENERATOR_NAME_REGEX,
 } from '@nx-console/schema';
 
-export const formatTask = (architect: TaskExecutionSchema, configuration?: string): string => {
-  const positionals = architect.positional?.match(
-    WORKSPACE_GENERATOR_NAME_REGEX
-  );
-  if (architect.command === 'generate' && positionals && positionals.length) {
-    architect = {
-      ...architect,
-      cliName: 'nx',
-      command: `workspace-${positionals[1]}`,
-      positional: positionals[2],
-    };
-  }
+export const formatTask = (
+  architect: TaskExecutionSchema,
+  configuration?: string
+): string => {
+  architect = handleWorkspaceGenerators(architect);
 
-  return configuration
-    ? `${architect.cliName} ${architect.command} ${architect.positional} ${getConfigurationFlag(configuration)}`
-    : `${architect.cliName} ${architect.command} ${architect.positional}`;
+  const commandBuilder = [
+    architect.cliName,
+    surroundWithQuotesIfHasWhiteSpace(architect.command),
+    surroundWithQuotesIfHasWhiteSpace(architect.positional),
+  ];
+  if (configuration) {
+    commandBuilder.push(getConfigurationFlag(configuration));
+  }
+  return commandBuilder.join(' ');
 };
 
 export const getConfigurationFlag = (configuration?: string): string => {
@@ -29,4 +28,33 @@ export const getConfigurationFlag = (configuration?: string): string => {
   } else {
     return `-c=${configuration}`;
   }
+};
+
+function handleWorkspaceGenerators(
+  architect: TaskExecutionSchema
+): TaskExecutionSchema {
+  const positionals = architect.positional?.match(
+    WORKSPACE_GENERATOR_NAME_REGEX
+  );
+  let newArchitect = { ...architect };
+  if (
+    newArchitect.command === 'generate' &&
+    positionals &&
+    positionals.length
+  ) {
+    newArchitect = {
+      ...architect,
+      cliName: 'nx',
+      command: `workspace-${positionals[1]}`,
+      positional: positionals[2],
+    };
+  }
+  return newArchitect;
+}
+
+function surroundWithQuotesIfHasWhiteSpace(target: string): string {
+  if (target.match(/\s/g)) {
+    return `"${target}"`;
+  }
+  return target;
 }

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -403,8 +403,8 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
     }
 
     window.vscode.postMessage({
-      command: architect.command,
-      positional: architect.positional,
+      command: surroundWithQuotesIfHasWhiteSpace(architect.command),
+      positional: surroundWithQuotesIfHasWhiteSpace(architect.positional),
       flags,
     });
   }
@@ -512,4 +512,11 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
 function sanitizeWhitespace(value: string) {
   const trimmed = value.trim();
   return /\s/.test(trimmed) ? `'${trimmed}'` : trimmed; // NOTE: We use ' rather than " for powershell compatibility
+}
+
+function surroundWithQuotesIfHasWhiteSpace(target: string): string {
+  if (target.match(/\s/g)) {
+    return `"${target}"`;
+  }
+  return target;
 }

--- a/libs/vscode/nx-run-target-view/src/lib/run-target-tree-item.ts
+++ b/libs/vscode/nx-run-target-view/src/lib/run-target-tree-item.ts
@@ -3,27 +3,14 @@ import { verifyWorkspace } from '@nx-console/vscode/nx-workspace';
 import { join } from 'path';
 import { TreeItem, TreeItemCollapsibleState, TreeView, Uri } from 'vscode';
 
-export type WorkspaceRouteTitle = string;
-
 const LIGHT_SVG_URL = 'nx-cli-light.svg';
 const DARK_SVG_URL = 'nx-cli-dark.svg';
 
-export const routeList = async (): Promise<WorkspaceRouteTitle[]> => {
-  const defaultCommands = ['Generate', 'Run'];
+export const commandList = async (): Promise<string[]> => {
+  const defaultCommands = ['generate', 'run'];
   const workspaceSpecificTargetNames = await getTargetNames();
-  return [...defaultCommands, ...workspaceSpecificTargetNames.map(titleCase)];
+  return [...defaultCommands, ...workspaceSpecificTargetNames];
 };
-
-function titleCase(target: string): string {
-  return target.split(' ').map(singleWordTitleCase).join(' ');
-}
-
-function singleWordTitleCase(target: string) {
-  if (target.length) {
-    return `${target[0].toUpperCase()}${target.slice(1)}`;
-  }
-  return target;
-}
 
 export class RunTargetTreeItem extends TreeItem {
   revealWorkspaceRoute(currentWorkspace: TreeView<RunTargetTreeItem>) {
@@ -57,11 +44,11 @@ export class RunTargetTreeItem extends TreeItem {
 
   iconPath = RunTargetTreeItem.getIconUriForRoute(this.extensionPath);
 
-  label: WorkspaceRouteTitle;
+  label: string;
 
   constructor(
     readonly configurationFilePath: string,
-    readonly route: WorkspaceRouteTitle,
+    readonly route: string,
     readonly extensionPath: string,
     readonly generatorType?: GeneratorType
   ) {

--- a/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
+++ b/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
@@ -1,9 +1,8 @@
-import { commands, ExtensionContext, TreeItem } from 'vscode';
-
 import { AbstractTreeProvider, clearJsonCache } from '@nx-console/server';
-import { routeList, RunTargetTreeItem } from './run-target-tree-item';
-import { dirname, join } from 'path';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
+import { join } from 'path';
+import { commands, ExtensionContext, TreeItem } from 'vscode';
+import { commandList, RunTargetTreeItem } from './run-target-tree-item';
 
 const SCANNING_FOR_WORKSPACE = new TreeItem(
   'Scanning for your Nx Workspace...'
@@ -78,9 +77,9 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
     CHANGE_WORKSPACE.description = 'Current: ' + workspacePath;
 
     return [
-      ...(await routeList()).map(
-        (route) =>
-          new RunTargetTreeItem(workspacePath, route, this.extensionPath)
+      ...(await commandList()).map(
+        (command) =>
+          new RunTargetTreeItem(workspacePath, command, this.extensionPath)
       ),
       CHANGE_WORKSPACE,
     ];

--- a/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
+++ b/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
@@ -1,7 +1,7 @@
-import { TreeItem } from 'vscode';
+import { commands, ExtensionContext, TreeItem } from 'vscode';
 
-import { AbstractTreeProvider } from '@nx-console/server';
-import { ROUTE_LIST, RunTargetTreeItem } from './run-target-tree-item';
+import { AbstractTreeProvider, clearJsonCache } from '@nx-console/server';
+import { routeList, RunTargetTreeItem } from './run-target-tree-item';
 import { dirname, join } from 'path';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
 
@@ -27,12 +27,15 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
   private scanning = Boolean(
     WorkspaceConfigurationStore.instance.get('nxWorkspacePath', '')
   );
+  private extensionPath: string;
 
   /**
    * Provides data for the "Generate & Run Target" view
    */
-  constructor(readonly extensionPath: string) {
+  constructor(readonly context: ExtensionContext) {
     super();
+    const extensionPath = context.extensionPath;
+    this.extensionPath = extensionPath;
     LOCATE_YOUR_WORKSPACE.iconPath = {
       light: join(extensionPath, 'assets', 'nx-console-light.svg'),
       dark: join(extensionPath, 'assets', 'nx-console-dark.svg'),
@@ -41,6 +44,12 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
       light: join(extensionPath, 'assets', 'nx-console-light.svg'),
       dark: join(extensionPath, 'assets', 'nx-console-dark.svg'),
     };
+    context.subscriptions.push(
+      commands.registerCommand(
+        `nxConsole.refreshRunTargetTree`,
+        this.refreshRunTargetTree
+      )
+    );
   }
 
   getParent() {
@@ -52,7 +61,7 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
     this.refresh();
   }
 
-  getChildren() {
+  async getChildren() {
     const workspacePath = WorkspaceConfigurationStore.instance.get(
       'nxWorkspacePath',
       ''
@@ -69,11 +78,21 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
     CHANGE_WORKSPACE.description = 'Current: ' + workspacePath;
 
     return [
-      ...ROUTE_LIST.map(
+      ...(await routeList()).map(
         (route) =>
           new RunTargetTreeItem(workspacePath, route, this.extensionPath)
       ),
       CHANGE_WORKSPACE,
     ];
   }
+
+  private refreshRunTargetTree = async () => {
+    const workspacePath = WorkspaceConfigurationStore.instance.get(
+      'nxWorkspacePath',
+      ''
+    );
+    clearJsonCache(workspacePath);
+
+    this.refresh();
+  };
 }

--- a/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
+++ b/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
@@ -16,7 +16,7 @@ export async function revealNxProject(
   );
   const projectPath = buildProjectPath(workspacePath, root);
   const workspaceJsonPath = join(workspacePath, 'workspace.json');
-  const angularJsonPath = join(workspacePath, '');
+  const angularJsonPath = join(workspacePath, 'angular.json');
 
   let path = workspacePath;
   if (await fileExists(projectPath)) {

--- a/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
+++ b/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
@@ -16,7 +16,7 @@ export async function revealNxProject(
   );
   const projectPath = buildProjectPath(workspacePath, root);
   const workspaceJsonPath = join(workspacePath, 'workspace.json');
-  const angularJsonPath = join(workspacePath, 'angular.json');
+  const angularJsonPath = join(workspacePath, '');
 
   let path = workspacePath;
   if (await fileExists(projectPath)) {

--- a/libs/vscode/tasks/src/lib/cli-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-commands.ts
@@ -2,10 +2,7 @@ import { commands, ExtensionContext, window, Uri } from 'vscode';
 
 import { verifyWorkspace } from '@nx-console/vscode/nx-workspace';
 import { verifyBuilderDefinition } from '@nx-console/vscode/verify';
-import {
-  WorkspaceRouteTitle,
-  RunTargetTreeItem,
-} from '@nx-console/vscode/nx-run-target-view';
+import { RunTargetTreeItem } from '@nx-console/vscode/nx-run-target-view';
 import { CliTaskProvider } from './cli-task-provider';
 import { CliTaskQuickPickItem } from './cli-task-quick-pick-item';
 import { selectFlags } from './select-flags';
@@ -137,7 +134,7 @@ async function selectCliCommandAndShowUi(
   }
   const workspaceTreeItem = new RunTargetTreeItem(
     configurationFilePath,
-    `${command[0].toUpperCase()}${command.slice(1)}` as WorkspaceRouteTitle,
+    `${command[0].toUpperCase()}${command.slice(1)}`,
     extensionPath,
     generatorType
   );
@@ -219,7 +216,9 @@ async function selectCliCommandAndPromptForFlags(
 
     flags = await selectFlags(
       isRunCommand
-        ? `${command} ${projectName}:${target}`
+        ? `${command} ${projectName}:${surroundWithQuotesIfHasWhiteSpace(
+            target
+          )}`
         : `${command} ${projectName}`,
       options,
       workspaceType
@@ -228,11 +227,20 @@ async function selectCliCommandAndPromptForFlags(
 
   if (flags !== undefined) {
     cliTaskProvider.executeTask({
-      positional: isRunCommand ? `${projectName}:${target}` : projectName,
+      positional: isRunCommand
+        ? `${projectName}:${surroundWithQuotesIfHasWhiteSpace(target)}`
+        : projectName,
       command,
       flags,
     });
   }
+}
+
+function surroundWithQuotesIfHasWhiteSpace(target: string): string {
+  if (target.match(/\s/g)) {
+    return `"${target}"`;
+  }
+  return target;
 }
 
 async function selectGeneratorAndPromptForFlags() {

--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -33,36 +33,6 @@ export async function getTaskExecutionSchema(
 
     const command = workspaceRouteTitle.toLowerCase();
     switch (workspaceRouteTitle) {
-      case 'Build':
-      case 'E2E':
-      case 'Lint':
-      case 'Serve':
-      case 'Test': {
-        const selectedProject = await selectCliProject(command, json);
-
-        if (!selectedProject) return;
-
-        const { validBuilder, options } = await verifyBuilderDefinition(
-          selectedProject.projectName,
-          command,
-          json
-        );
-        if (!validBuilder) {
-          return;
-        }
-        return {
-          // TODO: Verify architect package is in node_modules
-          ...readTargetDef(
-            command,
-            selectedProject.targetDef,
-            selectedProject.projectName
-          ),
-          options,
-          positional: selectedProject.projectName,
-          command,
-          cliName: workspaceType,
-        };
-      }
       case 'Run': {
         const runnableItems = (await cliTaskProvider.getProjectEntries())
           .filter(([, { targets }]) => Boolean(targets))
@@ -152,6 +122,37 @@ export async function getTaskExecutionSchema(
           : undefined;
 
         return { ...generator, cliName: workspaceType, contextValues };
+      }
+      case 'Build':
+      case 'E2E':
+      case 'Lint':
+      case 'Serve':
+      case 'Test':
+      default: {
+        const selectedProject = await selectCliProject(command, json);
+
+        if (!selectedProject) return;
+
+        const { validBuilder, options } = await verifyBuilderDefinition(
+          selectedProject.projectName,
+          command,
+          json
+        );
+        if (!validBuilder) {
+          return;
+        }
+        return {
+          // TODO: Verify architect package is in node_modules
+          ...readTargetDef(
+            command,
+            selectedProject.targetDef,
+            selectedProject.projectName
+          ),
+          options,
+          positional: selectedProject.projectName,
+          command,
+          cliName: workspaceType,
+        };
       }
     }
   } catch (e) {

--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -7,7 +7,6 @@ import {
 import { getNxConfig, verifyWorkspace } from '@nx-console/vscode/nx-workspace';
 import { verifyBuilderDefinition } from '@nx-console/vscode/verify';
 import { Uri, window } from 'vscode';
-import { WorkspaceRouteTitle } from '@nx-console/vscode/nx-run-target-view';
 import {
   CliTaskProvider,
   CliTaskQuickPickItem,
@@ -17,7 +16,7 @@ import {
 
 export async function getTaskExecutionSchema(
   cliTaskProvider: CliTaskProvider,
-  workspaceRouteTitle: WorkspaceRouteTitle = 'Run',
+  command = 'run',
   contextMenuUri?: Uri,
   generatorType?: GeneratorType
 ): Promise<TaskExecutionSchema | void> {
@@ -31,9 +30,8 @@ export async function getTaskExecutionSchema(
       return;
     }
 
-    const command = workspaceRouteTitle.toLowerCase();
-    switch (workspaceRouteTitle) {
-      case 'Run': {
+    switch (command) {
+      case 'run': {
         const runnableItems = (await cliTaskProvider.getProjectEntries())
           .filter(([, { targets }]) => Boolean(targets))
           .flatMap(([project, { targets, root }]) => ({
@@ -87,7 +85,7 @@ export async function getTaskExecutionSchema(
           };
         });
       }
-      case 'Generate': {
+      case 'generate': {
         const generator = await selectGenerator(
           cliTaskProvider.getWorkspacePath(),
           workspaceType,
@@ -123,11 +121,6 @@ export async function getTaskExecutionSchema(
 
         return { ...generator, cliName: workspaceType, contextValues };
       }
-      case 'Build':
-      case 'E2E':
-      case 'Lint':
-      case 'Serve':
-      case 'Test':
       default: {
         const selectedProject = await selectCliProject(command, json);
 


### PR DESCRIPTION
## What it does:

+ Makes the "Generate & Run Target" view list all (and only) targets that you support in your workspace
  + (Generate and Run targets are still there)
+ Makes this pane update on changes to workspace configuration (on save)