### PR TITLE
fix: truncate status label text for cloud integration

### DIFF
--- a/libs/vscode/nx-cloud-view/src/webview/components/status-labels.ts
+++ b/libs/vscode/nx-cloud-view/src/webview/components/status-labels.ts
@@ -111,13 +111,15 @@ class StatusLabel extends LitElement {
     .flexcontainer .text {
       grid-column: 2 / -1;
       font-weight: bold;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
     }
     .flexcontainer .actions {
       grid-column: -1;
     }
     .actions {
       display: grid;
-      grid-template-columns: 1fr 1fr;
       gap: 0.25rem;
     }
     .dot {
@@ -155,24 +157,34 @@ class StatusLabel extends LitElement {
         <!-- Status Dot-->
         <span class="dot status-${this.status}" .title="${hoverText}"> </span>
         <!-- Label-->
-        <span class="text"> ${this.text} </span>
-        <div class="actions">
-          <!-- Optional Disconnected Button -->
-          ${this.status !== 0
-            ? undefined
-            : html` <vscode-button
-                appearance="icon"
-                @click=${this._connectClicked}
-                ><codicon-element icon="debug-disconnect"></codicon-element
-              ></vscode-button>`}
-          <!-- Help Button-->
-          <vscode-button
-            appearance="icon"
-            @click=${this._helpClicked}
-            style="grid-column: 2"
-            ><codicon-element icon="question"></codicon-element
-          ></vscode-button>
-        </div>
+        <span class="text" .title="${this.text}"> ${this.text} </span>
+        ${this.status === 0
+          ? html`
+              <div class="actions" style="grid-template-columns: 1fr 1fr;">
+                <!-- Disconnected Button -->
+                <vscode-button appearance="icon" @click=${this._connectClicked}
+                  ><codicon-element icon="debug-disconnect"></codicon-element
+                ></vscode-button>
+                <!-- Help Button-->
+                <vscode-button
+                  appearance="icon"
+                  @click=${this._helpClicked}
+                  style="grid-column: 2"
+                  ><codicon-element icon="question"></codicon-element
+                ></vscode-button>
+              </div>
+            `
+          : html`
+              <div class="actions" style="grid-template-columns: 1fr;">
+                <!-- Help Button-->
+                <vscode-button
+                  appearance="icon"
+                  @click=${this._helpClicked}
+                  style="grid-column: 2"
+                  ><codicon-element icon="question"></codicon-element
+                ></vscode-button>
+              </div>
+            `}
       </div>
     `;
   }


### PR DESCRIPTION
<img width="343" alt="image" src="https://user-images.githubusercontent.com/34165455/215755041-7e97c8f8-3cf2-41fc-979f-39862c5e5600.png">

I also added a small hover text so people aren't confused when it's truncated
