### PR TITLE
fix(nxls): do not output exec to stdio (#1644

### DIFF
--- a/apps/intellij/build.gradle.kts
+++ b/apps/intellij/build.gradle.kts
@@ -173,12 +173,16 @@ tasks {
 }
 
 tasks.register<Exec>("buildNxls") {
-    commandLine = listOf("bash", "-c", "npx nx run nxls:build")
+    commandLine = buildCommands().apply {
+        add("npx nx run nxls:build")
+    }
     workingDir = rootDir
 }
 
 tasks.register<Exec>("buildGenerateUi") {
-    commandLine = listOf("bash", "-c", "npx nx run generate-ui:build:production-intellij")
+    commandLine = buildCommands().apply {
+        add("npx nx run generate-ui:build:production-intellij")
+    }
     workingDir = rootDir
 }
 
@@ -193,4 +197,12 @@ tasks.register<DefaultTask>("publish") {
     // does nothing
     group = "publish"
     description = "Placeholder task to workaround the semantic-release plugin"
+}
+
+fun buildCommands() = mutableListOf<String>().apply {
+    if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+        addAll(listOf("pwsh", "-command"))
+    } else {
+        addAll(listOf("bash", "-c"))
+    }
 }

--- a/apps/intellij/build.gradle.kts
+++ b/apps/intellij/build.gradle.kts
@@ -1,6 +1,10 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 
+fun isWindows(): Boolean {
+    return System.getProperty("os.name").toLowerCase().startsWith("windows")
+}
+
 val nxlsRoot = "${rootDir}/dist/apps/nxls"
 
 buildDir = file("${rootDir}/dist/apps/intellij")
@@ -173,16 +177,12 @@ tasks {
 }
 
 tasks.register<Exec>("buildNxls") {
-    commandLine = buildCommands().apply {
-        add("npx nx run nxls:build")
-    }
+    commandLine = buildCommands() + "npx nx run nxls:build"
     workingDir = rootDir
 }
 
 tasks.register<Exec>("buildGenerateUi") {
-    commandLine = buildCommands().apply {
-        add("npx nx run generate-ui:build:production-intellij")
-    }
+    commandLine = buildCommands() + "npx nx run generate-ui:build:production-intellij"
     workingDir = rootDir
 }
 
@@ -199,10 +199,9 @@ tasks.register<DefaultTask>("publish") {
     description = "Placeholder task to workaround the semantic-release plugin"
 }
 
-fun buildCommands() = mutableListOf<String>().apply {
-    if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-        addAll(listOf("pwsh", "-command"))
+fun buildCommands() =
+    if (isWindows()) {
+        mutableListOf("pwsh", "-command")
     } else {
-        addAll(listOf("bash", "-c"))
+        mutableListOf("bash", "-c")
     }
-}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
@@ -14,6 +14,8 @@ import dev.nx.console.models.ProjectGraphOutput
 import dev.nx.console.utils.jcef.getHexColor
 import dev.nx.console.utils.jcef.onBrowserLoadEnd
 import java.io.File
