### PR TITLE
fix(vscode): fix running (re)move from command prompt

### DIFF
--- a/apps/vscode/src/package.json
+++ b/apps/vscode/src/package.json
@@ -79,12 +79,12 @@
         },
         {
           "when": "isNxWorkspace && config.nxConsole.enableGenerateFromContextMenu",
-          "command": "nx.move.fileexplorer",
+          "command": "nx.move",
           "group": "7_modification@-1"
         },
         {
           "when": "isNxWorkspace && config.nxConsole.enableGenerateFromContextMenu",
-          "command": "nx.remove.fileexplorer",
+          "command": "nx.remove",
           "group": "7_modification@-1"
         },
         {
@@ -685,12 +685,12 @@
       {
         "category": "Nx",
         "title": "Move Nx Project...",
-        "command": "nx.move.fileexplorer"
+        "command": "nx.move"
       },
       {
         "category": "Nx",
         "title": "Remove Nx Project...",
-        "command": "nx.remove.fileexplorer"
+        "command": "nx.remove"
       },
       {
         "category": "Nx",

--- a/libs/vscode/tasks/src/lib/cli-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-commands.ts
@@ -92,8 +92,8 @@ export function registerCliTaskCommands(
      */
     const version = await getNxVersion();
     if (version.major >= 8) {
-      commands.registerCommand(`${cli}.move.fileexplorer`, async (uri: Uri) => {
-        const generator = await selectReMoveGenerator(uri.toString(), 'move');
+      commands.registerCommand(`${cli}.move`, async (uri: Uri) => {
+        const generator = await selectReMoveGenerator(uri?.toString(), 'move');
         if (!generator) {
           return;
         }
@@ -106,25 +106,22 @@ export function registerCliTaskCommands(
         );
       });
 
-      commands.registerCommand(
-        `${cli}.remove.fileexplorer`,
-        async (uri: Uri) => {
-          const generator = await selectReMoveGenerator(
-            uri.toString(),
-            'remove'
-          );
-          if (!generator) {
-            return;
-          }
-          selectCliCommandAndShowUi(
-            'generate',
-            context.extensionPath,
-            uri,
-            GeneratorType.Other,
-            generator
-          );
+      commands.registerCommand(`${cli}.remove`, async (uri: Uri) => {
+        const generator = await selectReMoveGenerator(
+          uri?.toString(),
+          'remove'
+        );
+        if (!generator) {
+          return;
         }
-      );
+        selectCliCommandAndShowUi(
+          'generate',
+          context.extensionPath,
+          uri,
+          GeneratorType.Other,
+          generator
+        );
+      });
     }
 
     commands.registerCommand(`${cli}.generate`, () =>

--- a/libs/vscode/tasks/src/lib/select-re-move-generator.ts
+++ b/libs/vscode/tasks/src/lib/select-re-move-generator.ts
@@ -4,7 +4,7 @@ import { getGenerators } from '@nx-console/vscode/nx-workspace';
 import { window } from 'vscode';
 
 export async function selectReMoveGenerator(
-  path: string,
+  path: string | undefined,
   target: 'move' | 'remove'
 ): Promise<string | undefined> {
   const generators = await getGenerators();
@@ -21,7 +21,7 @@ export async function selectReMoveGenerator(
     GlobalConfigurationStore.instance.get('moveGeneratorPatterns') ?? {};
   let matchedCollection: string | undefined;
   for (const [pattern, collection] of Object.entries(patterns)) {
-    if (matchWithWildcards(path, pattern, false)) {
+    if (path && matchWithWildcards(path, pattern, false)) {
       matchedCollection = collection;
     }
   }
@@ -36,8 +36,13 @@ export async function selectReMoveGenerator(
     generator: generator.name,
   }));
 
-  const selectedGenerator = (await window.showQuickPick(quickPickItems))
-    ?.generator;
+  const selectedGenerator = (
+    await window.showQuickPick(quickPickItems, {
+      title: `Select ${target} generator`,
+      placeHolder: `@nrwl/workspace:${target}`,
+      canPickMany: false,
+    })
+  )?.generator;
 
   return selectedGenerator;
 }


### PR DESCRIPTION
fixes https://github.com/nrwl/nx-console/issues/1545

Since `nx.remove.fileexplorer` wasn't really specific to the file explorer, I renamed it to `nx.remove` and made the `Uri` param optional.