### PR TITLE
fix(intellij): fix default values in webview by passing correct name to nxls

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateRunAnythingProvider.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateRunAnythingProvider.kt
@@ -125,7 +125,7 @@ class NxGenerateRunAnythingProvider : RunAnythingCommandLineProvider() {
                     .generatorOptions(
                         NxGeneratorOptionsRequestOptions(
                             collection = generator.data.collection,
-                            name = generator.name,
+                            name = generator.data.name,
                             path = generator.path
                         )
                     )

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
@@ -122,7 +122,7 @@ class NxGenerateService(val project: Project) {
                         .generatorOptions(
                             NxGeneratorOptionsRequestOptions(
                                 generator.data.collection,
-                                generator.name,
+                                generator.data.name,
                                 generator.path
                             )
                         )


### PR DESCRIPTION
before we passed the full generator name (e.g. `@nx/react:component`) to the nxls instead of just `component`. This meant that the workspace default lookup broke and default values weren't correctly displayed. 
That's fixed now.