### PR TITLE
fix(nxls): do not include workspace layout in directory context for generate calls

### DIFF
--- a/libs/language-server/workspace/src/lib/get-generator-context-from-path.ts
+++ b/libs/language-server/workspace/src/lib/get-generator-context-from-path.ts
@@ -34,11 +34,18 @@ export async function getGeneratorContextFromPath(
   const libsDir = workspaceLayout.libsDir;
   if (
     appsDir &&
-    (generator?.name === 'application' || generator?.name === 'app')
+    (generator?.name === 'application' ||
+      generator?.name === 'app' ||
+      modifiedPath.startsWith(appsDir))
   ) {
     modifiedPath = modifiedPath.replace(appsDir, '').replace(/^\//, '');
   }
-  if (libsDir && (generator?.name === 'library' || generator?.name === 'lib')) {
+  if (
+    libsDir &&
+    (generator?.name === 'library' ||
+      generator?.name === 'lib' ||
+      modifiedPath.startsWith(libsDir))
+  ) {
     modifiedPath = modifiedPath.replace(libsDir, '').replace(/^\//, '');
   }
 


### PR DESCRIPTION
When generating with the context menu, (depending where the context menu is initialized) sometimes we get the workspace layout directory prefilled. This causes generates to create a duplicated nested folders. (ie, `libs/libs`)