### PR TITLE
feat: enable selecting move generator instead of defaulting to @nrwl/angular

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,9 @@
     "add-dev-dependency",
     "migrate"
   ],
+  "nxConsole.moveGeneratorPatterns": {
+    "*": "@nrwl/workspace",
+    "libs/generate-ui/*": "@nrwl/angular"
+  },
   "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
 }

--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -825,6 +825,15 @@
           "type": "boolean",
           "default": true,
           "description": "Configures whether to do dry runs on change when using \"Generate\" command"
+        },
+        "nxConsole.moveGeneratorPatterns": {
+          "type": "object",
+          "scope": "resource",
+          "default": {},
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Controls which collections (re)move generators will be used for a project matching a given wildcard pattern. \nIf a path matches multiple patterns, the last match will be used.\nIf a path matches no pattern, you can decide manually.\n Example: { \"libs/frontend/*\": \"@nrwl/angular\",  \"libs/backend/*\": \"@nx-dotnet\", }"
         }
       }
     },

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -6,6 +6,7 @@ import {
   TaskExecutionSchema,
 } from '@nx-console/shared/schema';
 import { ProjectConfiguration } from '@nrwl/devkit';
+import { SemVer } from 'semver';
 
 export const NxChangeWorkspace: NotificationType<string> = new NotificationType(
   'nx/changeWorkspace'
@@ -65,3 +66,6 @@ export const NxGeneratorContextFromPathRequest: RequestType<
   | undefined,
   unknown
 > = new RequestType('nx/generatorContextFromPath');
+
+export const NxVersionRequest: RequestType<undefined, SemVer, unknown> =
+  new RequestType('nx/version');

--- a/libs/language-server/workspace/src/index.ts
+++ b/libs/language-server/workspace/src/index.ts
@@ -4,4 +4,5 @@ export * from './lib/get-generator-options';
 export * from './lib/get-project-by-path';
 export * from './lib/get-generator-context-from-path';
 export * from './lib/get-executors';
+export * from './lib/get-nx-version';
 export { getNxDaemonClient } from './lib/get-nx-workspace-package';

--- a/libs/language-server/workspace/src/lib/get-nx-version.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-version.ts
@@ -1,4 +1,4 @@
-import { findNxPackagePath } from './find-nx-package-path';
+import { findNxPackagePath } from '@nx-console/shared/npm';
 import { coerce, SemVer } from 'semver';
 
 declare function __non_webpack_require__(importPath: string): any;
@@ -8,7 +8,7 @@ let loadedNxPackage = false;
 
 const defaultSemver = new SemVer('0.0.0');
 
-export async function nxVersion(workspacePath: string): Promise<SemVer> {
+export async function getNxVersion(workspacePath: string): Promise<SemVer> {
   if (!loadedNxPackage) {
     const packagePath = await findNxPackagePath(workspacePath, 'package.json');
 

--- a/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
@@ -3,16 +3,16 @@ import type {
   ProjectGraph,
   ProjectsConfigurations,
 } from '@nrwl/devkit';
+import { lspLogger } from '@nx-console/language-server/utils';
 import { readAndCacheJsonFile } from '@nx-console/shared/file-system';
-import { nxVersion } from '@nx-console/shared/npm';
 import { Logger } from '@nx-console/shared/schema';
+import { NxWorkspaceConfiguration } from '@nx-console/shared/types';
 import { join } from 'path';
+import { getNxVersion } from './get-nx-version';
 import {
   getNxProjectGraph,
   getNxWorkspacePackageFileUtils,
 } from './get-nx-workspace-package';
-import { NxWorkspaceConfiguration } from '@nx-console/shared/types';
-import { lspLogger } from '@nx-console/language-server/utils';
 
 let projectGraph: ProjectGraph | null = null;
 
@@ -36,7 +36,7 @@ export async function getNxWorkspaceConfig(
 }> {
   const start = performance.now();
   logger.log('Retrieving workspace configuration');
-  const version = await nxVersion(workspacePath);
+  const version = await getNxVersion(workspacePath);
 
   if (version.major < 12) {
     lspLogger.log('Major version is less than 12');

--- a/libs/shared/npm/src/index.ts
+++ b/libs/shared/npm/src/index.ts
@@ -1,5 +1,4 @@
 export * from './lib/workspace-dependencies';
 export * from './lib/find-nx-package-path';
 export * from './lib/ng-version';
-export * from './lib/nx-version';
 export * from './lib/package-details';

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -28,7 +28,10 @@ export function toWorkspaceFormat(
   return newFormat;
 }
 
-export function hasKey<T>(obj: T, key: PropertyKey): key is keyof T {
+export function hasKey<T extends object>(
+  obj: T,
+  key: PropertyKey
+): key is keyof T {
   return key in obj;
 }
 
@@ -42,4 +45,16 @@ export function formatError(message: string, err: any): string {
     return `${message}: ${err.toString()}`;
   }
   return message;
+}
+
+export function matchWithWildcards(
+  text: string,
+  expression: string,
+  strict = true
+) {
+  const escapeRegex = (str: string) =>
+    str.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1');
+  return new RegExp(
+    `${strict ? '^' : ''}${expression.split('*').map(escapeRegex).join('.*')}$`
+  ).test(text);
 }

--- a/libs/vscode/configuration/src/lib/configuration-keys.ts
+++ b/libs/vscode/configuration/src/lib/configuration-keys.ts
@@ -9,6 +9,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'generatorBlocklist',
   'enableTaskExecutionDryRunOnChange',
   'projectViewingStyle',
+  'moveGeneratorPatterns',
 ] as const;
 
 export type GlobalConfig = {
@@ -21,7 +22,8 @@ export type GlobalConfig = {
   generatorAllowlist: string[];
   generatorBlocklist: string[];
   enableTaskExecutionDryRunOnChange: boolean;
-  projectViewingStyle: 'list' | 'tree';
+  projectViewingStyle: 'list' | 'tree' | 'automatic';
+  moveGeneratorPatterns: Record<string, string>;
 };
 
 /**

--- a/libs/vscode/nx-workspace/src/index.ts
+++ b/libs/vscode/nx-workspace/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/get-project-by-path';
 export * from './lib/get-generators';
 export * from './lib/get-generator-options';
 export * from './lib/get-generator-context-from-path';
+export * from './lib/get-nx-version';

--- a/libs/vscode/nx-workspace/src/lib/get-nx-version.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-version.ts
@@ -1,0 +1,7 @@
+import { NxVersionRequest } from '@nx-console/language-server/types';
+import { sendRequest } from '@nx-console/vscode/lsp-client';
+import { SemVer } from 'semver';
+
+export async function getNxVersion(): Promise<SemVer> {
+  return sendRequest(NxVersionRequest, undefined);
+}

--- a/libs/vscode/tasks/src/lib/select-generator.ts
+++ b/libs/vscode/tasks/src/lib/select-generator.ts
@@ -1,21 +1,18 @@
-import { readAndCacheJsonFile } from '@nx-console/shared/file-system';
 import {
   Generator,
   GeneratorType,
-  Option,
   TaskExecutionSchema,
 } from '@nx-console/shared/schema';
-import { normalizeSchema } from '@nx-console/shared/schema/normalize';
+import { matchWithWildcards } from '@nx-console/shared/utils';
 import { GlobalConfigurationStore } from '@nx-console/vscode/configuration';
 import {
   getGeneratorOptions,
   getGenerators,
-  getNxWorkspace,
 } from '@nx-console/vscode/nx-workspace';
 import { QuickPickItem, window } from 'vscode';
 
 export async function selectGenerator(
-  workspacePath: string,
+  workspacePath: string | undefined,
   workspaceType: 'nx' | 'ng',
   generatorType?: GeneratorType,
   generator?: { collection: string; name: string }
@@ -77,7 +74,9 @@ export async function selectGenerator(
             quickPick.generator.collection === generator.collection &&
             quickPick.generator.name === generator.name
         )
-      : await window.showQuickPick(generatorsQuickPicks);
+      : generatorsQuickPicks.length > 1
+      ? await window.showQuickPick(generatorsQuickPicks)
+      : generatorsQuickPicks[0];
     if (selection) {
       const options =
         selection.generator.options ||
@@ -97,12 +96,4 @@ export async function selectGenerator(
       };
     }
   }
-}
-
-function matchWithWildcards(text: string, expression: string) {
-  const escapeRegex = (str: string) =>
-    str.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1');
-  return new RegExp(
-    `^${expression.split('*').map(escapeRegex).join('.*')}$`
-  ).test(text);
 }

--- a/libs/vscode/tasks/src/lib/select-re-move-generator.ts
+++ b/libs/vscode/tasks/src/lib/select-re-move-generator.ts
@@ -1,0 +1,43 @@
+import { matchWithWildcards } from '@nx-console/shared/utils';
+import { GlobalConfigurationStore } from '@nx-console/vscode/configuration';
+import { getGenerators } from '@nx-console/vscode/nx-workspace';
+import { window } from 'vscode';
+
+export async function selectReMoveGenerator(
+  path: string,
+  target: 'move' | 'remove'
+): Promise<string | undefined> {
+  const generators = await getGenerators();
+
+  const reMoveGenerators = generators.filter(
+    (generator) => generator.data?.name === target
+  );
+
+  if (reMoveGenerators.length === 1) {
+    return reMoveGenerators[0].name;
+  }
+
+  const patterns =
+    GlobalConfigurationStore.instance.get('moveGeneratorPatterns') ?? {};
+  let matchedCollection: string | undefined;
+  for (const [pattern, collection] of Object.entries(patterns)) {
+    if (matchWithWildcards(path, pattern, false)) {
+      matchedCollection = collection;
+    }
+  }
+
+  if (matchedCollection) {
+    return `${matchedCollection}:${target}`;
+  }
+
+  const quickPickItems = reMoveGenerators.map((generator) => ({
+    description: generator.data?.description,
+    label: `${generator.data?.collection} - ${generator.data?.name}`,
+    generator: generator.name,
+  }));
+
+  const selectedGenerator = (await window.showQuickPick(quickPickItems))
+    ?.generator;
+
+  return selectedGenerator;
+}


### PR DESCRIPTION
- refactor: move nx version retrieval to nxls
- feat(vscode): enable choosing (re)move generator from file explorer
- feat: provide wildcard pattern setting for (re)move generators
- refactor: revert selectgenerator changes
