### PR TITLE
chore: allow unused arguments if they are named '_'

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,12 @@
               }
             ]
           }
+        ],
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "argsIgnorePattern": "^_$"
+          }
         ]
       }
     },

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
@@ -1,13 +1,12 @@
 import { AbstractTreeProvider } from '@nx-console/utils';
-import { NxCommandsTreeItem } from './nx-commands-tree-item';
 import { ExtensionContext } from 'vscode';
+import { NxCommandsTreeItem } from './nx-commands-tree-item';
 
 export class NxCommandsTreeProvider extends AbstractTreeProvider<NxCommandsTreeItem> {
   constructor(private readonly context: ExtensionContext) {
     super();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getParent(_: NxCommandsTreeItem) {
     return null;
   }

--- a/libs/vscode/nx-help-and-feedback-view/src/lib/nx-help-and-feedback-provider.ts
+++ b/libs/vscode/nx-help-and-feedback-view/src/lib/nx-help-and-feedback-provider.ts
@@ -7,7 +7,6 @@ export class NxHelpAndFeedbackProvider extends AbstractTreeProvider<NxHelpAndFee
   constructor(private readonly context: ExtensionContext) {
     super();
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getParent(_: NxHelpAndFeedbackTreeItem) {
     return null;
   }


### PR DESCRIPTION
Some arguments have to remain unused and it's a good pattern used in nx console to name them `_`.
This PR specifically allows that instead of having to use eslint ignores.