### PR TITLE
fix(intellij): change default task name

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowFactory.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowFactory.kt
@@ -17,6 +17,15 @@ class NxToolWindowFactory : ToolWindowFactory, DumbAware {
 
 data class NxTaskSet(val nxProjects: List<String>, val nxTargets: List<String>)
 
-val NxTaskSet.suggestedName
-    get() =
-        nxProjects.joinToString(separator = ",") + nxTargets.joinToString(separator = ",", "[", "]")
+val NxTaskSet.suggestedName: String
+    get() {
+        var name = nxProjects.joinToString(separator = ",")
+        name +=
+            if (nxTargets.size > 1) {
+                " --targets=${nxTargets.joinToString(separator = ",")}"
+            } else {
+                ":${nxTargets.first()}"
+            }
+
+        return name
+    }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
@@ -42,7 +42,15 @@ class NxCommandConfiguration(project: Project, factory: ConfigurationFactory) :
     }
 
     override fun suggestedName(): String {
-        return "${nxRunSettings.nxProjects}[${nxRunSettings.nxTargets}]"
+        if (nxRunSettings.nxProjects.isEmpty() || nxRunSettings.nxTargets.isEmpty()) {
+            return ""
+        }
+
+        if (',' in nxRunSettings.nxTargets) {
+            return "${nxRunSettings.nxProjects} --targets=${nxRunSettings.nxTargets}"
+        }
+
+        return "${nxRunSettings.nxProjects}:${nxRunSettings.nxTargets}"
     }
 }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxTaskExecutionManager.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxTaskExecutionManager.kt
@@ -22,7 +22,7 @@ class NxTaskExecutionManager(val project: Project) {
                 }
                 ?: runManager
                     .createConfiguration(
-                        "$nxProject[$nxTarget]",
+                        "$nxProject:$nxTarget",
                         NxCommandConfigurationType::class.java
                     )
                     .apply {


### PR DESCRIPTION
## What it does
Original implementation showed default task names as `project[target]`

The reasoning behind this was because we can run multiple targets, and multiple targets would show as `project[task1,task2]`

I'm changing this logic to the following:

If there's more than one target configured we'll show this:
`project --targets=task1,task2`

If there's only one target configured then we'll show this:
`project:task`

This inlines the UI to match the cli pattern 
