### PR TITLE
fix: wait for nx console viewcontrol

### DIFF
--- a/apps/vscode-e2e/specs/utils.ts
+++ b/apps/vscode-e2e/specs/utils.ts
@@ -43,6 +43,9 @@ export function getTestWorkspacePath() {
 export async function openNxConsoleViewContainer() {
   const workbench = await browser.getWorkbench();
   await workbench.wait();
+  await browser.waitUntil(async () => {
+    return await !!workbench.getActivityBar().getViewControl('Nx Console');
+  });
   const nxActivityBaritem = await workbench
     .getActivityBar()
     .getViewControl('Nx Console');


### PR DESCRIPTION
test was flaky because of improper wait command