### PR TITLE
fix: camel case targets not working in generate & run target pane

### DIFF
--- a/libs/vscode/webview/src/lib/get-task-execution-schema.ts
+++ b/libs/vscode/webview/src/lib/get-task-execution-schema.ts
@@ -30,8 +30,8 @@ export async function getTaskExecutionSchema(
     if (!validWorkspaceJson) {
       return;
     }
-    command = command.toLowerCase();
-    switch (command) {
+    const lowerCommand = command.toLowerCase();
+    switch (lowerCommand) {
       case 'run': {
         const runnableItems = (await cliTaskProvider.getProjectEntries())
           .filter(([, { targets }]) => Boolean(targets))


### PR DESCRIPTION
# What it does:

+ fixes camel case targets so they still work in the generate and run target pane