### PR TITLE
fix(nxls): use `workspaceFolders` before `rootUri` for better Windows path compatibility

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
@@ -142,7 +142,6 @@ class NxlsWrapper(val project: Project) {
 
     fun getInitParams(): InitializeParams {
         val initParams = InitializeParams()
-        initParams.rootUri = project.nxBasePath
         initParams.workspaceFolders = listOf(WorkspaceFolder(project.nxBasePath))
 
         val workspaceClientCapabilities = WorkspaceClientCapabilities()

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -94,9 +94,9 @@ connection.onInitialize(async (params) => {
   try {
     WORKING_PATH =
       workspacePath ||
+      params.workspaceFolders?.[0]?.uri ||
       params.rootPath ||
-      URI.parse(params.rootUri ?? '').fsPath ||
-      params.workspaceFolders?.[0]?.uri;
+      URI.parse(params.rootUri ?? '').fsPath;
 
     if (!WORKING_PATH) {
       throw 'Unable to determine workspace path';


### PR DESCRIPTION
fixes #1585