### PR TITLE
fix(vscode): remove obsolete commands

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -362,33 +362,8 @@
       },
       {
         "category": "Nx",
-        "title": "lint",
-        "command": "nx.lint"
-      },
-      {
-        "category": "Nx",
-        "title": "build",
-        "command": "nx.build"
-      },
-      {
-        "category": "Nx",
-        "title": "e2e",
-        "command": "nx.e2e"
-      },
-      {
-        "category": "Nx",
         "title": "generate",
         "command": "nx.generate"
-      },
-      {
-        "category": "Nx",
-        "title": "serve",
-        "command": "nx.serve"
-      },
-      {
-        "category": "Nx",
-        "title": "test",
-        "command": "nx.test"
       },
       {
         "category": "Nx",


### PR DESCRIPTION
fixes #1682

I missed some more options that I initially tried to remove in https://github.com/nrwl/nx-console/pull/1672