### PR TITLE
fix(vscode): handle daemon better

### DIFF
--- a/apps/vscode/src/commands/refresh-workspace.ts
+++ b/apps/vscode/src/commands/refresh-workspace.ts
@@ -5,10 +5,12 @@ import { commands } from 'vscode';
 
 export const REFRESH_WORKSPACE = 'nxConsole.refreshWorkspace';
 
-const refresh = new Subject();
+const refresh = new Subject<boolean>();
 
-refresh.pipe(debounceTime(150)).subscribe(async () => {
-  sendNotification(NxWorkspaceRefreshNotification);
+refresh.pipe(debounceTime(150)).subscribe(async (fromLsp) => {
+  if (!fromLsp) {
+    sendNotification(NxWorkspaceRefreshNotification);
+  }
   commands.executeCommand('nxConsole.refreshNxProjectsTree');
   commands.executeCommand('nxConsole.refreshRunTargetTree');
   commands.executeCommand('nx.graph.refresh');
@@ -18,7 +20,7 @@ refresh.pipe(debounceTime(150)).subscribe(async () => {
  * Refresh workspace by debouncing multiple calls to only trigger once
  */
 export function refreshWorkspace() {
-  return commands.registerCommand(REFRESH_WORKSPACE, () => {
-    refresh.next(undefined);
+  return commands.registerCommand(REFRESH_WORKSPACE, (fromLsp: boolean) => {
+    refresh.next(fromLsp);
   });
 }

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -346,8 +346,6 @@ async function registerWorkspaceFileWatcher(
           setTimeout(() => {
             setWorkspace(workspacePath);
           }, 1000);
-        } else {
-          commands.executeCommand(REFRESH_WORKSPACE);
         }
       }
     )

--- a/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
@@ -36,6 +36,7 @@ export async function getNxWorkspaceConfig(
     // Always set the CI env variable to false
     (process.env as any).CI = false;
     (process.env as any).NX_PROJECT_GLOB_CACHE = false;
+    (process.env as any).NX_WORKSPACE_ROOT_PATH = workspacePath;
     const [nxWorkspacePackage, nxProjectGraph] = await Promise.all([
       getNxWorkspacePackageFileUtils(workspacePath, logger),
       getNxProjectGraph(workspacePath, logger),

--- a/libs/language-server/workspace/src/lib/get-nx-workspace-package.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-workspace-package.ts
@@ -9,39 +9,22 @@ import { Logger } from '@nx-console/shared/schema';
 
 declare function __non_webpack_require__(importPath: string): any;
 
-let RESOLVED_FILEUTILS_IMPORT: typeof NxFileUtils;
-let RESOLVED_PROJECTGRAPH_IMPORT: typeof NxProjectGraph;
-let RESOLVED_DAEMON_CLIENT: typeof NxDaemonClient;
-
 export async function getNxDaemonClient(
   workspacePath: string,
   logger: Logger
 ): Promise<typeof NxDaemonClient> {
-  if (RESOLVED_DAEMON_CLIENT) {
-    return RESOLVED_DAEMON_CLIENT;
-  }
-
   const importPath = await findNxPackagePath(
     workspacePath,
     join('src', 'daemon', 'client', 'client.js')
   );
   const backupPackage = await import('nx/src/daemon/client/client');
-  return getNxPackage(
-    importPath,
-    backupPackage,
-    RESOLVED_DAEMON_CLIENT,
-    logger
-  );
+  return getNxPackage(importPath, backupPackage, logger);
 }
 
 export async function getNxProjectGraph(
   workspacePath: string,
   logger: Logger
 ): Promise<typeof NxProjectGraph> {
-  if (RESOLVED_PROJECTGRAPH_IMPORT) {
-    return RESOLVED_PROJECTGRAPH_IMPORT;
-  }
-
   let importPath = await findNxPackagePath(
     workspacePath,
     join('src', 'project-graph', 'project-graph.js')
@@ -55,12 +38,7 @@ export async function getNxProjectGraph(
   }
 
   const nxProjectGraph = await import('nx/src/project-graph/project-graph');
-  return getNxPackage(
-    importPath,
-    nxProjectGraph,
-    RESOLVED_PROJECTGRAPH_IMPORT,
-    logger
-  );
+  return getNxPackage(importPath, nxProjectGraph, logger);
 }
 
 /**
@@ -70,10 +48,6 @@ export async function getNxWorkspacePackageFileUtils(
   workspacePath: string,
   logger: Logger
 ): Promise<typeof NxFileUtils> {
-  if (RESOLVED_FILEUTILS_IMPORT) {
-    return RESOLVED_FILEUTILS_IMPORT;
-  }
-
   let importPath = await findNxPackagePath(
     workspacePath,
     join('src', 'project-graph', 'file-utils.js')
@@ -87,18 +61,12 @@ export async function getNxWorkspacePackageFileUtils(
   }
 
   const nxFileUtils = await import('nx/src/project-graph/file-utils');
-  return getNxPackage(
-    importPath,
-    nxFileUtils,
-    RESOLVED_FILEUTILS_IMPORT,
-    logger
-  );
+  return getNxPackage(importPath, nxFileUtils, logger);
 }
 
 async function getNxPackage<T>(
   importPath: string | undefined,
   backupPackage: T,
-  cache: T,
   logger: Logger
 ): Promise<T> {
   try {
@@ -114,7 +82,6 @@ async function getNxPackage<T>(
 
     logger?.log(`Using local Nx package at ${importPath}`);
 
-    cache = imported;
     return imported;
   } catch (error) {
     logger?.log(
@@ -122,7 +89,6 @@ async function getNxPackage<T>(
 ${error}
     `
     );
-    cache = backupPackage;
     return backupPackage;
   }
 }

--- a/libs/vscode/lsp-client/src/lib/configure-lsp-client.ts
+++ b/libs/vscode/lsp-client/src/lib/configure-lsp-client.ts
@@ -69,7 +69,7 @@ export function configureLspClient(
   client.onNotification(NxWorkspaceRefreshNotification, () => {
     if (refreshCommand) {
       getOutputChannel().appendLine('Refreshing ui due to lsp notification');
-      commands.executeCommand(refreshCommand);
+      commands.executeCommand(refreshCommand, true);
     }
   });
 


### PR DESCRIPTION
* Adds a flag to only send notifications to the language server if the language server didn't send the notification first
* Removes the cache for finding local nx packages
* Set `NX_WORKSPACE_ROOT_PATH`