### PR TITLE
fix: always use full `--configuration` flag

### DIFF
--- a/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.pipe.spec.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.pipe.spec.ts
@@ -38,14 +38,17 @@ describe('FormatTaskPipe', () => {
 
   it('should optionally include configuration flag', () => {
     expect(
-      pipe.transform({
-        name: '',
-        cliName: 'nx',
-        description: '',
-        options: [],
-        command: 'build',
-        positional: 'the-project',
-      }, 'production')
-    ).toEqual('nx build the-project --prod');
-  })
+      pipe.transform(
+        {
+          name: '',
+          cliName: 'nx',
+          description: '',
+          options: [],
+          command: 'build',
+          positional: 'the-project',
+        },
+        'production'
+      )
+    ).toEqual('nx build the-project --configuration production');
+  });
 });

--- a/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.ts
+++ b/libs/vscode-ui/feature-task-execution-form/src/lib/format-task/format-task.ts
@@ -23,10 +23,8 @@ export const formatTask = (
 export const getConfigurationFlag = (configuration?: string): string => {
   if (!configuration || !configuration.length) {
     return '';
-  } else if (configuration === 'production') {
-    return '--prod';
   } else {
-    return `-c=${configuration}`;
+    return `--configuration ${configuration}`;
   }
 };
 


### PR DESCRIPTION
## What it does
In certain versions of Angular CLI using the short form `--prod` does not work. This changes that so that all configurations are not short cutted and instead use the full configuration name. 

Fixes #1281
