### PR TITLE
fix(intellij): use the local binary for nx generate instead of package managers

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate_ui/run_generator/RunGeneratorManager.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate_ui/run_generator/RunGeneratorManager.kt
@@ -1,6 +1,5 @@
 package dev.nx.console.generate_ui.run_generator
 
-import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.filters.TextConsoleBuilderFactory
@@ -10,15 +9,13 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.execution.ui.RunContentManager
 import com.intellij.javascript.nodejs.NodeCommandLineUtil
-import com.intellij.javascript.nodejs.npm.NpmPackageDescriptor
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
-import dev.nx.console.NxConsoleBundle
 import dev.nx.console.NxIcons
-import java.nio.file.Paths
+import dev.nx.console.utils.NxExecutable
 
 val log = logger<RunGeneratorManager>()
 
@@ -58,16 +55,15 @@ class RunGeneratorManager(val project: Project) {
             ApplicationManager.getApplication()
                 .invokeLater(
                     {
-                        val binPath =
-                            Paths.get(project.basePath ?: ".", "node_modules", ".bin").toString()
-                        log.info("Using ${binPath} as base to find local nx binary")
-                        val nxPackage =
-                            NpmPackageDescriptor.findLocalBinaryFilePackage(binPath, "nx")
-                                ?: throw ExecutionException(NxConsoleBundle.message("nx.not.found"))
+                        val nxExecutable =
+                            NxExecutable.getExecutablePath(
+                                project.basePath
+                                    ?: throw Exception("Project base path does not exist")
+                            )
 
                         val commandLine =
                             GeneralCommandLine().apply {
-                                exePath = nxPackage.systemDependentPath
+                                exePath = nxExecutable
                                 addParameters(definition)
                                 setWorkDirectory(project.basePath)
                                 withParentEnvironmentType(

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxExecutable.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxExecutable.kt
@@ -1,0 +1,34 @@
+package dev.nx.console.utils
+
+import com.intellij.execution.ExecutionException
+import com.intellij.javascript.nodejs.npm.NpmPackageDescriptor
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.SystemInfo
+import dev.nx.console.NxConsoleBundle
+import java.io.File
+import java.nio.file.Paths
+
+val logger = logger<NxExecutable>()
+
+class NxExecutable {
+    companion object {
+        fun getExecutablePath(basePath: String): String {
+
+            logger.info("Checking if there is standalone nx")
+            val nxExecutableName = if (SystemInfo.isWindows) "nx.bat" else "nx"
+            val nxExecutable = File(Paths.get(basePath, nxExecutableName).toString())
+
+            if (nxExecutable.exists()) {
+                return nxExecutable.absolutePath
+            }
+
+            val binPath = Paths.get(basePath ?: ".", "node_modules", ".bin").toString()
+            logger.info("Using ${binPath} as base to find local nx binary")
+            val nxPackage =
+                NpmPackageDescriptor.findLocalBinaryFilePackage(binPath, "nx")
+                    ?: throw ExecutionException(NxConsoleBundle.message("nx.not.found"))
+
+            return nxPackage.systemIndependentPath
+        }
+    }
+}

--- a/apps/intellij/src/main/resources/messages/NxConsoleBundle.properties
+++ b/apps/intellij/src/main/resources/messages/NxConsoleBundle.properties
@@ -6,3 +6,4 @@ language.server.not.found=Nxls is not found.
 
 create.nx.workspace.name=Nx
 create.nx.workspace.description=<a href=\"https://nx.dev\">Nx</a> is a smart, fast and extensible build system with first class monorepo support and powerful integrations.
+nx.not.found=Cannot find a local installation of Nx.


### PR DESCRIPTION
## What it does
This will use the local install of Nx to run the generate command. This removes the need to check for package managers and just run nx directly.

Should also enable easier support when we move to standalone nx 