### PR TITLE
feat(intellij): display target configurations in the toolwindow & run configuration editor

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
@@ -62,7 +62,7 @@ class NxGraphFocusTaskAction(private val targetDescriptor: NxTargetDescriptor? =
             dataContext.getData(NxTreeNodeKey).let { it as? NxSimpleNode.Target }
 
         if (targetTreeNode != null) {
-            return NxTargetDescriptor(targetTreeNode.nxProjectName, targetTreeNode.nxTarget)
+            return NxTargetDescriptor(targetTreeNode.nxProjectName, targetTreeNode.nxTargetName)
         }
 
         return null

--- a/apps/intellij/src/main/kotlin/dev/nx/console/models/NxTarget.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/models/NxTarget.kt
@@ -1,3 +1,3 @@
 package dev.nx.console.models
 
-data class NxTarget(val executor: String) {}
+data class NxTarget(val executor: String, val configurations: Map<String, Any>) {}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxProjectsTreeStructure.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxProjectsTreeStructure.kt
@@ -210,7 +210,7 @@ class NxProjectsTreeStructure(
         if (userObject != null) {
             return NxTaskSet(
                 nxProjects = listOf(userObject.nxProjectName),
-                nxTargets = listOf(userObject.nxTarget)
+                nxTargets = listOf(userObject.nxTargetName)
             )
         }
         return null

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxProjectsTreeStructure.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxProjectsTreeStructure.kt
@@ -91,8 +91,8 @@ class NxProjectsTreeStructure(
             val taskSet: NxTaskSet? = createTaskSetFromSelectedNodes()
             val runManager = project.service<RunManager>()
             if (taskSet != null) {
-                val nxTarget = taskSet.nxTargets.first()
-                val nxProject = taskSet.nxProjects.first()
+                val nxTarget = taskSet.nxTarget
+                val nxProject = taskSet.nxProject
                 val runnerAndConfigurationSettings: RunnerAndConfigurationSettings =
                     runManager
                         .getConfigurationSettingsList(NxCommandConfigurationType.getInstance())
@@ -161,8 +161,9 @@ class NxProjectsTreeStructure(
                     if (event.button == 1 && clickCount == 2) {
                         val taskSet: NxTaskSet = createTaskSetFromSelectedNodes() ?: return false
                         nxTaskExecutionManager.execute(
-                            taskSet.nxProjects.first(),
-                            taskSet.nxTargets.first()
+                            taskSet.nxProject,
+                            taskSet.nxTarget,
+                            taskSet.nxTargetConfiguration
                         )
                         return true
                     }
@@ -198,21 +199,34 @@ class NxProjectsTreeStructure(
             val taskSet: NxTaskSet? = createTaskSetFromSelectedNodes()
             if (taskSet != null) {
                 nxTaskExecutionManager.execute(
-                    taskSet.nxProjects.first(),
-                    taskSet.nxTargets.first()
+                    taskSet.nxProject,
+                    taskSet.nxTarget,
+                    taskSet.nxTargetConfiguration
                 )
             }
         }
     }
 
     private fun createTaskSetFromSelectedNodes(): NxTaskSet? {
-        val userObject = tree.selectedNode as? NxSimpleNode.Target
-        if (userObject != null) {
+        val targetNode = tree.selectedNode as? NxSimpleNode.Target
+
+        if (targetNode != null) {
             return NxTaskSet(
-                nxProjects = listOf(userObject.nxProjectName),
-                nxTargets = listOf(userObject.nxTargetName)
+                nxProject = targetNode.nxProjectName,
+                nxTarget = targetNode.nxTargetName
             )
         }
+
+        val targetConfigurationNode = tree.selectedNode as? NxSimpleNode.TargetConfiguration
+
+        if (targetConfigurationNode != null) {
+            return NxTaskSet(
+                nxProject = targetConfigurationNode.nxProjectName,
+                nxTarget = targetConfigurationNode.nxTargetName,
+                nxTargetConfiguration = targetConfigurationNode.nxTargetConfigurationName
+            )
+        }
+
         return null
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxSimpleNode.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxSimpleNode.kt
@@ -126,7 +126,7 @@ sealed class NxSimpleNode(val nxProject: NxProject?, parent: SimpleNode?) :
                     TargetConfiguration(
                         nxTargetConfigurationName = it,
                         nxTargetName = nxTargetName,
-                        nxProject = nxProject,
+                        nxProject = nxProject!!,
                         parent = this
                     )
                 }
@@ -162,13 +162,15 @@ sealed class NxSimpleNode(val nxProject: NxProject?, parent: SimpleNode?) :
     }
 
     class TargetConfiguration(
-        private val nxTargetConfigurationName: String,
+        val nxTargetConfigurationName: String,
         val nxTargetName: String,
-        nxProject: NxProject?,
+        nxProject: NxProject,
         parent: SimpleNode
     ) : NxSimpleNode(nxProject, parent) {
+        val nxProjectName = nxProject.name
+
         override val id: String =
-            "config_${nxProject?.name}_${nxTargetName}_$nxTargetConfigurationName"
+            "config_${nxProject.name}_${nxTargetName}_$nxTargetConfigurationName"
 
         init {
             icon = AllIcons.General.Gear

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowFactory.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowFactory.kt
@@ -15,17 +15,12 @@ class NxToolWindowFactory : ToolWindowFactory, DumbAware {
     }
 }
 
-data class NxTaskSet(val nxProjects: List<String>, val nxTargets: List<String>)
-
-val NxTaskSet.suggestedName: String
-    get() {
-        var name = nxProjects.joinToString(separator = ",")
-        name +=
-            if (nxTargets.size > 1) {
-                " --targets=${nxTargets.joinToString(separator = ",")}"
-            } else {
-                ":${nxTargets.first()}"
-            }
-
-        return name
-    }
+data class NxTaskSet(
+    val nxProject: String,
+    val nxTarget: String,
+    val nxTargetConfiguration: String?
+) {
+    constructor(nxProject: String, nxTarget: String) : this(nxProject, nxTarget, null) {}
+    val suggestedName =
+        "${nxProject}:${nxTarget}${if(nxTargetConfiguration.isNullOrBlank().not()) ":$nxTargetConfiguration" else ""}"
+}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
@@ -47,10 +47,10 @@ class NxCommandConfiguration(project: Project, factory: ConfigurationFactory) :
         }
 
         if (',' in nxRunSettings.nxTargets) {
-            return "${nxRunSettings.nxProjects} --targets=${nxRunSettings.nxTargets}"
+            return "${nxRunSettings.nxProjects} --targets=${nxRunSettings.nxTargets} ${if(nxRunSettings.nxTargetsConfiguration.isNullOrBlank().not()) "-c ${nxRunSettings.nxTargetsConfiguration}" else ""}"
         }
 
-        return "${nxRunSettings.nxProjects}:${nxRunSettings.nxTargets}"
+        return "${nxRunSettings.nxProjects}:${nxRunSettings.nxTargets}${if(nxRunSettings.nxTargetsConfiguration.isNullOrBlank().not()) ":${nxRunSettings.nxTargetsConfiguration}" else ""}"
     }
 }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandLineState.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandLineState.kt
@@ -22,14 +22,25 @@ class NxCommandLineState(
         val nxRunSettings = runConfiguration.nxRunSettings
         val nxProjects = nxRunSettings.nxProjects.split(",")
         val nxTargets = nxRunSettings.nxTargets.split(",")
+        val nxTargetsConfiguration = nxRunSettings.nxTargetsConfiguration
         val args =
-            if (nxProjects.size > 1 || nxTargets.size > 1)
+            if (nxProjects.size > 1 || nxTargets.size > 1) {
+                val array =
+                    arrayOf(
+                        "run-many",
+                        "--targets=${nxTargets.joinToString(separator = ",")}",
+                        "--projects=${nxProjects.joinToString(separator = ",")}",
+                    )
+                if (nxTargetsConfiguration.isNullOrBlank().not()) {
+                    array + "-c $nxTargetsConfiguration"
+                } else {
+                    array
+                }
+            } else
                 arrayOf(
-                    "run-many",
-                    "--targets=${nxTargets.joinToString(separator = ",")}",
-                    "--projects=${nxProjects.joinToString(separator = ",")}",
+                    "run",
+                    "${nxProjects.first()}:${nxTargets.first()}${if(nxTargetsConfiguration.isNullOrBlank().not()) ":$nxTargetsConfiguration" else ""}"
                 )
-            else arrayOf("run", "${nxProjects.first()}:${nxTargets.first()}")
 
         TelemetryService.getInstance(project)
             .featureUsed("Nx Run - from context menu/target list/codelens")

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandRunAnythingProvider.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandRunAnythingProvider.kt
@@ -49,9 +49,14 @@ class NxCommandRunAnythingProvider : RunAnythingCommandLineProvider() {
         val nxTarget = task.substringAfter(":")
 
         val runnerAndConfigurationSettings =
-            getOrCreateRunnerConfigurationSettings(project, nxProject, nxTarget, args).also {
-                runManager.addConfiguration(it)
-            }
+            getOrCreateRunnerConfigurationSettings(
+                    project,
+                    nxProject,
+                    nxTarget,
+                    null,
+                    args,
+                )
+                .also { runManager.addConfiguration(it) }
 
         runManager.selectedConfiguration = runnerAndConfigurationSettings
         val executor: Executor = DefaultRunExecutor.getRunExecutorInstance()

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunAction.kt
@@ -23,7 +23,7 @@ class NxRunAction(private val nxProject: String, private val nxTarget: String) :
             NxCommandConfiguration(project, NxRunConfigurationProducer().configurationFactory)
         runConfig.nxRunSettings = NxRunSettings().copy(nxProjects = nxProject, nxTargets = nxTarget)
 
-        val runner = getOrCreateRunnerConfigurationSettings(project, nxProject, nxTarget)
+        val runner = getOrCreateRunnerConfigurationSettings(project, nxProject, nxTarget, null)
 
         ProgramRunnerUtil.executeConfiguration(runner, DefaultRunExecutor.getRunExecutorInstance())
     }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationEditor.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationEditor.kt
@@ -3,17 +3,21 @@ package dev.nx.console.run
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.ui.RawCommandLineEditor
+import com.intellij.ui.components.JBTextField
 import com.intellij.ui.components.fields.ExpandableTextField
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.util.ui.ComponentWithEmptyText
 import javax.swing.JComponent
 
 class NxRunConfigurationEditor : SettingsEditor<NxCommandConfiguration>() {
 
-    private val nxProjects = ExpandableTextField()
-    private val nxTargets = ExpandableTextField()
-    private val environmentVariables = EnvironmentVariablesComponent()
-    private val arguments =
+    private lateinit var nxProjectsField: ExpandableTextField
+    private lateinit var nxTargetsField: ExpandableTextField
+    private lateinit var nxTargetsConfigurationField: JBTextField
+
+    private val environmentVariablesField = EnvironmentVariablesComponent()
+    private val argumentsField =
         RawCommandLineEditor().apply {
             if (textField is ComponentWithEmptyText) {
                 (textField as ComponentWithEmptyText).emptyText.text =
@@ -23,34 +27,53 @@ class NxRunConfigurationEditor : SettingsEditor<NxCommandConfiguration>() {
 
     override fun resetEditorFrom(configuration: NxCommandConfiguration) {
         val nxRunSettings = configuration.nxRunSettings
-        nxProjects.text = nxRunSettings.nxProjects
-        nxTargets.text = nxRunSettings.nxTargets
-        environmentVariables.envData = nxRunSettings.environmentVariables
-        arguments.text = nxRunSettings.arguments
+        nxProjectsField.text = nxRunSettings.nxProjects
+        nxTargetsField.text = nxRunSettings.nxTargets
+        nxTargetsConfigurationField.text = nxRunSettings.nxTargetsConfiguration
+        environmentVariablesField.envData = nxRunSettings.environmentVariables
+        argumentsField.text = nxRunSettings.arguments
     }
 
     override fun applyEditorTo(configuration: NxCommandConfiguration) {
         configuration.nxRunSettings =
             NxRunSettings(
-                nxProjects = nxProjects.text,
-                nxTargets = nxTargets.text,
-                environmentVariables = environmentVariables.envData,
-                arguments = arguments.text,
+                nxProjects = nxProjectsField.text,
+                nxTargets = nxTargetsField.text,
+                nxTargetsConfiguration = nxTargetsConfigurationField.text,
+                environmentVariables = environmentVariablesField.envData,
+                arguments = argumentsField.text,
             )
     }
 
     override fun createEditor(): JComponent {
         return panel {
             row("&Projects:") {
-                nxProjects(growX, pushX)
-                    .comment("Nx projects separated with commas, e.g. 'project1,project2'")
+                nxProjectsField =
+                    expandableTextField()
+                        .comment("Nx projects separated with commas, e.g. 'project1,project2'")
+                        .horizontalAlign(HorizontalAlign.FILL)
+                        .component
             }
             row("&Targets:") {
-                nxTargets(growX, pushX)
-                    .comment("Nx targets separated with commas, e.g. 'lint,test'")
+                nxTargetsField =
+                    expandableTextField()
+                        .comment("Nx targets separated with commas, e.g. 'lint,test'")
+                        .horizontalAlign(HorizontalAlign.FILL)
+                        .component
             }
-            row(environmentVariables.label) { environmentVariables(growX) }
-            row("A&rguments:") { arguments(growX, pushX) }
+            row("Configuration:") {
+                nxTargetsConfigurationField =
+                    textField()
+                        .comment(
+                            "Nx target configuration that will be used for all targets (if it exists), e.g. 'production'"
+                        )
+                        .horizontalAlign(HorizontalAlign.FILL)
+                        .component
+            }
+            row(environmentVariablesField.label) {
+                cell(environmentVariablesField.component).horizontalAlign(HorizontalAlign.FILL)
+            }
+            row("A&rguments:") { cell(argumentsField).horizontalAlign(HorizontalAlign.FILL) }
         }
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationProducer.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationProducer.kt
@@ -12,6 +12,7 @@ import dev.nx.console.utils.getTargetNodeFromLeafNode
 data class NxRunSettings(
     val nxProjects: String = "",
     val nxTargets: String = "",
+    val nxTargetsConfiguration: String? = "",
     val arguments: String = "",
     var environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 )
@@ -71,7 +72,9 @@ class NxRunConfigurationProducer : LazyRunConfigurationProducer<NxCommandConfigu
         thisRunSettings: NxRunSettings
     ): Boolean {
         return configuration.nxRunSettings.nxProjects == thisRunSettings.nxProjects &&
-            configuration.nxRunSettings.nxTargets == thisRunSettings.nxTargets
+            configuration.nxRunSettings.nxTargets == thisRunSettings.nxTargets &&
+            configuration.nxRunSettings.nxTargetsConfiguration ==
+                thisRunSettings.nxTargetsConfiguration
     }
 
     private fun getElement(context: ConfigurationContext): PsiElement? {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxTaskExecutionManager.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxTaskExecutionManager.kt
@@ -9,7 +9,11 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 
 class NxTaskExecutionManager(val project: Project) {
+
     fun execute(nxProject: String, nxTarget: String) {
+        execute(nxProject, nxTarget, null)
+    }
+    fun execute(nxProject: String, nxTarget: String, nxTargetConfiguration: String?) {
         val runManager = project.service<RunManager>()
 
         val runnerAndConfigurationSettings: RunnerAndConfigurationSettings =
@@ -18,11 +22,13 @@ class NxTaskExecutionManager(val project: Project) {
                 .firstOrNull {
                     val nxCommandConfiguration = it.configuration as NxCommandConfiguration
                     val nxRunSettings = nxCommandConfiguration.nxRunSettings
-                    nxRunSettings.nxTargets == nxTarget && nxRunSettings.nxProjects == nxProject
+                    nxRunSettings.nxTargets == nxTarget &&
+                        nxRunSettings.nxProjects == nxProject &&
+                        nxRunSettings.nxTargetsConfiguration == nxTargetConfiguration
                 }
                 ?: runManager
                     .createConfiguration(
-                        "$nxProject:$nxTarget",
+                        "$nxProject:$nxTarget${if(nxTargetConfiguration.isNullOrBlank().not()) ":$nxTargetConfiguration" else ""}",
                         NxCommandConfigurationType::class.java
                     )
                     .apply {
@@ -31,6 +37,7 @@ class NxTaskExecutionManager(val project: Project) {
                                 NxRunSettings(
                                     nxProjects = nxProject,
                                     nxTargets = nxTarget,
+                                    nxTargetsConfiguration = nxTargetConfiguration
                                 )
                         }
                     }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
@@ -8,6 +8,7 @@ fun getOrCreateRunnerConfigurationSettings(
     project: Project,
     nxProject: String,
     nxTarget: String,
+    nxTargetConfiguration: String? = "",
     args: List<String> = listOf()
 ): RunnerAndConfigurationSettings {
     val runManager = RunManager.getInstance(project)
@@ -17,16 +18,22 @@ fun getOrCreateRunnerConfigurationSettings(
         .firstOrNull {
             val nxCommandConfiguration = it.configuration as NxCommandConfiguration
             val nxRunSettings = nxCommandConfiguration.nxRunSettings
-            nxRunSettings.nxTargets == nxTarget && nxRunSettings.nxProjects == nxProject
+            nxRunSettings.nxTargets == nxTarget &&
+                nxRunSettings.nxProjects == nxProject &&
+                nxRunSettings.nxTargetsConfiguration == nxTargetConfiguration
         }
         ?: runManager
-            .createConfiguration("$nxProject:$nxTarget", NxCommandConfigurationType::class.java)
+            .createConfiguration(
+                "$nxProject:$nxTarget${if(nxTargetConfiguration.isNullOrBlank().not()) ":$nxTargetConfiguration" else ""}",
+                NxCommandConfigurationType::class.java
+            )
             .apply {
                 (configuration as NxCommandConfiguration).apply {
                     nxRunSettings =
                         NxRunSettings(
                             nxProjects = nxProject,
                             nxTargets = nxTarget,
+                            nxTargetsConfiguration = nxTargetConfiguration,
                             arguments = args.drop(1).joinToString(" "),
                         )
                 }


### PR DESCRIPTION
this adds functionality to the toolwindow so that configurations are shown. You can run them directly from there or configure them first. 
<img width="358" alt="image" src="https://user-images.githubusercontent.com/34165455/235942597-81bdd15d-ac29-49ed-879c-8d2bf52dd4ea.png">
<img width="658" alt="image" src="https://user-images.githubusercontent.com/34165455/235942713-3873fd4f-1bfc-4a4e-97c7-268d0611426f.png">
