### PR TITLE
feat(vscode): add command to clear nx cloud session storage manually

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -303,6 +303,10 @@
           "when": "isNxWorkspace"
         },
         {
+          "command": "nxConsole.clearCloudSessions",
+          "when": "isNxWorkspace"
+        },
+        {
           "command": "nxConsole.refreshCloudWebview",
           "when": "isNxWorkspace"
         },
@@ -530,6 +534,10 @@
       {
         "title": "Login to Nx Cloud",
         "command": "nxConsole.loginToNxCloud"
+      },
+      {
+        "title": "Clear local Nx Cloud sessions",
+        "command": "nxConsole.clearCloudSessions"
       },
       {
         "title": "Refresh Nx Cloud Webview",

--- a/libs/vscode/nx-cloud-view/src/lib/auth/nx-cloud-authentication-provider.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/auth/nx-cloud-authentication-provider.ts
@@ -41,7 +41,10 @@ export class NxCloudAuthenticationProvider
       ),
       commands.registerCommand('nxConsole.loginToNxCloud', () => {
         authentication.getSession('nxCloud', [], { createIfNone: true });
-      })
+      }),
+      commands.registerCommand('nxConsole.clearCloudSessions', () =>
+        this.clearSessions()
+      )
     );
     this.initialize();
   }
@@ -289,6 +292,22 @@ export class NxCloudAuthenticationProvider
     }
 
     return refreshedSessions;
+  }
+
+  private async clearSessions(): Promise<void> {
+    const sessions = await this._secretSessionStore.getSessions();
+    await this._secretSessionStore.storeSessions([]);
+    await this._secretSessionStore.storeRefreshTokens([]);
+
+    getTelemetry().featureUsed('nxConsole.cloud.clearSessions');
+
+    if (sessions) {
+      this._sessionChangeEmitter.fire({
+        added: [],
+        removed: sessions,
+        changed: [],
+      });
+    }
   }
 
   public async dispose() {


### PR DESCRIPTION
in case something goes wrong during login, we might get faulty session data - this way we can just clear it and try again