### PR TITLE
fix(vscode): run target filters projects

### DIFF
--- a/libs/vscode/tasks/src/lib/cli-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-commands.ts
@@ -186,8 +186,12 @@ async function selectCliCommandAndPromptForFlags(
   const { validWorkspaceJson, workspace } = await getNxWorkspace();
 
   if (!projectName) {
+    let taskToRun = command;
+    if (command === 'run' && target !== undefined) {
+      taskToRun = target;
+    }
     const selection = validWorkspaceJson
-      ? await selectCliProject(command, workspace)
+      ? await selectCliProject(taskToRun, workspace)
       : undefined;
     if (!selection) {
       return; // Do not execute a command if user clicks out of VSCode UI.


### PR DESCRIPTION
## What it does
Shows only projects that have the requested run target when clicking items in the Run Target view and the Nx: Run Target command prompt

