### PR TITLE
feat: add an allowlist and a blocklist for generators

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -676,11 +676,6 @@
           "default": true,
           "description": "Help make Nx Console better by sending anonymous usage data to the Nx Console team."
         },
-        "nxConsole.useNVM": {
-          "type": "boolean",
-          "default": false,
-          "description": "Runs tasks using Node Version Manager"
-        },
         "nxConsole.enableGenerateFromContextMenu": {
           "type": "boolean",
           "default": true,
@@ -695,6 +690,27 @@
           "type": "boolean",
           "default": true,
           "description": "Configures a TypeScript language server plugin to include configured libraries in root files for TypeScript projects. This allows for importing libraries into other libraries even when the import was not there before."
+        },
+        "nxConsole.enableGeneratorFilters": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enables the filter for listed generators with Nx Console."
+        },
+        "nxConsole.generatorAllowlist": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of generator names to show in the picker (can be combined with Generator Block List).\n\nThe name of the generator should be in this format: @package:generator.\n‎ ‎ ‎ ‎ ‎eamples: @nrwl/workspace:library, workspace-generator:my-generator"
+        },
+        "nxConsole.generatorBlocklist": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of generator names to hide in the picker (can be combined with Generator Allow List).\n\nThe name of the generator should be in this format: @package:generator.\n‎ ‎ ‎ ‎ ‎  examples: @nrwl/workspace:library, workspace-generator:my-generator"
         }
       }
     },

--- a/libs/vscode/configuration/src/lib/configuration-keys.ts
+++ b/libs/vscode/configuration/src/lib/configuration-keys.ts
@@ -1,9 +1,11 @@
 export const GLOBAL_CONFIG_KEYS = [
   'enableTelemetry',
-  'useNVM',
   'enableGenerateFromContextMenu',
   'enableWorkspaceConfigCodeLens',
   'enableLibraryImports',
+  'enableGeneratorFilters',
+  'generatorAllowlist',
+  'generatorBlocklist',
 ] as const;
 
 /**


### PR DESCRIPTION
## What it does
Adds new settings to enable filtering of the generator list within Nx Console. 

These settings are "nxConsole.enableGeneratorFilters", "nxConsole.generatorAllowlist", "nxConsole.generatorBlocklist".

The allow and block lists can be combined, where the allow list takes priority, then the block list is applied to the remaining items. 

Fixes #1272