### PR TITLE
fix: handle non existent json service

### DIFF
--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -110,16 +110,20 @@ connection.onCompletion(async (completionParams) => {
   const { jsonAst, document } = getJsonDocument(changedDocument);
 
   const completionResults =
-    (await getJsonLanguageService().doComplete(
+    (await getJsonLanguageService()?.doComplete(
       document,
       completionParams.position,
       jsonAst
     )) ?? CompletionList.create([]);
 
-  const schemas = await getJsonLanguageService().getMatchingSchemas(
+  const schemas = await getJsonLanguageService()?.getMatchingSchemas(
     document,
     jsonAst
   );
+
+  if (!schemas) {
+    return completionResults;
+  }
 
   const pathItems = await getCompletionItems(
     WORKING_PATH,
@@ -141,7 +145,7 @@ connection.onHover(async (hoverParams) => {
   }
 
   const { jsonAst, document } = getJsonDocument(hoverDocument);
-  return getJsonLanguageService().doHover(
+  return getJsonLanguageService()?.doHover(
     document,
     hoverParams.position,
     jsonAst
@@ -156,10 +160,14 @@ connection.onDocumentLinks(async (params) => {
   }
 
   const { jsonAst, document } = getJsonDocument(linkDocument);
-  const schemas = await getJsonLanguageService().getMatchingSchemas(
+  const schemas = await getJsonLanguageService()?.getMatchingSchemas(
     document,
     jsonAst
   );
+
+  if (!schemas) {
+    return;
+  }
 
   return getDocumentLinks(WORKING_PATH, jsonAst, document, schemas);
 });

--- a/libs/language-server/capabilities/code-completion/src/lib/get-completion-items.spec.ts
+++ b/libs/language-server/capabilities/code-completion/src/lib/get-completion-items.spec.ts
@@ -72,6 +72,13 @@ jest.mock(
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 jest.mock('fs', () => require('memfs').fs);
 
+const languageService = configureJsonLanguageService(
+  {
+    clientCapabilities: ClientCapabilities.LATEST,
+  },
+  {}
+);
+
 describe('getCompletionItems', () => {
   const getTestCompletionItemsFor = async (
     text: string,
@@ -86,8 +93,8 @@ describe('getCompletionItems', () => {
       0,
       text
     );
-    const jsonAst = getJsonLanguageService().parseJSONDocument(document);
-    const matchingSchemas = await getJsonLanguageService().getMatchingSchemas(
+    const jsonAst = languageService.parseJSONDocument(document);
+    const matchingSchemas = await languageService.getMatchingSchemas(
       document,
       jsonAst,
       schema
@@ -108,12 +115,6 @@ describe('getCompletionItems', () => {
   };
 
   beforeEach(() => {
-    configureJsonLanguageService(
-      {
-        clientCapabilities: ClientCapabilities.LATEST,
-      },
-      {}
-    );
     vol.fromNestedJSON({
       '/workspace': {
         'file.js': 'content',

--- a/libs/language-server/capabilities/document-links/src/lib/get-document-links.spec.ts
+++ b/libs/language-server/capabilities/document-links/src/lib/get-document-links.spec.ts
@@ -16,7 +16,7 @@ jest.mock(
   })
 );
 
-configureJsonLanguageService(
+const languageService = configureJsonLanguageService(
   {
     clientCapabilities: ClientCapabilities.LATEST,
   },
@@ -39,7 +39,7 @@ const { document, jsonAst } = documentMapper.retrieve(
 );
 
 it('should get all document links for properties that have a X_COMPLETION_TYPE (file type only)', async () => {
-  const matchingSchemas = await getJsonLanguageService().getMatchingSchemas(
+  const matchingSchemas = await languageService.getMatchingSchemas(
     document,
     jsonAst,
     {

--- a/libs/language-server/utils/src/lib/json-language-service.ts
+++ b/libs/language-server/utils/src/lib/json-language-service.ts
@@ -14,6 +14,8 @@ export function configureJsonLanguageService(
 ) {
   languageService = getLanguageService(params);
   languageService.configure(settings);
+
+  return languageService;
 }
 
 export function getJsonLanguageService(): LanguageService | undefined {

--- a/libs/language-server/utils/src/lib/json-language-service.ts
+++ b/libs/language-server/utils/src/lib/json-language-service.ts
@@ -4,6 +4,7 @@ import {
   LanguageServiceParams,
   LanguageSettings,
 } from 'vscode-json-languageservice';
+import { lspLogger } from './lsp-log';
 
 let languageService: LanguageService | undefined;
 
@@ -15,9 +16,9 @@ export function configureJsonLanguageService(
   languageService.configure(settings);
 }
 
-export function getJsonLanguageService(): LanguageService {
+export function getJsonLanguageService(): LanguageService | undefined {
   if (!languageService) {
-    throw 'Language service not configured';
+    lspLogger.log('Language service not configured');
   }
 
   return languageService;

--- a/libs/language-server/utils/src/lib/language-model-cache.ts
+++ b/libs/language-server/utils/src/lib/language-model-cache.ts
@@ -17,8 +17,8 @@ export interface LanguageModelCache<T> {
   dispose(): void;
 }
 
-const parse = (document: TextDocument): JSONDocument =>
-  getJsonLanguageService().parseJSONDocument(document);
+const parse = (document: TextDocument): JSONDocument | undefined =>
+  getJsonLanguageService()?.parseJSONDocument(document);
 
 let languageModels: {
   [uri: string]: {
@@ -82,6 +82,18 @@ export function getLanguageModelCache(): LanguageModelCache<JSONDocument> {
       }
 
       const languageModel = parse(document);
+
+      if (!languageModel) {
+        return {
+          jsonAst: {
+            root: undefined,
+            getNodeFromOffset() {
+              return undefined;
+            },
+          },
+          document,
+        };
+      }
 
       languageModels[document.uri] = {
         languageModel,


### PR DESCRIPTION
## What it does
Sets the json language service to return undefined. This makes all other places handle the undefined service if it doesnt get created. 

Fixes #1359
