### PR TITLE
fix: properly check positional argument for generating with UI

### DIFF
--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -24,6 +24,7 @@ export interface Option extends CliOption {
   items?: string[] | ItemsWithEnum;
   aliases: string[];
   isRequired: boolean;
+  'x-dropdown'?: 'projects';
 }
 
 export interface ItemTooltips {

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/task-execution-form.component.ts
@@ -463,7 +463,10 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
     architect: TaskExecutionSchema,
     configurationName?: string
   ): string[] {
-    const fields = architect.options.filter((s) => value[s.name]);
+    const fields = architect.options
+      .filter((s) => value[s.name])
+      .sort((a, b) => (a?.positional ?? 0) - (b?.positional ?? 0));
+
     const defaultValues = this.getDefaultValuesForConfiguration(
       architect,
       configurationName
@@ -480,7 +483,7 @@ export class TaskExecutionFormComponent implements OnInit, AfterViewChecked {
       )
         return;
 
-      if (f.positional) {
+      if (f.positional !== undefined && typeof f.positional === 'number') {
         args.add(sanitizeWhitespace(value[f.name]));
       } else if (f.type === OptionType.Boolean) {
         args.add(value[f.name] === 'false' ? `--no-${f.name}` : `--${f.name}`);

--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -217,6 +217,7 @@ function isProjectOption(option: Option) {
   return (
     option.name === 'project' ||
     option.name === 'projectName' ||
-    (option.$default && option.$default.$source === 'projectName')
+    option.$default?.$source === 'projectName' ||
+    option['x-dropdown'] === 'projects'
   );
 }


### PR DESCRIPTION
## What it does
This makes sure that positionals are properly checked. Since positionals start at `0`, JavaScript is very kind and thinks that 0 is false. So Nx Console never thought that positional 0 was valid. This caused issues with some schemas that had multiple positionals because then arguments went out of order.

This also includes a check for `x-dropdown` to see if `projects` is specified. This will allow Nx Console to display this property with the project dropdown/autocomplete. 

Fixes #1261
