### PR TITLE
fix: remove the usage of configurationPath

### DIFF
--- a/libs/language-server/capabilities/code-completion/src/lib/get-completion-items.spec.ts
+++ b/libs/language-server/capabilities/code-completion/src/lib/get-completion-items.spec.ts
@@ -18,7 +18,6 @@ jest.mock(
   (): Partial<typeof workspace> => ({
     nxWorkspace: jest.fn(() =>
       Promise.resolve<NxWorkspace>({
-        configurationFilePath: '/workspace.json',
         isLerna: false,
         validWorkspaceJson: true,
         workspaceType: 'nx',

--- a/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
@@ -32,7 +32,6 @@ export async function getNxWorkspaceConfig(
   logger: Logger
 ): Promise<{
   workspaceConfiguration: NxWorkspaceConfiguration;
-  configPath: string;
   daemonEnabled?: boolean;
 }> {
   const start = performance.now();
@@ -51,7 +50,6 @@ export async function getNxWorkspaceConfig(
       getNxWorkspacePackageFileUtils(workspacePath, logger),
       getNxProjectGraph(workspacePath, logger),
     ]);
-    const configFile = nxWorkspacePackage.workspaceFileName();
 
     let workspaceConfiguration: NxWorkspaceConfiguration;
     try {
@@ -100,9 +98,9 @@ export async function getNxWorkspaceConfig(
 
     return {
       workspaceConfiguration,
-      configPath: join(workspacePath, configFile),
     };
   } catch (e) {
+    lspLogger.log(`Unable to get nx workspace configuration: ${e}`);
     return readWorkspaceConfigs(format, workspacePath);
   }
 }

--- a/libs/language-server/workspace/src/lib/workspace.ts
+++ b/libs/language-server/workspace/src/lib/workspace.ts
@@ -90,7 +90,6 @@ async function _workspace(
       validWorkspaceJson: true,
       workspaceType: isAngularWorkspace ? 'ng' : 'nx',
       workspace: toWorkspaceFormat(config.workspaceConfiguration),
-      configurationFilePath: config.configPath,
       daemonEnabled: config.daemonEnabled,
       isLerna,
       workspaceLayout: {
@@ -117,7 +116,6 @@ async function _workspace(
         projects: {},
         version: 2,
       },
-      configurationFilePath: '',
       workspacePath,
       isLerna: false,
       workspaceLayout: {

--- a/libs/shared/types/src/lib/nx-workspace.ts
+++ b/libs/shared/types/src/lib/nx-workspace.ts
@@ -17,7 +17,6 @@ export interface NxWorkspace {
   validWorkspaceJson: boolean;
   workspace: NxWorkspaceConfiguration;
   workspaceType: 'ng' | 'nx';
-  configurationFilePath: string;
   daemonEnabled?: boolean;
   workspacePath: string;
   isLerna: boolean;

--- a/libs/vscode/nx-run-target-view/src/lib/run-target-tree-item.ts
+++ b/libs/vscode/nx-run-target-view/src/lib/run-target-tree-item.ts
@@ -47,7 +47,6 @@ export class RunTargetTreeItem extends TreeItem {
   label: string;
 
   constructor(
-    readonly configurationFilePath: string,
     readonly route: string,
     readonly extensionPath: string,
     readonly generatorType?: GeneratorType,

--- a/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
+++ b/libs/vscode/nx-run-target-view/src/lib/run-target-tree-provider.ts
@@ -78,8 +78,7 @@ export class RunTargetTreeProvider extends AbstractTreeProvider<
 
     return [
       ...(await commandList()).map(
-        (command) =>
-          new RunTargetTreeItem(workspacePath, command, this.extensionPath)
+        (command) => new RunTargetTreeItem(command, this.extensionPath)
       ),
       CHANGE_WORKSPACE,
     ];

--- a/libs/vscode/tasks/src/lib/cli-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-commands.ts
@@ -232,13 +232,12 @@ async function selectCliCommandAndShowUi(
     );
     return;
   }
-  const { validWorkspaceJson, configurationFilePath } = await getNxWorkspace();
+  const { validWorkspaceJson } = await getNxWorkspace();
   if (!validWorkspaceJson) {
     window.showErrorMessage('Invalid configuration file');
     return;
   }
   const workspaceTreeItem = new RunTargetTreeItem(
-    configurationFilePath,
     command,
     extensionPath,
     generatorType,


### PR DESCRIPTION
With an upcoming release of Nx, workspace.json support is completely removed. There was a function being used here that expected those config files, but Nx Console hasnt used that in quite a while. So it is safe to remove that function. 