### PR TITLE
fix(vscode): fix cloud view connecting to staging

### DIFF
--- a/apps/vscode-e2e/testworkspaces/testworkspace-nested/src/environments/environment.prod.ts
+++ b/apps/vscode-e2e/testworkspaces/testworkspace-nested/src/environments/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true,
-};

--- a/apps/vscode-e2e/testworkspaces/testworkspace-nested/src/environments/environment.ts
+++ b/apps/vscode-e2e/testworkspaces/testworkspace-nested/src/environments/environment.ts
@@ -1,6 +1,0 @@
-// This file can be replaced during build by using the `fileReplacements` array.
-// When building for production, this file is replaced with `environment.prod.ts`.
-
-export const environment = {
-  production: false,
-};

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -238,7 +238,10 @@ async function setWorkspace(workspacePath: string) {
 
     registerVscodeAddDependency(context);
 
-    initNxCloudOnboardingView(context, environment.production);
+    initNxCloudOnboardingView(
+      context,
+      context.extensionMode !== ExtensionMode.Development
+    );
     initGenerateUiWebview(context);
 
     nxProjectsTreeProvider = initNxProjectView(context);

--- a/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
@@ -216,13 +216,10 @@ export class NxCloudService extends StateBaseService<InternalState> {
 
     const { nxVersion } = await getNxWorkspace();
 
-    const cloudRunnerUrl =
+    const env =
       this.config.appUrl === stagingConfig.appUrl
-        ? stagingConfig.appUrl
-        : undefined;
-    const env = cloudRunnerUrl
-      ? { ...process.env, NX_CLOUD_API: this.config.appUrl }
-      : process.env;
+        ? { ...process.env, NX_CLOUD_API: this.config.appUrl }
+        : process.env;
 
     window.withProgress(
       {


### PR DESCRIPTION
with esbuild, `fileReplacements` isn't a thing anymore so `environment.production` is useless. 
Switched to the tried and true `context.extensionMode === ExtensionMode.Development`