### PR TITLE
feat(vscode): run commands with encapsulated nx (#1557

### DIFF
--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -197,6 +197,7 @@ async function executeInitGenerator(
     getShellExecutionForConfig({
       cwd: workspacePath,
       displayCommand: command,
+      standaloneNx: false,
     })
   );
   tasks.executeTask(task);

--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -197,7 +197,7 @@ async function executeInitGenerator(
     getShellExecutionForConfig({
       cwd: workspacePath,
       displayCommand: command,
-      standaloneNx: false,
+      encapsulatedNx: false,
     })
   );
   tasks.executeTask(task);

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
@@ -73,7 +73,8 @@ export class NxCommandsTreeProvider extends AbstractTreeProvider<NxCommandsTreeI
     const prefixedCommand = command.startsWith('nx ')
       ? command
       : `nx ${command}`;
-    const { workspacePath, workspaceType } = await getNxWorkspace();
+    const { workspacePath, workspaceType, isStandaloneNx } =
+      await getNxWorkspace();
     const pkgManager = detectPackageManager(workspacePath);
 
     const task = new Task(
@@ -84,6 +85,7 @@ export class NxCommandsTreeProvider extends AbstractTreeProvider<NxCommandsTreeI
       getShellExecutionForConfig({
         cwd: workspacePath,
         displayCommand: prefixedCommand,
+        standaloneNx: isStandaloneNx,
       })
     );
     tasks.executeTask(task);

--- a/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
+++ b/libs/vscode/nx-commands-view/src/lib/nx-commands-provider.ts
@@ -73,7 +73,7 @@ export class NxCommandsTreeProvider extends AbstractTreeProvider<NxCommandsTreeI
     const prefixedCommand = command.startsWith('nx ')
       ? command
       : `nx ${command}`;
-    const { workspacePath, workspaceType, isStandaloneNx } =
+    const { workspacePath, workspaceType, isEncapsulatedNx } =
       await getNxWorkspace();
     const pkgManager = detectPackageManager(workspacePath);
 
@@ -85,7 +85,7 @@ export class NxCommandsTreeProvider extends AbstractTreeProvider<NxCommandsTreeI
       getShellExecutionForConfig({
         cwd: workspacePath,
         displayCommand: prefixedCommand,
-        standaloneNx: isStandaloneNx,
+        encapsulatedNx: isEncapsulatedNx,
       })
     );
     tasks.executeTask(task);

--- a/libs/vscode/nx-conversion/src/lib/vscode-nx-conversion.ts
+++ b/libs/vscode/nx-conversion/src/lib/vscode-nx-conversion.ts
@@ -124,7 +124,7 @@ function createMakeNgFasterTask() {
     getShellExecutionForConfig({
       cwd: workspacePath,
       displayCommand,
-      standaloneNx: false,
+      encapsulatedNx: false,
     })
   );
   return task;

--- a/libs/vscode/nx-conversion/src/lib/vscode-nx-conversion.ts
+++ b/libs/vscode/nx-conversion/src/lib/vscode-nx-conversion.ts
@@ -124,6 +124,7 @@ function createMakeNgFasterTask() {
     getShellExecutionForConfig({
       cwd: workspacePath,
       displayCommand,
+      standaloneNx: false,
     })
   );
   return task;

