### PR TITLE
fix: make sure to read schemas from both builders and executors for builder

### DIFF
--- a/libs/server/src/lib/utils/read-projects.ts
+++ b/libs/server/src/lib/utils/read-projects.ts
@@ -79,8 +79,10 @@ export async function readBuilderSchema(
       path.dirname(packageJson.path)
     );
 
-    const builderDef = (buildersJson.json.builders ||
-      buildersJson.json.executors)[builderName];
+    const builderDef = {
+      ...buildersJson.json.builders,
+      ...buildersJson.json.executors,
+    }[builderName];
     const builderSchema = await readAndCacheJsonFile(
       builderDef.schema,
       path.dirname(buildersJson.path)


### PR DESCRIPTION
## What it does
Make sure to read both the builder and executor schema's

Fixes #1251
