### PR TITLE
feat(intellij): suggest installing plugin by dependency support

### DIFF
--- a/apps/intellij/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,7 @@
   <depends>JavaScript</depends>
 
   <extensions defaultExtensionNs="com.intellij">
+    <dependencySupport kind="javascript" coordinate="npm:nx" displayName="Nx Console"/>
 
     <!-- works in WebStorm and other SmallIDEs -->
     <directoryProjectGenerator implementation="dev.nx.console.cli.NxCreateWorkspaceProjectGenerator"/>


### PR DESCRIPTION
This PR should add suggestion for installing plugin when finding nx javascript dependency in the project
Like for stylus here below

<img width="428" alt="Screenshot 2023-03-03 at 20 36 57" src="https://user-images.githubusercontent.com/9085108/222811781-b4f1c2ff-1533-40f9-a30a-881dd3e7ca44.png">
  
It should be available after publishing this to marketplace