### PR TITLE
fix(intellij): find the proper run configuration settings for nx targets

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunAction.kt
@@ -1,7 +1,6 @@
 package dev.nx.console.run
 
 import com.intellij.execution.ProgramRunnerUtil
-import com.intellij.execution.RunManager
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -24,9 +23,8 @@ class NxRunAction(private val nxProject: String, private val nxTarget: String) :
             NxCommandConfiguration(project, NxRunConfigurationProducer().configurationFactory)
         runConfig.nxRunSettings = NxRunSettings().copy(nxProjects = nxProject, nxTargets = nxTarget)
 
-        ProgramRunnerUtil.executeConfiguration(
-            RunManager.getInstance(project).getConfigurationSettingsList(runConfig.type).first(),
-            DefaultRunExecutor.getRunExecutorInstance()
-        )
+        val runner = getOrCreateRunnerConfigurationSettings(project, nxProject, nxTarget)
+
+        ProgramRunnerUtil.executeConfiguration(runner, DefaultRunExecutor.getRunExecutorInstance())
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
@@ -1,0 +1,34 @@
+package dev.nx.console.run
+
+import com.intellij.execution.RunManager
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.openapi.project.Project
+
+fun getOrCreateRunnerConfigurationSettings(
+    project: Project,
+    nxProject: String,
+    nxTarget: String,
+    args: List<String> = listOf()
+): RunnerAndConfigurationSettings {
+    val runManager = RunManager.getInstance(project)
+
+    return runManager
+        .getConfigurationSettingsList(NxCommandConfigurationType.getInstance())
+        .firstOrNull {
+            val nxCommandConfiguration = it.configuration as NxCommandConfiguration
+            val nxRunSettings = nxCommandConfiguration.nxRunSettings
+            nxRunSettings.nxTargets == nxTarget && nxRunSettings.nxProjects == nxProject
+        }
+        ?: runManager
+            .createConfiguration("$nxProject:$nxTarget", NxCommandConfigurationType::class.java)
+            .apply {
+                (configuration as NxCommandConfiguration).apply {
+                    nxRunSettings =
+                        NxRunSettings(
+                            nxProjects = nxProject,
+                            nxTargets = nxTarget,
+                            arguments = args.drop(1).joinToString(" "),
+                        )
+                }
+            }
+}


### PR DESCRIPTION
## What it does
Running the `Nx Run Target` from the command prompt or context menu finds the proper run configuration now. Before it always selected the first one without checking if it was the proper run configuration
