### PR TITLE
fix(intellij): include package.json for nx file types

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/DocumentUtils.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/DocumentUtils.kt
@@ -10,7 +10,7 @@ import org.eclipse.lsp4j.Position
 
 private val log = logger<DocumentUtils>()
 
-private val nxFiles = setOf("nx.json", "workspace.json", "project.json")
+private val nxFiles = setOf("nx.json", "workspace.json", "project.json", "package.json")
 
 class DocumentUtils {
     companion object {


### PR DESCRIPTION
## What it does
Includes `package.json` in the list of nx files so that we can attach the lsp to. 
