### PR TITLE
fix: correctly infer project path in standalone workspace

### DIFF
--- a/libs/vscode/nx-workspace/src/lib/find-project-with-path.ts
+++ b/libs/vscode/nx-workspace/src/lib/find-project-with-path.ts
@@ -12,23 +12,30 @@ export async function findProjectWithPath(
 
   const { workspace } = await getNxWorkspace();
   const projectEntries = Object.entries(workspace.projects);
-  const entry = projectEntries.find(([, def]) => {
+  let perfectMatchEntry: [string, ProjectConfiguration] | undefined;
+  let secondaryMatchEntry: [string, ProjectConfiguration] | undefined;
+  projectEntries.forEach((entry) => {
+    const [, def] = entry;
     const fullProjectPath = join(
       workspacePath,
       // If root is empty, that means we're in an angular project with the old ng workspace setup. Otherwise use the sourceRoot
       def.root || def.sourceRoot || ''
     );
     if (fullProjectPath === selectedPath) {
-      return true;
+      perfectMatchEntry = entry;
     }
 
     const relativePath = relative(fullProjectPath, selectedPath);
-    return (
+    if (
       relativePath &&
       !relativePath.startsWith('..') &&
       !isAbsolute(relativePath)
-    );
+    ) {
+      secondaryMatchEntry = entry;
+    }
   });
+
+  const entry = perfectMatchEntry ?? secondaryMatchEntry;
 
   return entry ? { name: entry[0], ...entry[1] } : null;
 }


### PR DESCRIPTION
before: right clicking on a lib in a standalone project and selecting `nx generate` would infer the project path to be the root project.

after: correctly infers the lib as the clicked project.