### PR TITLE
chore: rename build-webview-files target to build

### DIFF
--- a/apps/vscode/project.json
+++ b/apps/vscode/project.json
@@ -27,7 +27,7 @@
             "color": "magenta"
           },
           {
-            "command": "yarn nx run vscode-nx-cloud-view:watch-webview-files",
+            "command": "yarn nx run vscode-nx-cloud-view:watch",
             "prefix": "cloud-view",
             "color": "yellow"
           }
@@ -172,7 +172,7 @@
           "minify": false
         }
       },
-      "dependsOn": ["^build", "^build-webview-files", "extract-dependencies"],
+      "dependsOn": ["^build", "extract-dependencies"],
       "outputs": ["{options.outputPath}"]
     },
     "extract-dependencies": {

--- a/libs/vscode/nx-cloud-view/project.json
+++ b/libs/vscode/nx-cloud-view/project.json
@@ -11,7 +11,7 @@
         "lintFilePatterns": ["libs/vscode/nx-cloud-view/**/*.ts"]
       }
     },
-    "build-webview-files": {
+    "build": {
       "executor": "@nx/esbuild:esbuild",
       "options": {
         "main": "libs/vscode/nx-cloud-view/src/webview/main.ts",
@@ -32,7 +32,7 @@
       "dependsOn": ["extract-dependencies"],
       "inputs": ["{projectRoot}/src/webview/**/*"]
     },
-    "watch-webview-files": {
+    "watch": {
       "executor": "@nx/esbuild:esbuild",
       "options": {
         "main": "libs/vscode/nx-cloud-view/src/webview/main.ts",

--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,6 @@
           "e2e",
           "build-storybook",
           "package",
-          "build-webview-files",
           "extract-dependencies"
         ],
         "accessToken": "YTg3Yzk1YWMtZTQ3MC00MTIwLTkyM2ItMjAyMGI0ZTJlZDc3fHJlYWQtd3JpdGU="


### PR DESCRIPTION
this was a relic from the dev process, there's no reason it should have this special name anymore
