### PR TITLE
fix: check if dependency path type is directory with bit flag

### DIFF
--- a/libs/npm/src/lib/workspace-dependencies.spec.ts
+++ b/libs/npm/src/lib/workspace-dependencies.spec.ts
@@ -1,4 +1,7 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 import { PartialDeep } from 'type-fest';
+import { mocked } from 'ts-jest/utils';
 
 import { workspaceDependencyPath } from './workspace-dependencies';
 
@@ -12,32 +15,33 @@ jest.mock(
     ),
   })
 );
-const mockedPnpDependencies = pnpDependencies as jest.Mocked<
-  typeof pnpDependencies
->;
+const mockedPnpDependencies = mocked(pnpDependencies);
 
 import * as vscode from 'vscode';
 jest.mock('vscode', (): PartialDeep<typeof vscode> => {
   return {
     FileType: {
       Directory: 2,
+      SymbolicLink: 64,
     },
     Uri: {
       file: jest.fn((path) => path as any),
     },
     workspace: {
       fs: {
-        stat: () =>
+        stat: jest.fn(() =>
           Promise.resolve({
             ctime: 0,
             mtime: 0,
             size: 0,
             type: 2,
-          }),
+          })
+        ),
       },
     },
   };
 });
+const mockedVsCode = mocked(vscode, true);
 
 describe('workspace-dependencies path', () => {
   it('should return a path to a workspace dependency when using node_modules', async () => {
@@ -70,6 +74,25 @@ describe('workspace-dependencies path', () => {
     );
     expect(dependencyPath).toMatchInlineSnapshot(
       `"/workspace/tools/local/executor"`
+    );
+  });
+
+  it('should support symbolic directory links', async () => {
+    mockedVsCode.workspace.fs.stat.mockImplementationOnce(() => {
+      return Promise.resolve({
+        ctime: 0,
+        mtime: 0,
+        size: 0,
+        type: 66,
+      });
+    });
+
+    const dependencyPath = await workspaceDependencyPath(
+      '/workspace',
+      '@nrwl/nx'
+    );
+    expect(dependencyPath).toMatchInlineSnapshot(
+      `"/workspace/node_modules/@nrwl/nx"`
     );
   });
 });

--- a/libs/npm/src/lib/workspace-dependencies.spec.ts
+++ b/libs/npm/src/lib/workspace-dependencies.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 import { PartialDeep } from 'type-fest';
 import { mocked } from 'ts-jest/utils';
 

--- a/libs/npm/src/lib/workspace-dependencies.ts
+++ b/libs/npm/src/lib/workspace-dependencies.ts
@@ -39,7 +39,8 @@ export async function workspaceDependencyPath(
 
   const path = join(workspacePath, 'node_modules', workspaceDependencyName);
   try {
-    return (await workspace.fs.stat(Uri.file(path))).type === FileType.Directory
+    const fileType = (await workspace.fs.stat(Uri.file(path))).type;
+    return (fileType & FileType.Directory) === FileType.Directory
       ? path
       : undefined;
   } catch {

--- a/libs/npm/src/lib/workspace-dependencies.ts
+++ b/libs/npm/src/lib/workspace-dependencies.ts
@@ -39,8 +39,8 @@ export async function workspaceDependencyPath(
 
   const path = join(workspacePath, 'node_modules', workspaceDependencyName);
   try {
-    const fileType = (await workspace.fs.stat(Uri.file(path))).type;
-    return (fileType & FileType.Directory) === FileType.Directory
+    const directoryType = (await workspace.fs.stat(Uri.file(path))).type;
+    return (directoryType & FileType.Directory) === FileType.Directory
       ? path
       : undefined;
   } catch {


### PR DESCRIPTION
## What it does
This checks to make sure that the fileType is checking with the bit flag. VSCode shows that the `type` can be both a directory or a symbolic link. And we need to make sure we check for both instances
