### PR TITLE
fix(intellij): slightly reduce generate-ui white flicker

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/NxGenerateUiFile.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/NxGenerateUiFile.kt
@@ -70,6 +70,7 @@ class DefaultNxGenerateUiFile(name: String, project: Project) : NxGenerateUiFile
     override fun createMainComponent(project: Project): JComponent {
 
         browser.jbCefClient.setProperty(JBCefClient.Properties.JS_QUERY_POOL_SIZE, 10)
+        browser.setPageBackgroundColor(getHexColor(UIUtil.getPanelBackground()))
         registerAppSchemeHandler()
         browser.loadURL("http://nxconsole/index.html")
         Disposer.register(project, browser)


### PR DESCRIPTION
the browser will now load the correct background color as soon as it's loaded instead of after communicating with the IntelliJ. Not sure how to eliminate the remaining flicker.