### PR TITLE
feat: handle ts paths imports with asterix

### DIFF
--- a/libs/server/src/index.ts
+++ b/libs/server/src/index.ts
@@ -18,5 +18,6 @@ export {
 export { watchFile } from './lib/utils/watch-file';
 export { buildProjectPath } from './lib/utils/build-project-path';
 export { findConfig } from './lib/utils/find-config';
+export { findFilesInPath } from './lib/utils/find-files-in-path';
 export { getShellExecutionForConfig } from './lib/utils/shell-execution';
 export { checkIsNxWorkspace } from './lib/check-is-nx-workspace';

--- a/libs/server/src/lib/utils/find-files-in-path.ts
+++ b/libs/server/src/lib/utils/find-files-in-path.ts
@@ -1,0 +1,43 @@
+import { join } from 'path';
+import * as vscode from 'vscode';
+
+export type FileWithDirectory = {
+  directory: string;
+  file: string;
+};
+
+async function findInNestedDirectories(
+  filesWithDirectory: FileWithDirectory[],
+  pathToCheck: string
+): Promise<void> {
+  const libUri = vscode.Uri.parse(pathToCheck);
+  try {
+    for await (const fileResult of await vscode.workspace.fs.readDirectory(
+      libUri
+    )) {
+      if (fileResult[1] === vscode.FileType.Directory) {
+        await findInNestedDirectories(
+          filesWithDirectory,
+          join(pathToCheck, fileResult[0])
+        );
+      }
+      if (fileResult[1] === vscode.FileType.File) {
+        filesWithDirectory.push({
+          file: join(pathToCheck, fileResult[0]),
+          directory: pathToCheck,
+        });
+      }
+    }
+  } catch (err) {
+    console.warn('ts path not found directory on', libUri);
+  }
+}
+
+export async function findFilesInPath(
+  pathWithAsterix: string
+): Promise<FileWithDirectory[]> {
+  const libPath = pathWithAsterix.replace('/*', '');
+  const filesWithDirectory: FileWithDirectory[] = [];
+  await findInNestedDirectories(filesWithDirectory, libPath);
+  return filesWithDirectory;
+}


### PR DESCRIPTION
`    "paths": {
      "@hehe-nx/blabla/*": ["libs/blabla/src/lib/*"],
      "@hehe-nx/bobo/roro/coco": ["libs/bobo/roro/coco/src/index.ts"]
    }`

consider this paths, currently we only handle  **"@hehe-nx/bobo/roro/coco": ["libs/bobo/roro/coco/src/index.ts"]** 
but alot of users have paths like **"@hehe-nx/blabla/*": ["libs/blabla/src/lib/*"],** so i added solution to resolved this files to have imports autocomplete