--- a/libs/vscode/project-graph/src/lib/create-project-graph.ts
+++ b/libs/vscode/project-graph/src/lib/create-project-graph.ts
@@ -11,7 +11,7 @@ import * as cacheDir from 'find-cache-dir';
 let projectGraphCacheDir: string | undefined;
 
 export async function createProjectGraph() {
-  const { isStandaloneNx, workspacePath } = await getNxWorkspace();
+  const { isEncapsulatedNx, workspacePath } = await getNxWorkspace();
   return new Promise<void | string>((res, rej) => {
     if (!projectGraphCacheDir) {
       projectGraphCacheDir = cacheDir({
@@ -24,7 +24,7 @@ export async function createProjectGraph() {
       cwd: workspacePath,
       displayCommand:
         'nx dep-graph --file ' + getProjectGraphOutput().relativePath,
-      standaloneNx: isStandaloneNx,
+      encapsulatedNx: isEncapsulatedNx,
     });
 
     getOutputChannel().appendLine(

--- a/libs/vscode/project-graph/src/lib/create-project-graph.ts
+++ b/libs/vscode/project-graph/src/lib/create-project-graph.ts
@@ -1,37 +1,37 @@
 import { detectPackageManager, getPackageManagerCommand } from '@nrwl/devkit';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
-import { getOutputChannel } from '@nx-console/vscode/utils';
+import { getNxWorkspace } from '@nx-console/vscode/nx-workspace';
+import {
+  getOutputChannel,
+  getShellExecutionForConfig,
+} from '@nx-console/vscode/utils';
 import { execSync } from 'child_process';
 import * as cacheDir from 'find-cache-dir';
 
 let projectGraphCacheDir: string | undefined;
 
 export async function createProjectGraph() {
+  const { isStandaloneNx, workspacePath } = await getNxWorkspace();
   return new Promise<void | string>((res, rej) => {
     if (!projectGraphCacheDir) {
       projectGraphCacheDir = cacheDir({
         name: 'nx-console-project-graph',
-        cwd: WorkspaceConfigurationStore.instance.get('nxWorkspacePath', ''),
+        cwd: workspacePath,
       });
     }
 
-    const workspacePath = WorkspaceConfigurationStore.instance.get(
-      'nxWorkspacePath',
-      ''
-    );
-    const packageManager = detectPackageManager(workspacePath);
-    const packageCommand = getPackageManagerCommand(packageManager);
-
-    // TODO(cammisuli): determine the correct command depending on Nx Version
-    const command = `${packageCommand.exec} nx dep-graph --file ${
-      getProjectGraphOutput().relativePath
-    }`;
+    const shellExecution = getShellExecutionForConfig({
+      cwd: workspacePath,
+      displayCommand:
+        'nx dep-graph --file ' + getProjectGraphOutput().relativePath,
+      standaloneNx: isStandaloneNx,
+    });
 
     getOutputChannel().appendLine(
-      `Generating graph with command: \`${command}\``
+      `Generating graph with command: \`${shellExecution.command}\``
     );
     try {
-      execSync(command, {
+      execSync(shellExecution.commandLine ?? '', {
         cwd: workspacePath,
       });
 

--- a/libs/vscode/project-graph/src/lib/create-project-graph.ts
+++ b/libs/vscode/project-graph/src/lib/create-project-graph.ts
@@ -1,4 +1,3 @@
-import { detectPackageManager, getPackageManagerCommand } from '@nrwl/devkit';
 import { WorkspaceConfigurationStore } from '@nx-console/vscode/configuration';
 import { getNxWorkspace } from '@nx-console/vscode/nx-workspace';
 import {

--- a/libs/vscode/project-graph/src/lib/graph.machine.spec.ts
+++ b/libs/vscode/project-graph/src/lib/graph.machine.spec.ts
@@ -5,6 +5,8 @@ import { PartialDeep } from 'type-fest';
 import type { OutputChannel } from 'vscode';
 
 import * as utils from '@nx-console/vscode/utils';
+import { NxWorkspace } from '@nx-console/shared/types';
+
 jest.mock(
   '@nx-console/vscode/utils',
   (): PartialDeep<typeof utils> => ({
@@ -16,6 +18,20 @@ jest.mock(
       } as unknown as OutputChannel;
     },
   })
+);
+
+jest.mock(
+  '@nx-console/vscode/nx-workspace',
+  (): PartialDeep<typeof import('@nx-console/vscode/nx-workspace')> => {
+    return {
+      async getNxWorkspace(reset?: boolean): Promise<NxWorkspace> {
+        return {
+          isEncapsulatedNx: false,
+          workspacePath: 'temp',
+        } as NxWorkspace;
+      },
+    };
+  }
 );
 
 const mockMachine = graphMachine.withConfig({

--- a/libs/vscode/tasks/src/lib/cli-task-provider.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-provider.ts
@@ -68,7 +68,7 @@ export class CliTaskProvider implements TaskProvider {
   }
 
   async createTask(definition: CliTaskDefinition) {
-    return CliTask.create(definition, this.getWorkspacePath());
+    return CliTask.create(definition);
   }
 
   async executeTask(definition: CliTaskDefinition) {
@@ -88,14 +88,11 @@ export class CliTaskProvider implements TaskProvider {
       positionals &&
       positionals.length > 2
     ) {
-      task = NxTask.create(
-        {
-          command: `workspace-${positionals[1]}`,
-          positional: positionals[2],
-          flags: definition.flags,
-        },
-        this.getWorkspacePath()
-      );
+      task = await NxTask.create({
+        command: `workspace-${positionals[1]}`,
+        positional: positionals[2],
+        flags: definition.flags,
+      });
     } else {
       task = await this.createTask(definition);
     }

--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -2,19 +2,19 @@ import { checkIsNxWorkspace } from '@nx-console/shared/utils';
 import { getShellExecutionForConfig } from '@nx-console/vscode/utils';
 import { Task, TaskGroup, TaskScope } from 'vscode';
 import { CliTaskDefinition } from './cli-task-definition';
+import { getNxWorkspace } from '@nx-console/vscode/nx-workspace';
 
 export class CliTask extends Task {
-  static async create(
-    definition: CliTaskDefinition,
-    workspacePath: string
-  ): Promise<CliTask> {
+  static async create(definition: CliTaskDefinition): Promise<CliTask> {
     const { command } = definition;
 
     // Using `run [project]:[command]` is more backwards compatible in case different
     // versions of CLI does not handle `[command] [project]` args.
     const args = getArgs(definition);
 
-    const useNxCli = await checkIsNxWorkspace(workspacePath);
+    const { isStandaloneNx, workspacePath, workspaceType } =
+      await getNxWorkspace();
+    const useNxCli = workspaceType == 'nx';
 
     const displayCommand = useNxCli
       ? `nx ${args.join(' ')}`
@@ -29,6 +29,7 @@ export class CliTask extends Task {
       getShellExecutionForConfig({
         displayCommand,
         cwd: workspacePath,
+        standaloneNx: isStandaloneNx,
       })
     );
 

--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -12,7 +12,7 @@ export class CliTask extends Task {
     // versions of CLI does not handle `[command] [project]` args.
     const args = getArgs(definition);
 
-    const { isStandaloneNx, workspacePath, workspaceType } =
+    const { isEncapsulatedNx, workspacePath, workspaceType } =
       await getNxWorkspace();
     const useNxCli = workspaceType == 'nx';
 
@@ -29,7 +29,7 @@ export class CliTask extends Task {
       getShellExecutionForConfig({
         displayCommand,
         cwd: workspacePath,
-        standaloneNx: isStandaloneNx,
+        encapsulatedNx: isEncapsulatedNx,
       })
     );
 

--- a/libs/vscode/tasks/src/lib/nx-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/nx-task-commands.ts
@@ -256,14 +256,11 @@ async function promptForAffectedFlags(target: string) {
   const { positional, command, flags } = await selectAffectedFlags(target);
 
   if (flags !== undefined) {
-    const task = NxTask.create(
-      {
-        command,
-        flags,
-        positional,
-      },
-      cliTaskProvider.getWorkspacePath()
-    );
+    const task = await NxTask.create({
+      command,
+      flags,
+      positional,
+    });
     tasks.executeTask(task);
   }
 }
@@ -328,13 +325,10 @@ async function promptForRunMany() {
   const flags = await selectFlags('run-many', options, 'nx', { target });
 
   if (flags !== undefined) {
-    const task = NxTask.create(
-      {
-        command: 'run-many',
-        flags,
-      },
-      cliTaskProvider.getWorkspacePath()
-    );
+    const task = await NxTask.create({
+      command: 'run-many',
+      flags,
+    });
     tasks.executeTask(task);
   }
 }
@@ -342,13 +336,10 @@ async function promptForRunMany() {
 async function promptForList() {
   const telemetry = getTelemetry();
   telemetry.featureUsed('affected-cli');
-  const task = NxTask.create(
-    {
-      command: 'list',
-      flags: [],
-    },
-    cliTaskProvider.getWorkspacePath()
-  );
+  const task = await NxTask.create({
+    command: 'list',
+    flags: [],
+  });
   tasks.executeTask(task);
 }
 
@@ -381,13 +372,10 @@ async function promptForMigrate() {
   if (depVersioningInfo !== undefined) {
     const { dep, version } = depVersioningInfo;
 
-    const task = NxTask.create(
-      {
-        command: 'migrate',
-        flags: [`${dep}@${version}`],
-      },
-      cliTaskProvider.getWorkspacePath()
-    );
+    const task = await NxTask.create({
+      command: 'migrate',
+      flags: [`${dep}@${version}`],
+    });
 
     tasks.executeTask(task);
   }

--- a/libs/vscode/tasks/src/lib/nx-task.ts
+++ b/libs/vscode/tasks/src/lib/nx-task.ts
@@ -1,3 +1,4 @@
+import { getNxWorkspace } from '@nx-console/vscode/nx-workspace';
 import { getShellExecutionForConfig } from '@nx-console/vscode/utils';
 import { Task, TaskScope } from 'vscode';
 
@@ -8,7 +9,7 @@ export interface NxTaskDefinition {
 }
 
 export class NxTask extends Task {
-  static create(definition: NxTaskDefinition, workspacePath: string): NxTask {
+  static async create(definition: NxTaskDefinition): Promise<NxTask> {
     const { command, flags, positional } = definition;
 
     const args: string[] = [
@@ -16,6 +17,8 @@ export class NxTask extends Task {
       ...(positional ? [positional] : []),
       ...flags,
     ];
+
+    const { isStandaloneNx, workspacePath } = await getNxWorkspace();
 
     const displayCommand = `nx ${args.join(' ')}`;
     const task = new NxTask(
@@ -27,6 +30,7 @@ export class NxTask extends Task {
       getShellExecutionForConfig({
         displayCommand,
         cwd: workspacePath,
+        standaloneNx: isStandaloneNx,
       })
     );
     return task;

--- a/libs/vscode/tasks/src/lib/nx-task.ts
+++ b/libs/vscode/tasks/src/lib/nx-task.ts
@@ -18,7 +18,7 @@ export class NxTask extends Task {
       ...flags,
     ];
 
-    const { isStandaloneNx, workspacePath } = await getNxWorkspace();
+    const { isEncapsulatedNx, workspacePath } = await getNxWorkspace();
 
     const displayCommand = `nx ${args.join(' ')}`;
     const task = new NxTask(
@@ -30,7 +30,7 @@ export class NxTask extends Task {
       getShellExecutionForConfig({
         displayCommand,
         cwd: workspacePath,
-        standaloneNx: isStandaloneNx,
+        encapsulatedNx: isEncapsulatedNx,
       })
     );
     return task;

--- a/libs/vscode/utils/src/lib/shell-execution.ts
+++ b/libs/vscode/utils/src/lib/shell-execution.ts
@@ -6,14 +6,14 @@ import { ShellExecution } from 'vscode';
 export interface ShellConfig {
   cwd: string;
   displayCommand: string;
-  standaloneNx: boolean;
+  encapsulatedNx: boolean;
 }
 
 export function getShellExecutionForConfig(
   config: ShellConfig
 ): ShellExecution {
   let command = config.displayCommand;
-  if (config.standaloneNx) {
+  if (config.encapsulatedNx) {
     if (platform() == 'win32') {
       command = command.replace(/^nx/, './nx.bat');
     } else {

--- a/libs/vscode/utils/src/lib/shell-execution.ts
+++ b/libs/vscode/utils/src/lib/shell-execution.ts
@@ -1,21 +1,31 @@
 import { detectPackageManager, getPackageManagerCommand } from '@nrwl/devkit';
+import { platform } from 'os';
+
 import { ShellExecution } from 'vscode';
 
 export interface ShellConfig {
   cwd: string;
   displayCommand: string;
+  standaloneNx: boolean;
 }
 
 export function getShellExecutionForConfig(
   config: ShellConfig
 ): ShellExecution {
-  const packageManager = detectPackageManager(config.cwd);
-  const packageManagerCommand = getPackageManagerCommand(packageManager);
-
-  return new ShellExecution(
-    `${packageManagerCommand.exec} ${config.displayCommand}`,
-    {
-      cwd: config.cwd,
+  let command = config.displayCommand;
+  if (config.standaloneNx) {
+    if (platform() == 'win32') {
+      command = command.replace(/^nx/, './nx.bat');
+    } else {
+      command = command.replace(/^nx/, './nx');
     }
-  );
+  } else {
+    const packageManager = detectPackageManager(config.cwd);
+    const packageManagerCommand = getPackageManagerCommand(packageManager);
+    command = `${packageManagerCommand.exec} ${command}`;
+  }
+
+  return new ShellExecution(command, {
+    cwd: config.cwd,
+  });
 }


### PR DESCRIPTION
Using the nxls we can check if the workspace has an encapsulated version of Nx. And if so, we change all the shell executions to run with `./nx` or `./nx.bat`
