### PR TITLE
fix: sort properties by required

### DIFF
--- a/libs/server/src/lib/utils/utils.spec.ts
+++ b/libs/server/src/lib/utils/utils.spec.ts
@@ -52,6 +52,28 @@ describe('utils', () => {
       expect(r.map((x) => x.name)).toEqual(['a', 'c', 'b']);
     });
 
+    it('should sort required arguments', async () => {
+      const r = await normalizeSchema({
+        properties: {
+          a: { $default: { $source: 'argv', index: 1 } },
+          b: {},
+          c: {},
+          d: { $default: { $source: 'argv', index: 0 } },
+          e: {},
+        },
+        required: ['c', 'e'],
+      });
+      expect(r.map((x) => x.name)).toMatchInlineSnapshot(`
+        Array [
+          "d",
+          "a",
+          "c",
+          "e",
+          "b",
+        ]
+      `);
+    });
+
     it('should set items when enum is provided', async () => {
       const option = {
         ...mockOption,

--- a/libs/server/src/lib/utils/utils.ts
+++ b/libs/server/src/lib/utils/utils.ts
@@ -223,12 +223,12 @@ export async function normalizeSchema(
       return -1;
     } else if (typeof b.positional === 'number') {
       return 1;
-    } else if (a.required) {
-      if (b.required) {
+    } else if (a.isRequired) {
+      if (b.isRequired) {
         return a.name.localeCompare(b.name);
       }
       return -1;
-    } else if (b.required) {
+    } else if (b.isRequired) {
       return 1;
     } else if (IMPORTANT_FIELDS_SET.has(a.name)) {
       if (IMPORTANT_FIELDS_SET.has(b.name)) {


### PR DESCRIPTION
## What it does
This makes sure that required properties are sorted near the top of the list (there are still some properties that are more important)

Fixes #1265
