### PR TITLE
chore: update vscode

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": "^1.50.0"
+    "vscode": "^1.71.0"
   },
   "keywords": [
     "angular",

--- a/libs/vscode/configuration/src/lib/global-configuration-store.ts
+++ b/libs/vscode/configuration/src/lib/global-configuration-store.ts
@@ -41,7 +41,7 @@ export class GlobalConfigurationStore implements Store {
     this.storage(key).update(key, undefined);
   }
 
-  storage(key: GlobalConfigKeys): Memento {
+  storage(key: GlobalConfigKeys): VSCState {
     return isConfig(key) ? this.config : this.state;
   }
 
@@ -59,5 +59,5 @@ function isConfig(key: GlobalConfigKeys): boolean {
 export interface VSCState {
   get<T>(key: string): T | undefined;
   get<T>(key: string, defaultValue: T): T;
-  update(key: string, value: any, target: ConfigurationTarget): void;
+  update(key: string, value: any, target?: ConfigurationTarget): void;
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/node": "18.7.1",
     "@types/universal-analytics": "0.4.5",
     "@types/uuid": "^8.3.4",
-    "@types/vscode": "1.50.0",
+    "@types/vscode": "1.71.0",
     "@typescript-eslint/eslint-plugin": "5.24.0",
     "@typescript-eslint/parser": "5.24.0",
     "@yarnpkg/pnp": "^3.1.1-rc.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7278,10 +7278,10 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
-"@types/vscode@1.50.0":
-  version "1.50.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.50.0.tgz#9f409d9dce22ebc11e2fcdd28fabd1917a961bb7"
-  integrity sha512-QnIeyi4L2DiD9M2bAQKRzT/EQvc80qP9UL6JD5TiLlNRL1khIDg4ej4mDSRbtFrDAsRntFI1RhMvdomUThMsqg==
+"@types/vscode@1.71.0":
+  version "1.71.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.71.0.tgz#a8d9bb7aca49b0455060e6eb978711b510bdd2e2"
+  integrity sha512-nB50bBC9H/x2CpwW9FzRRRDrTZ7G0/POttJojvN/LiVfzTGfLyQIje1L1QRMdFXK9G41k5UJN/1B9S4of7CSzA==
 
 "@types/webpack-env@^1.16.0":
   version "1.16.2"


### PR DESCRIPTION
@types/vscode now at 1.71.1 (with quickpick seperator api!)