### PR TITLE
fix(intellij): do not use `runBlocking` for SearchEverywhereContributor

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGeneratorSearchEverywhereContributorFactory.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGeneratorSearchEverywhereContributorFactory.kt
@@ -16,7 +16,9 @@ import com.intellij.util.Processor
 import dev.nx.console.generate.ui.NxGeneratorListCellRenderer
 import dev.nx.console.models.NxGenerator
 import javax.swing.ListCellRenderer
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class NxGeneratorSearchEverywhereContributorFactory :
     SearchEverywhereContributorFactory<NxGenerator> {
@@ -71,7 +73,7 @@ class NxGeneratorSearchEverywhereContributor(private val event: AnActionEvent) :
         val matcher = NameUtil.buildMatcher(pattern).build()
 
         val task = Runnable {
-            runBlocking {
+            CoroutineScope(Dispatchers.Default).launch {
                 NxGenerateService.getInstance(project)
                     .getFilteredGenerators()
                     .filter { matcher.matches(it.name) }


### PR DESCRIPTION
Calling `runBlocking` on a init field could cause the plugin to potentially freeze the UI. 

Moving this to `invokeLater` where it's actually needed seems to improve performance. 