### PR TITLE
fix(intellij): do not add or remove document listeners on editors that are not connected to the language server

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/listeners/NxEditorListener.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/listeners/NxEditorListener.kt
@@ -1,6 +1,5 @@
 package dev.nx.console.listeners
 
-import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.event.EditorFactoryEvent
@@ -15,8 +14,11 @@ private val log = logger<NxEditorListener>()
 class NxEditorListener : EditorFactoryListener {
 
     override fun editorReleased(event: EditorFactoryEvent) {
-        val project = event.editor.project ?: return super.editorCreated(event)
-        project.service<NxlsService>().removeDocument(event.editor)
+        val project = event.editor.project ?: return super.editorReleased(event)
+        val service = NxlsService.getInstance(project)
+        if (service.isEditorConnected(event.editor)) {
+            service.removeDocument(event.editor)
+        }
 
         super.editorReleased(event)
     }
@@ -28,7 +30,10 @@ class NxEditorListener : EditorFactoryListener {
 
         if (DocumentUtils.isNxFile(file.name)) {
             log.info("Connecting ${file.path} to lsp")
-            NxlsService.getInstance(project).addDocument(event.editor)
+            val service = NxlsService.getInstance(project)
+            if (!service.isEditorConnected(event.editor)) {
+                service.addDocument(event.editor)
+            }
         }
 
         super.editorCreated(event)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/managers/DocumentManager.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/managers/DocumentManager.kt
@@ -23,7 +23,7 @@ class DocumentManager(val editor: Editor) {
 
     companion object {
         fun getInstance(editor: Editor): DocumentManager {
-            return documentManagers.getOrPut(getFilePath(editor.document) ?: "") {
+            return documentManagers.getOrPut(getFilePath(editor.document)) {
                 DocumentManager(editor)
             }
         }
@@ -155,6 +155,6 @@ class DocumentManager(val editor: Editor) {
     }
 }
 
-fun getFilePath(document: Document): String? {
-    return FileDocumentManager.getInstance().getFile(document)?.url
+fun getFilePath(document: Document): String {
+    return FileDocumentManager.getInstance().getFile(document)?.url ?: "/dev/"
 }


### PR DESCRIPTION
fixes #1618