### PR TITLE
feat: add dependency functionality

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -133,6 +133,12 @@ export async function activate(c: ExtensionContext) {
       await import('@nx-console/vscode/nx-workspace');
     new WorkspaceCodeLensProvider(context);
 
+    const { AddDependencyCodelensProvider } = await import(
+      '@nx-console/vscode/add-dependency'
+    );
+
+    new AddDependencyCodelensProvider(context);
+
     NxConversion.createInstance(context);
 
     await enableTypeScriptPlugin(context);

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -50,6 +50,7 @@ import { getGenerators } from '@nx-console/shared/collections';
 import { fileExists } from '@nx-console/shared/file-system';
 import { nxVersion } from '@nx-console/shared/npm';
 import { enableTypeScriptPlugin } from '@nx-console/vscode/typescript-plugin';
+import { registerVscodeAddDependency } from '@nx-console/vscode/add-dependency';
 import { configureLspClient } from '@nx-console/vscode/lsp-client';
 import { NxConversion } from '@nx-console/vscode/nx-conversion';
 import {
@@ -225,6 +226,8 @@ async function setWorkspace(workspacePath: string) {
     tasks.registerTaskProvider('ng', cliTaskProvider);
     tasks.registerTaskProvider('nx', cliTaskProvider);
     registerCliTaskCommands(context, cliTaskProvider);
+
+    registerVscodeAddDependency(context);
 
     nxProjectsTreeProvider = new NxProjectTreeProvider(
       context,

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -50,7 +50,10 @@ import { getGenerators } from '@nx-console/shared/collections';
 import { fileExists } from '@nx-console/shared/file-system';
 import { nxVersion } from '@nx-console/shared/npm';
 import { enableTypeScriptPlugin } from '@nx-console/vscode/typescript-plugin';
-import { registerVscodeAddDependency } from '@nx-console/vscode/add-dependency';
+import {
+  AddDependencyCodelensProvider,
+  registerVscodeAddDependency,
+} from '@nx-console/vscode/add-dependency';
 import { configureLspClient } from '@nx-console/vscode/lsp-client';
 import { NxConversion } from '@nx-console/vscode/nx-conversion';
 import {
@@ -62,6 +65,7 @@ import {
   refreshWorkspace,
   REFRESH_WORKSPACE,
 } from './commands/refresh-workspace';
+import { WorkspaceCodeLensProvider } from '@nx-console/vscode/nx-workspace';
 
 let runTargetTreeView: TreeView<RunTargetTreeItem>;
 let nxProjectTreeView: TreeView<NxProjectTreeItem>;
@@ -129,13 +133,7 @@ export async function activate(c: ExtensionContext) {
 
     //   registers itself as a CodeLensProvider and watches config to dispose/re-register
 
-    const { WorkspaceCodeLensProvider: WorkspaceCodeLensProvider } =
-      await import('@nx-console/vscode/nx-workspace');
     new WorkspaceCodeLensProvider(context);
-
-    const { AddDependencyCodelensProvider } = await import(
-      '@nx-console/vscode/add-dependency'
-    );
 
     new AddDependencyCodelensProvider(context);
 

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -674,6 +674,10 @@
         "category": "Nx",
         "title": "Make ng Faster with Nx",
         "command": "nxConsole.makeNgFaster"
+      },
+      {
+        "title": "Add dependency to workspace",
+        "command": "nxConsole.addDependency"
       }
     ],
     "configuration": {

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -678,6 +678,10 @@
       {
         "title": "Add dependency to workspace",
         "command": "nxConsole.addDependency"
+      },
+      {
+        "title": "Add dev dependency to workspace",
+        "command": "nxConsole.addDevDependency"
       }
     ],
     "configuration": {

--- a/libs/shared/collections/src/lib/get-executors.ts
+++ b/libs/shared/collections/src/lib/get-executors.ts
@@ -1,12 +1,18 @@
 import { CollectionInfo, WorkspaceProjects } from '@nx-console/shared/schema';
 import { readCollections } from './read-collections';
 
+export type GetExecutorsOptions = { includeHidden: boolean };
 export async function getExecutors(
   workspacePath: string,
   projects: WorkspaceProjects,
-  clearPackageJsonCache: boolean
+  clearPackageJsonCache: boolean,
+  options = { includeHidden: false }
 ): Promise<CollectionInfo[]> {
   return (
-    await readCollections(workspacePath, { projects, clearPackageJsonCache })
+    await readCollections(workspacePath, {
+      projects,
+      clearPackageJsonCache,
+      includeHidden: options.includeHidden,
+    })
   ).filter((collection) => collection.type === 'executor');
 }

--- a/libs/shared/collections/src/lib/get-generators.ts
+++ b/libs/shared/collections/src/lib/get-generators.ts
@@ -14,14 +14,18 @@ import {
   listFiles,
 } from '@nx-console/shared/file-system';
 
+export type GetGeneratorsOptions = { includeHidden: boolean };
+
 export async function getGenerators(
   workspacePath: string,
-  projects?: WorkspaceProjects
+  projects?: WorkspaceProjects,
+  options: GetGeneratorsOptions = { includeHidden: false }
 ): Promise<CollectionInfo[]> {
   const basedir = workspacePath;
   const collections = await readCollections(workspacePath, {
     projects,
     clearPackageJsonCache: false,
+    includeHidden: options.includeHidden,
   });
   let generatorCollections = collections.filter(
     (collection) => collection.type === 'generator'
@@ -29,8 +33,8 @@ export async function getGenerators(
 
   generatorCollections = [
     ...generatorCollections,
-    ...(await checkAndReadWorkspaceGenerators(basedir, 'schematics')),
-    ...(await checkAndReadWorkspaceGenerators(basedir, 'generators')),
+    ...(await checkAndReadWorkspaceGenerators(basedir, 'schematics', options)),
+    ...(await checkAndReadWorkspaceGenerators(basedir, 'generators', options)),
   ];
   return generatorCollections.filter(
     (collection): collection is CollectionInfo => !!collection.data
@@ -39,14 +43,16 @@ export async function getGenerators(
 
 async function checkAndReadWorkspaceGenerators(
   basedir: string,
-  workspaceGeneratorType: 'generators' | 'schematics'
+  workspaceGeneratorType: 'generators' | 'schematics',
+  options: GetGeneratorsOptions
 ) {
   const workspaceGeneratorsPath = join('tools', workspaceGeneratorType);
   if (await directoryExists(join(basedir, workspaceGeneratorsPath))) {
     const collection = await readWorkspaceGeneratorsCollection(
       basedir,
       workspaceGeneratorsPath,
-      workspaceGeneratorType
+      workspaceGeneratorType,
+      options
     );
     return collection;
   }
@@ -56,7 +62,8 @@ async function checkAndReadWorkspaceGenerators(
 async function readWorkspaceGeneratorsCollection(
   basedir: string,
   workspaceGeneratorsPath: string,
-  workspaceGeneratorType: 'generators' | 'schematics'
+  workspaceGeneratorType: 'generators' | 'schematics',
+  options: GetGeneratorsOptions
 ): Promise<CollectionInfo[]> {
   const collectionDir = join(basedir, workspaceGeneratorsPath);
   const collectionName = `workspace-${
@@ -76,7 +83,8 @@ async function readWorkspaceGeneratorsCollection(
         path: collectionPath,
         json: {},
       },
-      collection.json
+      collection.json,
+      options
     );
   } else {
     return await Promise.all(

--- a/libs/shared/collections/src/lib/get-generators.ts
+++ b/libs/shared/collections/src/lib/get-generators.ts
@@ -14,18 +14,22 @@ import {
   listFiles,
 } from '@nx-console/shared/file-system';
 
-export type GetGeneratorsOptions = { includeHidden: boolean };
+export type GetGeneratorsOptions = {
+  includeHidden: boolean;
+  includeNgAdd: boolean;
+};
 
 export async function getGenerators(
   workspacePath: string,
   projects?: WorkspaceProjects,
-  options: GetGeneratorsOptions = { includeHidden: false }
+  options: GetGeneratorsOptions = { includeHidden: false, includeNgAdd: false }
 ): Promise<CollectionInfo[]> {
   const basedir = workspacePath;
   const collections = await readCollections(workspacePath, {
     projects,
     clearPackageJsonCache: false,
     includeHidden: options.includeHidden,
+    includeNgAdd: options.includeNgAdd,
   });
   let generatorCollections = collections.filter(
     (collection) => collection.type === 'generator'

--- a/libs/shared/collections/src/lib/read-collections.ts
+++ b/libs/shared/collections/src/lib/read-collections.ts
@@ -16,12 +16,14 @@ import {
   readAndCacheJsonFile,
 } from '@nx-console/shared/file-system';
 
+export type ReadCollectionsOptions = {
+  projects?: WorkspaceProjects;
+  clearPackageJsonCache?: boolean;
+  includeHidden?: boolean;
+};
 export async function readCollections(
   workspacePath: string,
-  options: {
-    projects?: WorkspaceProjects;
-    clearPackageJsonCache?: boolean;
-  }
+  options: ReadCollectionsOptions
 ): Promise<CollectionInfo[]> {
   if (options?.clearPackageJsonCache) {
     clearJsonCache('package.json', workspacePath);
@@ -36,7 +38,9 @@ export async function readCollections(
   );
 
   const allCollections = (
-    await Promise.all(collections.map((c) => readCollection(workspacePath, c)))
+    await Promise.all(
+      collections.map((c) => readCollection(workspacePath, c, options))
+    )
   ).flat();
 
   /**
@@ -73,7 +77,8 @@ async function readCollection(
     packagePath: string;
     packageName: string;
     packageJson: any;
-  }
+  },
+  options: ReadCollectionsOptions
 ): Promise<CollectionInfo[] | null> {
   try {
     const [executorCollections, generatorCollections] = await Promise.all([
@@ -86,7 +91,8 @@ async function readCollection(
       packageName,
       packagePath,
       executorCollections,
-      generatorCollections
+      generatorCollections,
+      options
     );
   } catch (e) {
     return null;
@@ -98,7 +104,8 @@ export async function getCollectionInfo(
   collectionName: string,
   collectionPath: string,
   executorCollection: { path: string; json: any },
-  generatorCollection: { path: string; json: any }
+  generatorCollection: { path: string; json: any },
+  options: ReadCollectionsOptions
 ): Promise<CollectionInfo[]> {
   const collectionMap: Map<string, CollectionInfo> = new Map();
 
@@ -126,7 +133,7 @@ export async function getCollectionInfo(
     ...executorCollection.json.builders,
   };
   for (const [key, schema] of Object.entries<any>(executors)) {
-    if (!canUse(key, schema)) {
+    if (!canUse(key, schema, options.includeHidden)) {
       continue;
     }
     const collectionInfo = buildCollectionInfo(
@@ -151,7 +158,7 @@ export async function getCollectionInfo(
     ...generatorCollection.json.schematics,
   };
   for (const [key, schema] of Object.entries<any>(generators)) {
-    if (!canUse(key, schema)) {
+    if (!canUse(key, schema, options.includeHidden)) {
       continue;
     }
 
@@ -204,7 +211,8 @@ export async function getCollectionInfo(
 
             return readCollection(
               workspacePath,
-              await packageDetails(dependencyPath)
+              await packageDetails(dependencyPath),
+              options
             );
           })
       )
@@ -264,9 +272,15 @@ function readCollectionGenerator(
  */
 function canUse(
   name: string,
-  s: { hidden: boolean; private: boolean; schema: string; extends: boolean }
+  s: { hidden: boolean; private: boolean; schema: string; extends: boolean },
+  includeHiddenCollections = false
 ): boolean {
-  return !s.hidden && !s.private && !s.extends && name !== 'ng-add';
+  return (
+    (!s.hidden || includeHiddenCollections) &&
+    !s.private &&
+    !s.extends &&
+    name !== 'ng-add'
+  );
 }
 
 function collectionNameWithType(name: string, type: 'generator' | 'executor') {

--- a/libs/shared/collections/src/lib/read-collections.ts
+++ b/libs/shared/collections/src/lib/read-collections.ts
@@ -20,6 +20,7 @@ export type ReadCollectionsOptions = {
   projects?: WorkspaceProjects;
   clearPackageJsonCache?: boolean;
   includeHidden?: boolean;
+  includeNgAdd?: boolean;
 };
 export async function readCollections(
   workspacePath: string,
@@ -133,7 +134,7 @@ export async function getCollectionInfo(
     ...executorCollection.json.builders,
   };
   for (const [key, schema] of Object.entries<any>(executors)) {
-    if (!canUse(key, schema, options.includeHidden)) {
+    if (!canUse(key, schema, options.includeHidden, options.includeNgAdd)) {
       continue;
     }
     const collectionInfo = buildCollectionInfo(
@@ -158,7 +159,7 @@ export async function getCollectionInfo(
     ...generatorCollection.json.schematics,
   };
   for (const [key, schema] of Object.entries<any>(generators)) {
-    if (!canUse(key, schema, options.includeHidden)) {
+    if (!canUse(key, schema, options.includeHidden, options.includeNgAdd)) {
       continue;
     }
 
@@ -273,13 +274,14 @@ function readCollectionGenerator(
 function canUse(
   name: string,
   s: { hidden: boolean; private: boolean; schema: string; extends: boolean },
-  includeHiddenCollections = false
+  includeHiddenCollections = false,
+  includeNgAddCollection = false
 ): boolean {
   return (
     (!s.hidden || includeHiddenCollections) &&
     !s.private &&
     !s.extends &&
-    name !== 'ng-add'
+    (name !== 'ng-add' || includeNgAddCollection)
   );
 }
 

--- a/libs/vscode/add-dependency/.eslintrc.json
+++ b/libs/vscode/add-dependency/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/vscode/add-dependency/README.md
+++ b/libs/vscode/add-dependency/README.md
@@ -1,0 +1,11 @@
+# vscode-add-dependency
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test vscode-add-dependency` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint vscode-add-dependency` to execute the lint via [ESLint](https://eslint.org/).

--- a/libs/vscode/add-dependency/jest.config.ts
+++ b/libs/vscode/add-dependency/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'vscode-add-dependency',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/vscode/add-dependency',
+};

--- a/libs/vscode/add-dependency/project.json
+++ b/libs/vscode/add-dependency/project.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/vscode/add-dependency/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/vscode/add-dependency/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/vscode/add-dependency"],
+      "options": {
+        "jestConfig": "libs/vscode/add-dependency/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/vscode/add-dependency/src/index.ts
+++ b/libs/vscode/add-dependency/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/vscode-add-dependency';
+export * from './lib/add-dependency-codelens-provider';

--- a/libs/vscode/add-dependency/src/index.ts
+++ b/libs/vscode/add-dependency/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/vscode-add-dependency';

--- a/libs/vscode/add-dependency/src/lib/add-dependency-codelens-provider.ts
+++ b/libs/vscode/add-dependency/src/lib/add-dependency-codelens-provider.ts
@@ -1,0 +1,79 @@
+import { getWorkspacePath } from '@nx-console/vscode/utils';
+import { join } from 'path';
+import {
+  isPropertyAssignment,
+  isStringLiteral,
+  ObjectLiteralElementLike,
+  ObjectLiteralExpression,
+  parseJsonText,
+} from 'typescript';
+import {
+  CodeLens,
+  CodeLensProvider,
+  Command,
+  ExtensionContext,
+  languages,
+  ProviderResult,
+  Range,
+  TextDocument,
+} from 'vscode';
+
+export class AddDependencyCodelensProvider implements CodeLensProvider {
+  constructor(context: ExtensionContext) {
+    this.registerAddDependencyCodeLensProvider(context);
+  }
+
+  provideCodeLenses(document: TextDocument): ProviderResult<CodeLens[]> {
+    const workspacePath = getWorkspacePath();
+    if (document.uri.path !== join(workspacePath, 'package.json')) {
+      return;
+    }
+
+    const packageJson = parseJsonText('package.json', document.getText());
+    const packageJsonObject = packageJson.statements[0]
+      .expression as ObjectLiteralExpression;
+
+    const depProperty = packageJsonObject.properties.find(
+      (property) => getPropertyName(property) === 'dependencies'
+    );
+    const devDepProperty = packageJsonObject.properties.find(
+      (property) => getPropertyName(property) === 'devDependencies'
+    );
+
+    const lenses: CodeLens[] = [];
+    if (depProperty) {
+      const pos = document.positionAt(depProperty.getStart(packageJson));
+      const command: Command = {
+        title: 'Add Dependency',
+        command: 'nxConsole.addDependency',
+      };
+      lenses.push(new CodeLens(new Range(pos, pos), command));
+    }
+    if (devDepProperty) {
+      const pos = document.positionAt(devDepProperty.getStart(packageJson));
+      const command: Command = {
+        title: 'Add Dev Dependency',
+        command: 'nxConsole.addDevDependency',
+      };
+      lenses.push(new CodeLens(new Range(pos, pos), command));
+    }
+
+    return lenses;
+  }
+
+  /**
+   * Registers this as a CodeLensProvider.
+   * @param context instance of ExtensionContext from activate
+   */
+  registerAddDependencyCodeLensProvider(context: ExtensionContext) {
+    context.subscriptions.push(
+      languages.registerCodeLensProvider({ pattern: '**/package.json' }, this)
+    );
+  }
+}
+
+function getPropertyName(property: ObjectLiteralElementLike) {
+  if (isPropertyAssignment(property) && isStringLiteral(property.name)) {
+    return property.name.text;
+  }
+}

--- a/libs/vscode/add-dependency/src/lib/add-dependency-codelens-provider.ts
+++ b/libs/vscode/add-dependency/src/lib/add-dependency-codelens-provider.ts
@@ -17,6 +17,10 @@ import {
   Range,
   TextDocument,
 } from 'vscode';
+import {
+  ADD_DEPENDENCY_COMMAND,
+  ADD_DEV_DEPENDENCY_COMMAND,
+} from './vscode-add-dependency';
 
 export class AddDependencyCodelensProvider implements CodeLensProvider {
   constructor(context: ExtensionContext) {
@@ -45,7 +49,7 @@ export class AddDependencyCodelensProvider implements CodeLensProvider {
       const pos = document.positionAt(depProperty.getStart(packageJson));
       const command: Command = {
         title: 'Add Dependency',
-        command: 'nxConsole.addDependency',
+        command: ADD_DEPENDENCY_COMMAND,
       };
       lenses.push(new CodeLens(new Range(pos, pos), command));
     }
@@ -53,7 +57,7 @@ export class AddDependencyCodelensProvider implements CodeLensProvider {
       const pos = document.positionAt(devDepProperty.getStart(packageJson));
       const command: Command = {
         title: 'Add Dev Dependency',
-        command: 'nxConsole.addDevDependency',
+        command: ADD_DEV_DEPENDENCY_COMMAND,
       };
       lenses.push(new CodeLens(new Range(pos, pos), command));
     }

--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -173,7 +173,12 @@ function getDependencySuggestions(): Promise<
       followRedirects: 5,
       headers,
     }).then((response) => {
-      return (JSON.parse(response.responseText) as { name: string }[])
+      return (
+        JSON.parse(response.responseText) as {
+          name: string;
+          description: string;
+        }[]
+      )
         .filter(
           (pkg) =>
             pkg.name !== 'add-nx-to-monorepo' &&
@@ -185,6 +190,7 @@ function getDependencySuggestions(): Promise<
         )
         .map((pkg) => ({
           name: `@nrwl/${pkg.name}`,
+          description: pkg.description,
         }));
     }),
     xhr({

--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -1,0 +1,162 @@
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+  PackageManager,
+} from '@nrwl/devkit';
+import { getGenerators } from '@nx-console/collections';
+import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
+import { getGeneratorOptions, selectFlags } from '@nx-console/vscode/tasks';
+import { getTelemetry } from '@nx-console/vscode/utils';
+import { xhr, XHRResponse } from 'request-light';
+import {
+  commands,
+  ExtensionContext,
+  ShellExecution,
+  Task,
+  tasks,
+  TaskScope,
+  window,
+} from 'vscode';
+
+export function registerVscodeAddDependency(context: ExtensionContext) {
+  context.subscriptions.push(
+    commands.registerCommand(
+      'nxConsole.addDependency',
+      vscodeAddDependencyCommand
+    )
+  );
+}
+
+let workspace: string;
+let pkgManager: PackageManager;
+
+async function vscodeAddDependencyCommand() {
+  workspace = WorkspaceConfigurationStore.instance.get('nxWorkspacePath', '');
+  pkgManager = detectPackageManager(workspace);
+
+  const dep = await promptForDependencyName();
+
+  if (dep) {
+    getTelemetry().featureUsed('add-dependency');
+    addDependency(dep);
+    const disposable = tasks.onDidEndTask(() => {
+      executeInitGenerator(dep);
+      disposable.dispose();
+    }, undefined);
+  }
+}
+
+async function promptForDependencyName(): Promise<string | undefined> {
+  const packageSuggestions = (await getDependencySuggestions()).map((pkg) => ({
+    label: pkg.name,
+    description: pkg.description,
+  }));
+  const dep = await new Promise<string | undefined>((resolve) => {
+    const quickPick = window.createQuickPick();
+    quickPick.items = packageSuggestions;
+    quickPick.placeholder =
+      'The name of the dependency you want to add. Can be anything on the npm registry.';
+    quickPick.canSelectMany = false;
+
+    quickPick.onDidChangeValue(() => {
+      quickPick.items = [
+        ...packageSuggestions,
+        {
+          label: quickPick.value,
+          description: `Look for package ${quickPick.value} on the registry.`,
+        },
+      ];
+    });
+
+    quickPick.onDidAccept(() => {
+      resolve(quickPick.selectedItems[0]?.label);
+      quickPick.hide();
+    });
+
+    quickPick.show();
+  });
+
+  return dep;
+}
+
+function addDependency(dependency: string) {
+  const command = `${getPackageManagerCommand(pkgManager).add} ${dependency}`;
+  const task = new Task(
+    {
+      type: 'nx',
+    },
+    TaskScope.Workspace,
+    command,
+    pkgManager,
+    new ShellExecution(command)
+  );
+  tasks.executeTask(task);
+}
+async function executeInitGenerator(dependency: string) {
+  const generators = await getGenerators(
+    WorkspaceConfigurationStore.instance.get('nxWorkspacePath', ''),
+    undefined,
+    { includeHidden: true }
+  );
+
+  const initGeneratorName = `${dependency}:init`;
+  const initGenerator = generators.find((c) => c.name === initGeneratorName);
+
+  if (initGenerator?.data?.collection) {
+    const workspaceType = WorkspaceConfigurationStore.instance.get(
+      'workspaceType',
+      'nx'
+    );
+    const opts = await getGeneratorOptions(
+      workspace,
+      initGenerator.data?.collection,
+      initGenerator.name,
+      initGenerator.path,
+      workspaceType
+    );
+    let selectedFlags;
+    if (opts.length) {
+      selectedFlags = await selectFlags(
+        initGenerator.name,
+        opts,
+        workspaceType
+      );
+    }
+    const command = `${
+      getPackageManagerCommand(pkgManager).exec
+    } nx g ${initGeneratorName} ${selectedFlags?.reduce(
+      (acc, curr) => `${acc} ${curr}`,
+      ''
+    )} --interactive=false`;
+    const task = new Task(
+      { type: 'nx' },
+      TaskScope.Workspace,
+      command,
+      pkgManager,
+      new ShellExecution(command)
+    );
+    tasks.executeTask(task);
+  }
+}
+
+function getDependencySuggestions(): Promise<
+  {
+    name: string;
+    description: string;
+    url: string;
+  }[]
+> {
+  const headers = { 'Accept-Encoding': 'gzip, deflate' };
+  return xhr({
+    url: 'https://raw.githubusercontent.com/nrwl/nx/master/community/approved-plugins.json',
+    followRedirects: 5,
+    headers,
+  }).then(
+    (response) => {
+      return JSON.parse(response.responseText);
+    },
+    (error: XHRResponse) => {
+      return Promise.reject(error.responseText);
+    }
+  );
+}

--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -45,9 +45,11 @@ async function vscodeAddDependencyCommand() {
   if (dep) {
     getTelemetry().featureUsed('add-dependency');
     addDependency(dep);
-    const disposable = tasks.onDidEndTask(() => {
-      executeInitGenerator(dep);
-      disposable.dispose();
+    const disposable = tasks.onDidEndTaskProcess((taskEndEvent) => {
+      if (taskEndEvent.execution.task.definition.type === 'nxconsole-add-dep') {
+        executeInitGenerator(dep);
+        disposable.dispose();
+      }
     }, undefined);
   }
 }
@@ -89,7 +91,7 @@ function addDependency(dependency: string) {
   const command = `${getPackageManagerCommand(pkgManager).add} ${dependency}`;
   const task = new Task(
     {
-      type: 'nx',
+      type: 'nxconsole-add-dep',
     },
     TaskScope.Workspace,
     command,

--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -104,11 +104,15 @@ async function executeInitGenerator(dependency: string) {
   const generators = await getGenerators(
     WorkspaceConfigurationStore.instance.get('nxWorkspacePath', ''),
     undefined,
-    { includeHidden: true }
+    { includeHidden: true, includeNgAdd: true }
   );
 
-  const initGeneratorName = `${dependency}:init`;
-  const initGenerator = generators.find((c) => c.name === initGeneratorName);
+  let initGeneratorName = `${dependency}:init`;
+  let initGenerator = generators.find((g) => g.name === initGeneratorName);
+  if (!initGenerator) {
+    initGeneratorName = `${dependency}:ng-add`;
+    initGenerator = generators.find((g) => g.name === initGeneratorName);
+  }
 
   if (!initGenerator?.data) {
     return;

--- a/libs/vscode/add-dependency/tsconfig.json
+++ b/libs/vscode/add-dependency/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/vscode/add-dependency/tsconfig.lib.json
+++ b/libs/vscode/add-dependency/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/vscode/add-dependency/tsconfig.spec.json
+++ b/libs/vscode/add-dependency/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/vscode/nx-commands-view/project.json
+++ b/libs/vscode/nx-commands-view/project.json
@@ -18,5 +18,6 @@
       }
     }
   },
-  "tags": ["type:vscode"]
+  "tags": ["type:vscode"],
+  "implicitDependencies": ["vscode-add-dependency"]
 }

--- a/libs/vscode/nx-commands-view/project.json
+++ b/libs/vscode/nx-commands-view/project.json
@@ -18,6 +18,5 @@
       }
     }
   },
-  "tags": ["type:vscode"],
-  "implicitDependencies": ["vscode-add-dependency"]
+  "tags": ["type:vscode"]
 }

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
@@ -23,8 +23,8 @@ export class NxCommandsTreeProvider extends AbstractTreeProvider<NxCommandsTreeI
       'affected:test',
       'list',
       'migrate',
-      'add-dependency',
-      'add-dev-dependency',
+      'Add Dependency',
+      'Add Dev Dependency',
     ].map((c) => new NxCommandsTreeItem(c, this.context.extensionPath));
   }
 }

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
@@ -23,6 +23,8 @@ export class NxCommandsTreeProvider extends AbstractTreeProvider<NxCommandsTreeI
       'affected:test',
       'list',
       'migrate',
+      'add-dependency',
+      'add-dev-dependency',
     ].map((c) => new NxCommandsTreeItem(c, this.context.extensionPath));
   }
 }

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-tree-item.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-tree-item.ts
@@ -18,5 +18,19 @@ export class NxCommandsTreeItem extends TreeItem {
     readonly extensionPath: string
   ) {
     super(affectedCommand, TreeItemCollapsibleState.None);
+    if (this.affectedCommand === 'add-dependency') {
+      this.command = {
+        title: this.affectedCommand,
+        command: 'nxConsole.addDependency',
+        tooltip: 'Add dependency',
+      };
+    }
+    if (this.affectedCommand === 'add-dev-dependency') {
+      this.command = {
+        title: this.affectedCommand,
+        command: 'nxConsole.addDevDependency',
+        tooltip: 'Add dev dependency',
+      };
+    }
   }
 }

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-tree-item.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-tree-item.ts
@@ -24,12 +24,28 @@ export class NxCommandsTreeItem extends TreeItem {
         command: 'nxConsole.addDependency',
         tooltip: 'Add dependency',
       };
+      this.iconPath = {
+        light: Uri.file(
+          join(this.extensionPath, 'assets', 'nx-console-light.svg')
+        ),
+        dark: Uri.file(
+          join(this.extensionPath, 'assets', 'nx-console-dark.svg')
+        ),
+      };
     }
     if (this.affectedCommand === 'add-dev-dependency') {
       this.command = {
         title: this.affectedCommand,
         command: 'nxConsole.addDevDependency',
         tooltip: 'Add dev dependency',
+      };
+      this.iconPath = {
+        light: Uri.file(
+          join(this.extensionPath, 'assets', 'nx-console-light.svg')
+        ),
+        dark: Uri.file(
+          join(this.extensionPath, 'assets', 'nx-console-dark.svg')
+        ),
       };
     }
   }

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-tree-item.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-tree-item.ts
@@ -18,7 +18,7 @@ export class NxCommandsTreeItem extends TreeItem {
     readonly extensionPath: string
   ) {
     super(affectedCommand, TreeItemCollapsibleState.None);
-    if (this.affectedCommand === 'add-dependency') {
+    if (this.affectedCommand === 'Add Dependency') {
       this.command = {
         title: this.affectedCommand,
         command: 'nxConsole.addDependency',
@@ -33,7 +33,7 @@ export class NxCommandsTreeItem extends TreeItem {
         ),
       };
     }
-    if (this.affectedCommand === 'add-dev-dependency') {
+    if (this.affectedCommand === 'Add Dev Dependency') {
       this.command = {
         title: this.affectedCommand,
         command: 'nxConsole.addDevDependency',

--- a/libs/vscode/tasks/src/index.ts
+++ b/libs/vscode/tasks/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/nx-task-commands';
 export * from './lib/cli-task-commands';
 export * from './lib/cli-task-quick-pick-item';
 export * from './lib/select-generator';
+export * from './lib/select-flags';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -58,6 +58,9 @@
       "@nx-console/vscode-ui/feature-task-execution-form": [
         "libs/vscode-ui/feature-task-execution-form/src/index.ts"
       ],
+      "@nx-console/vscode/add-dependency": [
+        "libs/vscode/add-dependency/src/index.ts"
+      ],
       "@nx-console/vscode/configuration": [
         "libs/vscode/configuration/src/index.ts"
       ],

--- a/workspace.json
+++ b/workspace.json
@@ -13,6 +13,7 @@
     "shared-utils": "libs/shared/utils",
     "shared-workspace": "libs/shared/workspace",
     "vscode": "apps/vscode",
+    "vscode-add-dependency": "libs/vscode/add-dependency",
     "vscode-configuration": "libs/vscode/configuration",
     "vscode-lsp-client": "libs/vscode/lsp-client",
     "vscode-nx-commands-view": "libs/vscode/nx-commands-view",


### PR DESCRIPTION
In order to make it easier to add dependecies and execute their corresponding init generators, a command that guides you through the process has been added.