### PR TITLE
docs: correctly document all allowed scopes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ If `nps format.check` fails, run `nps format`.
 
 ### Commit Message Guidelines
 
-Commit message should follow the following format:
+Commit message have to follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format. A basic example is this:
 
 ```
 type: subject
@@ -60,6 +60,12 @@ The type must be one of the following:
 - style
 - docs
 - test
+- chore
+- ci
+- perf
+- revert
+
+Refer to [commitizen/conventional-commit-types](https://github.com/commitizen/conventional-commit-types/blob/master/index.json) for a full explanation of each type.
 
 #### Subject
 


### PR DESCRIPTION
Hi @Cammisuli, I saw that you changed #1332 & #1334 to be "chore: ...." which I agree is the correct type here.
However, "chore" was not listed as an allowed type in `CONTRIBUTING.MD` so I added the correct types as they are validated by the `pr_title` action for clarity.