### PR TITLE
fix(vscode): get projects properly in cli-task-command

### DIFF
--- a/libs/vscode/tasks/src/lib/cli-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-commands.ts
@@ -295,7 +295,10 @@ export async function getCliProjectFromUri(
 }
 
 export async function selectCliProject(command: string) {
-  const projectEntries = Object.entries((await getNxWorkspace()) || {});
+  const {
+    workspace: { projects },
+  } = await getNxWorkspace();
+  const projectEntries = Object.entries(projects);
   const items = projectEntries
     .filter(([, { targets }]) => Boolean(targets))
     .flatMap(([project, { targets, root }]) => ({ project, targets, root }))


### PR DESCRIPTION
fixes #1713
