### PR TITLE
fix(generate-ui): force unbreakable strings to break instead of overflowing

### DIFF
--- a/libs/generate-ui/argument-list/src/lib/argument-list.component.scss
+++ b/libs/generate-ui/argument-list/src/lib/argument-list.component.scss
@@ -1,5 +1,6 @@
 div {
   overflow-wrap: break-word;
+  word-break: break-all;
   margin-left: 1em;
   text-indent: -1em;
 }


### PR DESCRIPTION
this
<img width="1735" alt="image" src="https://user-images.githubusercontent.com/34165455/217817850-f3d49a22-6247-4411-ba35-35d414a8830c.png">

instead of this
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/34165455/217818033-299bfac6-e17b-48ee-afc3-aea06888f79f.png">

