### PR TITLE
fix(generate-ui): make sure the form is centered correctly on large screens

### DIFF
--- a/libs/generate-ui/feature-task-execution-form/src/lib/task-execution-form/task-execution-form.component.scss
+++ b/libs/generate-ui/feature-task-execution-form/src/lib/task-execution-form/task-execution-form.component.scss
@@ -74,7 +74,6 @@ form {
   margin: auto;
   padding-left: 190px;
   padding-right: 190px;
-  padding-right: $host-padding-right - $scrollbar-width;
 }
 
 .scroll-container {


### PR DESCRIPTION
AFTER
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/34165455/221240743-251ac79d-6330-4b04-8c90-63140c45e1d0.png">


BEFORE
<img width="1658" alt="image" src="https://user-images.githubusercontent.com/34165455/221242730-0cd18c98-6828-4312-af03-d6b01af72490.png">

