### PR TITLE
feat(intellij): set custom renderer for nx generate ui popup

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate_ui/NxGenerateUiAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate_ui/NxGenerateUiAction.kt
@@ -23,11 +23,11 @@ import dev.nx.console.nxls.server.NxGeneratorContext
 import dev.nx.console.nxls.server.NxGeneratorOption
 import dev.nx.console.nxls.server.NxGeneratorOptionsRequestOptions
 import dev.nx.console.services.NxlsService
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.awt.Dimension
 import javax.swing.JList
 import javax.swing.ListSelectionModel.SINGLE_SELECTION
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 private val logger = logger<NxGenerateUiAction>()
 
@@ -71,11 +71,11 @@ class NxGenerateUiAction() : AnAction() {
                         )
                         append(
                             " " +
-                                    StringUtil.shortenTextWithEllipsis(
-                                        value.data.description,
-                                        80 - value.name.length,
-                                        0
-                                    ),
+                                StringUtil.shortenTextWithEllipsis(
+                                    value.data.description,
+                                    80 - value.name.length,
+                                    0
+                                ),
                             SimpleTextAttributes.GRAY_ATTRIBUTES,
                             false
                         )


### PR DESCRIPTION
This PR will add custom renderer to the nx generate ui popup to include description name and description

<img width="851" alt="Screenshot 2023-02-21 at 23 35 28" src="https://user-images.githubusercontent.com/9085108/220600716-24994841-3444-4140-afcc-4b6fdade26c5.png">