+import java.util.regex.Matcher
+import kotlin.io.path.Path
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import org.jetbrains.concurrency.await
@@ -113,11 +115,18 @@ class NxGraphBrowser(
 
     private fun loadGraphHtml(graphOutput: ProjectGraphOutput, reload: Boolean) {
         browserLoadedState.value = false
+
+        val fullPath = graphOutput.fullPath
+
+        val basePath = "${Path(fullPath).parent}/"
+
         val originalGraphHtml = File(graphOutput.fullPath).readText(Charsets.UTF_8)
         val transformedGraphHtml =
             originalGraphHtml.replace(
-                Regex("</head>"),
+                Regex("<head>"),
                 """
+          <head>
+          <base href="${Matcher.quoteReplacement(basePath)}">
           <style>
             #sidebar {
               display: none;
@@ -142,10 +151,10 @@ class NxGraphBrowser(
               padding: 12px;
             }
           </style>
-          </head>
           """
             )
-        browser.loadHTML(transformedGraphHtml, "file://${graphOutput.fullPath}")
+
+        browser.loadHTML(transformedGraphHtml, "https://nx-graph")
 
         if (reload) {
             lastCommand?.apply {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
@@ -44,7 +44,7 @@ interface NxService {
     }
 
     @JsonRequest
-    fun createProjectGraph(): CompletableFuture<CreateProjectGraphError?> {
+    fun createProjectGraph(): CompletableFuture<String?> {
         throw UnsupportedOperationException()
     }
     @JsonNotification

--- a/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
@@ -89,7 +89,9 @@ class NxlsService(val project: Project) {
 
     suspend fun createProjectGraph(): CreateProjectGraphError? {
         return try {
-            server()?.getNxService()?.createProjectGraph()?.await()
+            server()?.getNxService()?.createProjectGraph()?.await()?.let {
+                CreateProjectGraphError(1000, it)
+            }
         } catch (e: ResponseErrorException) {
             CreateProjectGraphError(e.responseError.code, e.responseError.message)
         }

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -65,6 +65,10 @@ process.on('unhandledRejection', (e: any) => {
   connection.console.error(formatError(`Unhandled exception`, e));
 });
 
+process.on('uncaughtException', (e) => {
+  connection.console.error(formatError('Unhandled exception', e));
+});
+
 let WORKING_PATH: string | undefined = undefined;
 let CLIENT_CAPABILITIES: ClientCapabilities | undefined = undefined;
 let unregisterFileWatcher: () => void = () => {
@@ -327,7 +331,11 @@ connection.onRequest(NxCreateProjectGraphRequest, async () => {
   if (!WORKING_PATH) {
     return new ResponseError(1000, 'Unable to get Nx info: no workspace path');
   }
-  return await createProjectGraph(WORKING_PATH);
+  try {
+    await createProjectGraph(WORKING_PATH, lspLogger);
+  } catch (e) {
+    return e;
+  }
 });
 
 connection.onNotification(NxWorkspaceRefreshNotification, async () => {

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -86,6 +86,6 @@ export const NxProjectGraphOutputRequest: RequestType<
 
 export const NxCreateProjectGraphRequest: RequestType<
   undefined,
-  undefined | ResponseError,
+  string | undefined,
   unknown
 > = new RequestType('nx/createProjectGraph');

--- a/libs/language-server/workspace/src/lib/get-project-graph-output.ts
+++ b/libs/language-server/workspace/src/lib/get-project-graph-output.ts
@@ -1,6 +1,5 @@
 import { cacheDir } from 'nx/src/devkit-exports';
-import { join, relative } from 'path';
-import { normalize } from '@angular-devkit/core';
+import { join, relative, normalize } from 'path';
 
 export function getProjectGraphOutput(workspacePath: string) {
   const directory = join(cacheDir, 'nx-console-project-graph');

--- a/libs/language-server/workspace/src/lib/get-project-graph-output.ts
+++ b/libs/language-server/workspace/src/lib/get-project-graph-output.ts
@@ -1,12 +1,13 @@
 import { cacheDir } from 'nx/src/devkit-exports';
-import { join } from 'path';
+import { join, relative } from 'path';
+import { normalize } from '@angular-devkit/core';
 
 export function getProjectGraphOutput(workspacePath: string) {
   const directory = join(cacheDir, 'nx-console-project-graph');
   const fullPath = `${directory}/project-graph.html`;
   return {
     directory,
-    relativePath: '.' + fullPath.replace(workspacePath, ''),
+    relativePath: `./${normalize(relative(workspacePath, fullPath))}`,
     fullPath,
   };
 }

--- a/libs/shared/utils/src/lib/get-nx-execution-command.ts
+++ b/libs/shared/utils/src/lib/get-nx-execution-command.ts
@@ -11,6 +11,7 @@ export function getNxExecutionCommand(config: {
   cwd: string;
   displayCommand: string;
   encapsulatedNx: boolean;
+  useNpx?: boolean;
 }): string {
   let command = config.displayCommand;
   if (config.encapsulatedNx) {
@@ -20,9 +21,13 @@ export function getNxExecutionCommand(config: {
       command = command.replace(/^nx/, './nx');
     }
   } else {
-    const packageManager = detectPackageManager(config.cwd);
-    const packageManagerCommand = getPackageManagerCommand(packageManager);
-    command = `${packageManagerCommand.exec} ${command}`;
+    if (config.useNpx) {
+      command = `npx ${command}`;
+    } else {
+      const packageManager = detectPackageManager(config.cwd);
+      const packageManagerCommand = getPackageManagerCommand(packageManager);
+      command = `${packageManagerCommand.exec} ${command}`;
+    }
   }
 
   return command;

--- a/libs/vscode/project-graph/src/lib/graph.machine.ts
+++ b/libs/vscode/project-graph/src/lib/graph.machine.ts
@@ -122,7 +122,7 @@ export const graphMachine =
     {
       services: {
         generateContent: async () => {
-          return (await createProjectGraph())?.message;
+          return await createProjectGraph();
         },
       },
       actions: {


### PR DESCRIPTION
## What it does
In vscode, nxls is started via a fork and communicates with ipc. So messages on stdio will not affect the communication.
With Intellij, the nxls is started with a separate process and communicates with stdio. This means that any `exec` calls that are called within the language server could pollute the stdio communicate and cause the process to exit. So we have to make sure that we set exec calls to `stdio: ignore`.

This also fixes the nx graph to show up properly in Windows.