### PR TITLE
fix: adjust generator autofilling

### DIFF
--- a/apps/generate-ui-v2-e2e/src/e2e/generator-context.cy.ts
+++ b/apps/generate-ui-v2-e2e/src/e2e/generator-context.cy.ts
@@ -6,7 +6,35 @@ import { clickShowMore, getFieldByName } from '../support/get-elements';
 import { visitGenerateUi } from '../support/visit-generate-ui';
 import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 
-const schema: GeneratorSchema = {
+const schemaProj: GeneratorSchema = {
+  collectionName: '@nx/test',
+  generatorName: 'test',
+  description: 'description',
+  options: [
+    {
+      name: 'project',
+      isRequired: true,
+      aliases: [],
+      items: ['project1', 'project2', 'project3'],
+    },
+  ],
+  context: {
+    project: 'project3',
+    directory: 'nested/nested2',
+  },
+};
+const schemaDir: GeneratorSchema = {
+  collectionName: '@nx/test',
+  generatorName: 'test',
+  description: 'description',
+  options: [{ name: 'directory', isRequired: false, aliases: [] }],
+  context: {
+    project: 'project3',
+    directory: 'nested/nested2',
+  },
+};
+
+const schemaBoth: GeneratorSchema = {
   collectionName: '@nx/test',
   generatorName: 'test',
   description: 'description',
@@ -25,21 +53,43 @@ const schema: GeneratorSchema = {
   },
 };
 describe('generator context', () => {
-  beforeEach(() => visitGenerateUi(schema));
-  it('should correctly use the context', () => {
-    clickShowMore();
-
+  it('should correctly use the context to autofill project', () => {
+    visitGenerateUi(schemaProj);
     getFieldByName('project').should('have.value', 'project3');
-    getFieldByName('directory').should('have.value', 'nested/nested2');
 
     spyOnConsoleLog().then((consoleLog) => {
       cy.get("[data-cy='generate-button']").click();
       expectConsoleLogToHaveBeenCalledWith(consoleLog, 'run-generator');
       expectConsoleLogToHaveBeenCalledWith(consoleLog, '--project=project3');
+    });
+  });
+
+  it('should correctly use the context to autofill directory', () => {
+    visitGenerateUi(schemaDir);
+
+    getFieldByName('directory').should('have.value', 'nested/nested2');
+
+    spyOnConsoleLog().then((consoleLog) => {
+      cy.get("[data-cy='generate-button']").click();
+      expectConsoleLogToHaveBeenCalledWith(consoleLog, 'run-generator');
       expectConsoleLogToHaveBeenCalledWith(
         consoleLog,
         '--directory=nested/nested2'
       );
+    });
+  });
+
+  it('should only fill project if both directory and project exist', () => {
+    visitGenerateUi(schemaBoth);
+    clickShowMore();
+
+    getFieldByName('project').should('have.value', 'project3');
+    getFieldByName('directory').should('be.empty');
+
+    spyOnConsoleLog().then((consoleLog) => {
+      cy.get("[data-cy='generate-button']").click();
+      expectConsoleLogToHaveBeenCalledWith(consoleLog, 'run-generator');
+      expectConsoleLogToHaveBeenCalledWith(consoleLog, '--project=project3');
     });
   });
 });

--- a/apps/generate-ui-v2/src/ide-communication.controller.ts
+++ b/apps/generate-ui-v2/src/ide-communication.controller.ts
@@ -136,17 +136,20 @@ export class IdeCommunicationController implements ReactiveController {
       option['x-priority'] !== 'internal';
 
     // THIS IS A FIX UNTIL DIR & PATH OPTIONS ARE PROPERLY HANDLED
-    // WE DON'T WANT TO PREFILL DIR WHEN THERE'S A PROJECT 
-    const transformContext = (schema: GeneratorSchema, context: GeneratorContext | undefined) => {
-      if(schema.options.find(opt => opt.name === "project")) {
+    // WE DON'T WANT TO PREFILL DIR WHEN THERE'S A PROJECT
+    const transformContext = (
+      schema: GeneratorSchema,
+      context: GeneratorContext | undefined
+    ) => {
+      if (schema.options.find((opt) => opt.name === 'project')) {
         return {
           ...context,
-          directory: undefined
-        }
+          directory: undefined,
+        };
       } else {
-        return context
+        return context;
       }
-    }
+    };
 
     switch (message.payloadType) {
       case 'generator': {

--- a/apps/generate-ui-v2/src/ide-communication.controller.ts
+++ b/apps/generate-ui-v2/src/ide-communication.controller.ts
@@ -135,6 +135,19 @@ export class IdeCommunicationController implements ReactiveController {
     const optionFilter = (option: Option) =>
       option['x-priority'] !== 'internal';
 
+    // THIS IS A FIX UNTIL DIR & PATH OPTIONS ARE PROPERLY HANDLED
+    // WE DON'T WANT TO PREFILL DIR WHEN THERE'S A PROJECT 
+    const transformContext = (schema: GeneratorSchema, context: GeneratorContext | undefined) => {
+      if(schema.options.find(opt => opt.name === "project")) {
+        return {
+          ...context,
+          directory: undefined
+        }
+      } else {
+        return context
+      }
+    }
+
     switch (message.payloadType) {
       case 'generator': {
         const schema = message.payload;
@@ -144,7 +157,7 @@ export class IdeCommunicationController implements ReactiveController {
         };
         this.generatorSchema = schemaWithFilteredOptions;
         this.generatorContextContextProvider.setValue(
-          this.generatorSchema.context
+          transformContext(schema, this.generatorSchema.context)
         );
 
         this.host.requestUpdate();

--- a/libs/language-server/workspace/src/lib/get-project-by-path.ts
+++ b/libs/language-server/workspace/src/lib/get-project-by-path.ts
@@ -1,6 +1,6 @@
 import type { ProjectConfiguration } from 'nx/src/devkit-exports';
 import { directoryExists } from '@nx-console/shared/file-system';
-import { isAbsolute, join, relative, sep } from 'path';
+import { isAbsolute, join, normalize, relative, sep } from 'path';
 import { nxWorkspace } from './workspace';
 
 export async function getProjectByPath(
@@ -38,7 +38,7 @@ export async function getProjectByPath(
       foundProject = projectConfig;
     } else if (
       !isDirectory &&
-      projectConfig.files.some(({ file }) => file === relativeFilePath)
+      projectConfig.files.some(({ file }) => normalize(file) === relativeFilePath)
     ) {
       foundProject = projectConfig;
     }
@@ -91,5 +91,5 @@ function findByFilePath(
 function isChildOrEqual(parent: string, child: string) {
   const p = parent.endsWith(sep) ? parent : parent + sep;
   const c = child.endsWith(sep) ? child : child + sep;
-  return c.startsWith(p);
+  return normalize(c).startsWith(normalize(p));
 }

--- a/libs/language-server/workspace/src/lib/get-project-by-path.ts
+++ b/libs/language-server/workspace/src/lib/get-project-by-path.ts
@@ -38,7 +38,9 @@ export async function getProjectByPath(
       foundProject = projectConfig;
     } else if (
       !isDirectory &&
-      projectConfig.files.some(({ file }) => normalize(file) === relativeFilePath)
+      projectConfig.files.some(
+        ({ file }) => normalize(file) === relativeFilePath
+      )
     ) {
       foundProject = projectConfig;
     }


### PR DESCRIPTION
fixes two things: 
- compare normalized paths in nxls to make sure detecting the project based on the path works 
- don't autofill `directory` if `project` also exists. For example this broke `@nx/react:component`. This is only until the current effort to standardize path/dir options is done in nx and we can be more consistent here.