### PR TITLE
chore(intellij): use yarn instead of yarn exec

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate_ui/run_generator/run_task.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate_ui/run_generator/run_task.kt
@@ -26,7 +26,7 @@ fun runGenerator(generator: String, flags: List<String>, project: Project): Unit
         )
     val pkgManagerExecCommand: String =
         if (npmPkgManager != null && NpmUtil.isYarnAlikePackage(npmPkgManager)) {
-            "yarn exec"
+            "yarn"
         } else if (npmPkgManager != null && NpmUtil.isPnpmPackage(npmPkgManager)) {
             "pnpm exec"
         } else {


### PR DESCRIPTION
ideally, we would reimplement nx devkit here or wrap it in the lsp because there are some more nuances regarding which command to use:
https://github.com/nrwl/nx/blob/master/packages/nx/src/utils/package-manager.ts#L81

for now I think it's fine to use the naive version.

