### PR TITLE
fix(intellij): use latest by default when creating a new workspace

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/cli/NxCreateWorkspaceProjectGenerator.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/cli/NxCreateWorkspaceProjectGenerator.kt
@@ -14,8 +14,8 @@ import javax.swing.Icon
 
 class NxCreateWorkspaceProjectGenerator : NpmPackageProjectGenerator() {
 
-    private val PACKAGE_NAME = "create-nx-workspace"
-    private val CREATE_COMMAND = "create-nx-workspace"
+    private val PACKAGE_NAME = "create-nx-workspace@latest"
+    private val CREATE_COMMAND = "create-nx-workspace@latest"
 
     override fun getId(): String = "Nx"
 
@@ -40,9 +40,9 @@ class NxCreateWorkspaceProjectGenerator : NpmPackageProjectGenerator() {
     }
     override fun packageName(): String = PACKAGE_NAME
 
-    override fun presentablePackageName(): String = "create-nx-&workspace:"
+    override fun presentablePackageName(): String = "Command:"
 
-    override fun getIcon(): Icon = NxIcons.Action
+    override fun getIcon(): Icon = NxIcons.FileType
 
     override fun validateProjectPath(path: String): String? {
         val error = NodePackageUtil.validateNpmPackageName(PathUtil.getFileName(path))


### PR DESCRIPTION
this isn't the greatest solution but it works for now. 
Before, the field would show a new version but npx cache would pick up an outdated one.

Ideally, we would have a custom UI here that lets you pick the version etc.