### PR TITLE
feat(intellij): add console folding

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/ide/ConsoleFolding.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/ide/ConsoleFolding.kt
@@ -1,0 +1,17 @@
+package dev.nx.console.ide
+
+import com.intellij.execution.ConsoleFolding
+import com.intellij.openapi.project.Project
+
+class ConsoleFolding : ConsoleFolding() {
+    override fun getPlaceholderText(project: Project, lines: MutableList<String>): String? {
+        val nxCommand = lines[0].split(" ").toMutableList()
+        nxCommand[0] = "nx"
+
+        return nxCommand.joinToString(" ")
+    }
+
+    override fun shouldFoldLine(project: Project, line: String): Boolean {
+        return "node_modules/.bin/nx" in line
+    }
+}

--- a/apps/intellij/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,8 @@
                     anchor="right"
                     factoryClass="dev.nx.console.nx_toolwindow.NxToolWindowFactory"
                     icon="dev.nx.console.NxIcons.Action"/>
+
+        <console.folding implementation="dev.nx.console.ide.ConsoleFolding"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
Simplifies the console/terminal output to hide the long path for the nx executable.


Before:
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/4332460/230130014-6f42a288-9fe7-41f1-9c75-6f1dbfb12ed4.png">

After:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/4332460/230129727-e4e84084-a7fa-4905-b794-e6609c51632f.png">
