### PR TITLE
feat: support package.json projects

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -115,7 +115,8 @@ export async function activate(c: ExtensionContext) {
       manuallySelectWorkspaceDefinitionCommand
     );
 
-    // registers itself as a CodeLensProvider and watches config to dispose/re-register
+    //   registers itself as a CodeLensProvider and watches config to dispose/re-register
+
     const { WorkspaceCodeLensProvider } = await import(
       '@nx-console/vscode/nx-workspace'
     );
@@ -203,12 +204,16 @@ async function setWorkspace(workspacePath: string) {
   }
 
   WorkspaceConfigurationStore.instance.set('nxWorkspacePath', workspacePath);
-  const { verifyWorkspace } = await import('@nx-console/vscode/nx-workspace');
 
-  const { validWorkspaceJson } = await verifyWorkspace();
-  if (!validWorkspaceJson) {
-    return;
-  }
+  // Set the NX_WORKSPACE_ROOT_PATH as soon as possible so that the nx utils can get this.
+  process.env.NX_WORKSPACE_ROOT_PATH = workspacePath;
+
+  // const { verifyWorkspace } = await import('@nx-console/vscode/nx-workspace');
+
+  // const { validWorkspaceJson } = await verifyWorkspace();
+  // if (!validWorkspaceJson) {
+  //   return;
+  // // }
 
   if (!cliTaskProvider) {
     cliTaskProvider = new CliTaskProvider();

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -25,6 +25,7 @@ import {
   teardownTelemetry,
   watchFile,
   fileExists,
+  checkIsNxWorkspace,
 } from '@nx-console/server';
 import {
   GlobalConfigurationStore,
@@ -194,6 +195,9 @@ async function scanForWorkspace(vscodeWorkspacePath: string) {
     if (await fileExists(join(currentDirectory, 'nx.json'))) {
       return setWorkspace(currentDirectory);
     }
+    if (await fileExists(join(currentDirectory, 'lerna.json'))) {
+      return setWorkspace(currentDirectory);
+    }
     currentDirectory = dirname(currentDirectory);
   }
 }
@@ -242,7 +246,7 @@ async function setWorkspace(workspacePath: string) {
 
   setApplicationAndLibraryContext(workspacePath);
 
-  const isNxWorkspace = existsSync(join(workspacePath, 'nx.json'));
+  const isNxWorkspace = await checkIsNxWorkspace(workspacePath);
   const isAngularWorkspace = existsSync(join(workspacePath, 'angular.json'));
 
   commands.executeCommand(

--- a/libs/server/src/index.ts
+++ b/libs/server/src/index.ts
@@ -19,3 +19,4 @@ export { watchFile } from './lib/utils/watch-file';
 export { buildProjectPath } from './lib/utils/build-project-path';
 export { findConfig } from './lib/utils/find-config';
 export { getShellExecutionForConfig } from './lib/utils/shell-execution';
+export { checkIsNxWorkspace } from './lib/check-is-nx-workspace';

--- a/libs/server/src/lib/check-is-nx-workspace.ts
+++ b/libs/server/src/lib/check-is-nx-workspace.ts
@@ -1,0 +1,15 @@
+import { join } from 'path';
+import { fileExists, readAndCacheJsonFile } from './utils/utils';
+
+export async function checkIsNxWorkspace(
+  workspacePath: string
+): Promise<boolean> {
+  let isNxWorkspace = await fileExists(join(workspacePath, 'nx.json'));
+
+  if (!isNxWorkspace) {
+    const lerna = await readAndCacheJsonFile('lerna.json', workspacePath);
+    isNxWorkspace = lerna.json.useNx ?? false;
+  }
+
+  return isNxWorkspace;
+}

--- a/libs/server/src/lib/utils/build-project-path.ts
+++ b/libs/server/src/lib/utils/build-project-path.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { fileExists } from './utils';
 
 /**
  * Builds the project path from the given project name.
@@ -6,9 +7,17 @@ import { join } from 'path';
  * @param projectPath The path to the project relative to the workspace
  * @returns The full path to the project.json file
  */
-export function buildProjectPath(
+export async function buildProjectPath(
   workspacePath: string,
   projectPath: string
-): string {
-  return join(workspacePath, projectPath, 'project.json');
+): Promise<string | undefined> {
+  const basePath = join(workspacePath, projectPath);
+
+  const projectJsonPath = join(basePath, 'project.json');
+  const packageJsonPath = join(basePath, 'package.json');
+  if (await fileExists(projectJsonPath)) {
+    return projectJsonPath;
+  } else if (await fileExists(packageJsonPath)) {
+    return packageJsonPath;
+  }
 }

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
@@ -1,10 +1,14 @@
-import type {
+import {
   NxJsonConfiguration,
   WorkspaceJsonConfiguration,
+  ProjectGraph,
 } from '@nrwl/devkit';
 import { readAndCacheJsonFile } from '@nx-console/server';
 import { join } from 'path';
-import { getNxWorkspacePackageFileUtils } from './get-nx-workspace-package';
+import {
+  getNxProjectGraph,
+  getNxWorkspacePackageFileUtils,
+} from './get-nx-workspace-package';
 import { nxVersion } from './nx-version';
 
 export type NxWorkspaceConfiguration = WorkspaceJsonConfiguration &
@@ -28,18 +32,55 @@ export async function getNxWorkspaceConfig(
 }> {
   const version = nxVersion();
 
-  if (version && version < 12) {
+  if (version < 12) {
     return readWorkspaceConfigs(format, basedir);
   }
 
   try {
-    const nxWorkspacePackage = await getNxWorkspacePackageFileUtils();
+    const [nxWorkspacePackage, nxProjectGraph] = await Promise.all([
+      getNxWorkspacePackageFileUtils(),
+      getNxProjectGraph(),
+    ]);
     const configFile = nxWorkspacePackage.workspaceFileName();
-    return {
-      workspaceConfiguration: nxWorkspacePackage.readWorkspaceConfig({
+
+    let projectGraph: ProjectGraph | null = null;
+    try {
+      if (format === 'angularCli') {
+        throw 'No project graph support';
+      }
+
+      if (version < 13) {
+        projectGraph = (nxProjectGraph as any).readCurrentProjectGraph();
+      } else {
+        projectGraph = nxProjectGraph.readCachedProjectGraph();
+      }
+
+      if (!projectGraph) {
+        if (version < 13) {
+          projectGraph = (nxProjectGraph as any).createProjectGraph();
+        } else {
+          projectGraph = await nxProjectGraph.createProjectGraphAsync();
+        }
+      }
+    } catch {
+      //noop
+    }
+
+    let workspaceConfiguration: NxWorkspaceConfiguration;
+    try {
+      workspaceConfiguration = nxWorkspacePackage.readWorkspaceConfig({
         format,
         path: basedir,
-      }),
+      });
+    } catch {
+      workspaceConfiguration = (await readWorkspaceConfigs(format, basedir))
+        .workspaceConfiguration;
+    }
+
+    addProjectTargets(workspaceConfiguration, projectGraph);
+
+    return {
+      workspaceConfiguration,
       configPath: join(basedir, configFile),
     };
   } catch (e) {
@@ -77,4 +118,19 @@ async function readWorkspaceConfigs(
         ? join(basedir, 'workspace.json')
         : join(basedir, 'angular.json'),
   };
+}
+
+function addProjectTargets(
+  workspaceConfiguration: NxWorkspaceConfiguration,
+  projectGraph: ProjectGraph | null
+) {
+  if (!projectGraph) {
+    return;
+  }
+
+  for (const [projectName, configuration] of Object.entries(
+    workspaceConfiguration.projects
+  )) {
+    configuration.targets = projectGraph.nodes[projectName].data.targets;
+  }
 }

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace-config.ts
@@ -6,6 +6,10 @@ import { readAndCacheJsonFile } from '@nx-console/server';
 import { join } from 'path';
 import { getNxWorkspacePackageFileUtils } from './get-nx-workspace-package';
 import { nxVersion } from './nx-version';
+
+export type NxWorkspaceConfiguration = WorkspaceJsonConfiguration &
+  NxJsonConfiguration;
+
 /**
  * There's a couple things that we need to handle here.
  *
@@ -19,7 +23,7 @@ export async function getNxWorkspaceConfig(
   basedir: string,
   format: 'nx' | 'angularCli'
 ): Promise<{
-  workspaceConfiguration: WorkspaceJsonConfiguration & NxJsonConfiguration;
+  workspaceConfiguration: NxWorkspaceConfiguration;
   configPath: string;
 }> {
   const version = nxVersion();

--- a/libs/vscode/nx-workspace/src/lib/nx-version.ts
+++ b/libs/vscode/nx-workspace/src/lib/nx-version.ts
@@ -3,9 +3,9 @@ import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
 declare function __non_webpack_require__(importPath: string): any;
 
 let nxWorkspacePackageJson: { version: string };
-let loadedNxWorkspacePackage = false;
-export function nxVersion(): number | null {
-  if (!loadedNxWorkspacePackage) {
+let loadedNxPackage = false;
+export function nxVersion(): number {
+  if (!loadedNxPackage) {
     const workspacePath = WorkspaceConfigurationStore.instance.get(
       'nxWorkspacePath',
       ''
@@ -14,9 +14,16 @@ export function nxVersion(): number | null {
       nxWorkspacePackageJson = __non_webpack_require__(
         `${workspacePath}/node_modules/@nrwl/workspace/package.json`
       );
-      loadedNxWorkspacePackage = true;
+      loadedNxPackage = true;
     } catch (e) {
-      return null;
+      try {
+        nxWorkspacePackageJson = __non_webpack_require__(
+          `${workspacePath}/node_modules/nx/package.json`
+        );
+        loadedNxPackage = true;
+      } catch {
+        return 0;
+      }
     }
   }
 

--- a/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
+++ b/libs/vscode/nx-workspace/src/lib/reveal-workspace-json.ts
@@ -14,12 +14,12 @@ export async function revealNxProject(
     'nxWorkspacePath',
     ''
   );
-  const projectPath = buildProjectPath(workspacePath, root);
+  const projectPath = await buildProjectPath(workspacePath, root);
   const workspaceJsonPath = join(workspacePath, 'workspace.json');
   const angularJsonPath = join(workspacePath, 'angular.json');
 
   let path = workspacePath;
-  if (await fileExists(projectPath)) {
+  if (projectPath) {
     path = projectPath;
   } else if (await fileExists(workspaceJsonPath)) {
     path = workspaceJsonPath;

--- a/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/verify-workspace.ts
@@ -36,8 +36,6 @@ export async function verifyWorkspace(): Promise<Workspace> {
     isAngularWorkspace ? 'angularCli' : 'nx'
   );
 
-  await addPackageJsonTargets(workspacePath, config.workspaceConfiguration);
-
   try {
     return {
       validWorkspaceJson: true,
@@ -71,34 +69,5 @@ export async function verifyWorkspace(): Promise<Workspace> {
       configurationFilePath: '',
       workspacePath,
     };
-  }
-}
-
-/**
- * Checks to see if projects do not have a target. If they do not, then we look into the package.json and get the script options.
- * @param workspaceConfig
- */
-async function addPackageJsonTargets(
-  workspaceRoot: string,
-  workspaceConfig: NxWorkspaceConfiguration
-) {
-  for (const projectConfiguration of Object.values(workspaceConfig.projects)) {
-    if (!projectConfiguration.targets) {
-      const { json } = await readAndCacheJsonFile(
-        join(projectConfiguration.root, 'package.json'),
-        workspaceRoot
-      );
-
-      if (json.scripts) {
-        for (const script of Object.keys(json.scripts)) {
-          projectConfiguration.targets ??= {};
-          projectConfiguration.targets[script] = {
-            executor: '@nrwl/nx',
-          };
-        }
-      }
-    } else {
-      continue;
-    }
   }
 }

--- a/libs/vscode/nx-workspace/src/lib/workspace-codelens-provider.ts
+++ b/libs/vscode/nx-workspace/src/lib/workspace-codelens-provider.ts
@@ -113,7 +113,7 @@ export class WorkspaceCodeLensProvider implements CodeLensProvider {
     }
     return lens;
   }
-  buildProjectLenses(
+  async buildProjectLenses(
     project: ProjectLocations[string],
     document: TextDocument,
     lens: CodeLens[],
@@ -128,7 +128,7 @@ export class WorkspaceCodeLensProvider implements CodeLensProvider {
       new ProjectCodeLens(
         new Range(position, position),
         projectName,
-        buildProjectPath(workspacePath, project.projectPath)
+        (await buildProjectPath(workspacePath, project.projectPath)) ?? ''
       )
     );
   }

--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -1,5 +1,7 @@
-import { fileExists, getShellExecutionForConfig } from '@nx-console/server';
-import { join } from 'path';
+import {
+  checkIsNxWorkspace,
+  getShellExecutionForConfig,
+} from '@nx-console/server';
 import { Task, TaskGroup, TaskScope } from 'vscode';
 import { CliTaskDefinition } from './cli-task-definition';
 
@@ -14,7 +16,7 @@ export class CliTask extends Task {
     // versions of CLI does not handle `[command] [project]` args.
     const args = getArgs(definition);
 
-    const useNxCli = await fileExists(join(workspacePath, 'nx.json'));
+    const useNxCli = await checkIsNxWorkspace(workspacePath);
 
     const displayCommand = useNxCli
       ? `nx ${args.join(' ')}`

--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -197,8 +197,8 @@ async function getConfigValuesFromContextMenuUri(
       .replace(/\\/g, '/')
       .replace(/^\//, '');
     const nxConfig = await getNxConfig(workspacePath);
-    const appsDir = nxConfig.workspaceLayout?.appsDir ?? 'apps';
-    const libsDir = nxConfig.workspaceLayout?.libsDir ?? 'libs';
+    const appsDir = nxConfig.workspaceLayout?.appsDir ?? 'packages';
+    const libsDir = nxConfig.workspaceLayout?.libsDir ?? 'packages';
     if (
       (appsDir && generator.name === 'application') ||
       generator.name === 'app'


### PR DESCRIPTION
## What it does
Uses the Nx Project graph to get the proper targets for package.json files and projects that do target inference. And because of this, we're able to support Lerna workspaces that have nx enabled with `useNx` set to true. 

Fixes #1202
Fixes #1289