### PR TITLE
feat(generate-ui): add copy to clipboard button to generate ui

### DIFF
--- a/apps/generate-ui-v2-e2e/src/e2e/app.cy.ts
+++ b/apps/generate-ui-v2-e2e/src/e2e/app.cy.ts
@@ -66,6 +66,21 @@ describe('generate-ui-v2', () => {
         );
       });
     });
+    it('should copy command to clipboard', () => {
+      clickShowMore();
+      getFieldByName('option1').type('test-option1');
+      getFieldByName('select-field').select('option1');
+
+      cy.get("[id='copy-button']").click();
+
+      cy.window()
+        .its('navigator.clipboard')
+        .then((clip) => clip.readText())
+        .should(
+          'equal',
+          'nx g @nx/test:test --option1=test-option1 --select-field=option1'
+        );
+    });
   });
   describe('keyboard shortcuts', () => {
     it('should be able to focus search bar with shortcut', () => {

--- a/apps/generate-ui-v2-e2e/src/support/visit-generate-ui.ts
+++ b/apps/generate-ui-v2-e2e/src/support/visit-generate-ui.ts
@@ -25,6 +25,9 @@ export const visitGenerateUi = (schema: GeneratorSchema) =>
               payload: {},
             });
           }
+          if (messageParsed.payloadType === 'copy-to-clipboard') {
+            win.navigator.clipboard.writeText(messageParsed.payload);
+          }
         },
         registerPostToWebviewCallback(callback: any) {
           console.log('registering post to webview callback', callback);

--- a/apps/generate-ui-v2/src/components/button.ts
+++ b/apps/generate-ui-v2/src/components/button.ts
@@ -1,6 +1,6 @@
+import { ContextConsumer } from '@lit-labs/context';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { consume, ContextConsumer } from '@lit-labs/context';
 import { editorContext } from '../contexts/editor-context';
 import { intellijFocusRing } from '../utils/ui-utils';
 
@@ -10,7 +10,7 @@ export class Button extends LitElement {
   text: string;
 
   @property()
-  appearance: 'primary' | 'secondary' = 'primary';
+  appearance: 'primary' | 'secondary' | 'icon' = 'primary';
 
   editor: string;
 
@@ -32,12 +32,27 @@ export class Button extends LitElement {
   }
 
   renderVSCode() {
+    if (this.appearance === 'icon') {
+      return html`
+        <vscode-button appearance="icon">
+          <icon-element
+            class="flex items-start"
+            icon="${this.text}"
+          ></icon-element>
+        </vscode-button>
+      `;
+    }
     return html`<vscode-button appearance="${this.appearance}"
       >${this.text}</vscode-button
     >`;
   }
 
   renderIntellij() {
+    if (this.appearance === 'icon') {
+      return html`<div class="hover:bg-fieldNavHoverBackground rounded p-1">
+        <icon-element icon="${this.text}"></icon-element>
+      </div>`;
+    }
     return html`<button
       class="${intellijFocusRing} ${this.appearance === 'primary'
         ? 'bg-primary focus:!ring-offset-1 focus:!ring-offset-background'

--- a/apps/generate-ui-v2/src/components/icon.ts
+++ b/apps/generate-ui-v2/src/components/icon.ts
@@ -14,10 +14,10 @@ export class Icon extends EditorContext(LitElement) {
         class="h-[1.25rem]"
       ></img>`;
     } else {
-      return html`<i
+      return html`<span
         class="codicon codicon-${this.icon}"
         style="text-align: center; font-size: 0.9rem;"
-      ></i>`;
+      ></span>`;
     }
   }
 

--- a/apps/generate-ui-v2/src/form-values.service.ts
+++ b/apps/generate-ui-v2/src/form-values.service.ts
@@ -9,6 +9,7 @@ import {
 } from './utils/generator-schema-utils';
 import {
   FormValues,
+  GenerateUiCopyToClipboardOutputMessage,
   GeneratorSchema,
   ValidationResults,
 } from '@nx-console/shared/generate-ui-types';
@@ -135,7 +136,20 @@ export class FormValuesService {
     500
   );
 
-  getSerializedFormValues(): string[] {
+  copyCommandToClipboard() {
+    const args = this.getSerializedFormValues();
+    const positional = getGeneratorIdentifier(this.icc.generatorSchema);
+    const command = `nx g ${positional} ${args.join(' ')}`;
+    if (this.icc.editor === 'vscode') {
+      navigator.clipboard.writeText(command);
+    } else {
+      this.icc.postMessageToIde(
+        new GenerateUiCopyToClipboardOutputMessage(command)
+      );
+    }
+  }
+
+  private getSerializedFormValues(): string[] {
     const args: string[] = [];
     Object.entries(this.formValues).forEach(([key, value]) => {
       const option = this.icc.generatorSchema?.options.find(

--- a/apps/generate-ui-v2/src/main.ts
+++ b/apps/generate-ui-v2/src/main.ts
@@ -80,6 +80,14 @@ export class Root extends LitElement {
           </div>
 
           <div class="flex shrink-0">
+            <button-element
+              class="flex items-center py-2 pl-3"
+              appearance="icon"
+              text="copy"
+              @click="${() => this.formValuesService.copyCommandToClipboard()}"
+              id="copy-button"
+            >
+            </button-element>
             ${when(
               !this.icc.configuration?.enableTaskExecutionDryRunOnChange,
               () =>

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/GenerateUiMessages.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/GenerateUiMessages.kt
@@ -26,6 +26,13 @@ data class GenerateUiRunGeneratorOutputMessage(
     val payload: GenerateUiRunGeneratorPayload
 ) : GenerateUiOutputMessage {}
 
+@Serializable()
+@SerialName("copy-to-clipboard")
+data class GenerateUiCopyToClipboardOutputMessage(
+    override val payloadType: String,
+    val payload: String
+) : GenerateUiOutputMessage {}
+
 // The payload will have to be changed for plugins to be truly supported in Intellij
 @Serializable()
 @SerialName("request-validation")

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/V2NxGenerateUiFile.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/V2NxGenerateUiFile.kt
@@ -1,6 +1,7 @@
 package dev.nx.console.generate.ui
 
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.*
@@ -12,6 +13,7 @@ import dev.nx.console.utils.jcef.CustomSchemeHandlerFactory
 import dev.nx.console.utils.jcef.OpenDevToolsContextMenuHandler
 import dev.nx.console.utils.jcef.getHexColor
 import dev.nx.console.utils.jcef.onBrowserLoadEnd
+import java.awt.datatransfer.StringSelection
 import javax.swing.JComponent
 import javax.swing.UIManager
 import kotlinx.serialization.decodeFromString
@@ -101,6 +103,11 @@ class V2NxGenerateUiFile(name: String, project: Project) : NxGenerateUiFile(name
         }
         if (messageParsed.payloadType == "request-validation") {
             this.postMessageToBrowser(GenerateUiValidationResultsInputMessage(mapOf()))
+        }
+        if (messageParsed.payloadType == "copy-to-clipboard") {
+            if (messageParsed is GenerateUiCopyToClipboardOutputMessage) {
+                CopyPasteManager.getInstance().setContents(StringSelection(messageParsed.payload))
+            }
         }
     }
 

--- a/apps/intellij/src/main/resources/generate_ui_v2/icons/chevron-down.svg
+++ b/apps/intellij/src/main/resources/generate_ui_v2/icons/chevron-down.svg
@@ -1,4 +1,4 @@
-<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8.00004 11.91L2.29004 6.20998L3.71004 4.78998L8.00004 9.08998L12.29 4.78998L13.71 6.20998L8.00004 11.91Z" fill="#7F8B91" fill-opacity="0.5"/>
+<path d="M11.5 6.25L8 9.75L4.5 6.25" stroke="#818594" stroke-linecap="round"/>
 </svg>

--- a/apps/intellij/src/main/resources/generate_ui_v2/icons/chevron-up.svg
+++ b/apps/intellij/src/main/resources/generate_ui_v2/icons/chevron-up.svg
@@ -1,4 +1,4 @@
-<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12.29 11.21L8.00004 6.91003L3.71004 11.21L2.29004 9.79003L8.00004 4.09003L13.71 9.79003L12.29 11.21Z" fill="#7F8B91" fill-opacity="0.5"/>
+<path d="M4.5 9.75L8 6.25L11.5 9.75" stroke="#818594" stroke-linecap="round"/>
 </svg>

--- a/apps/intellij/src/main/resources/generate_ui_v2/icons/close.svg
+++ b/apps/intellij/src/main/resources/generate_ui_v2/icons/close.svg
@@ -1,4 +1,4 @@
-<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M11.144 4.14999L11.8511 4.8571L8.70204 7.99795L11.8511 11.147L11.144 11.8541L7.99494 8.70506L4.85408 11.8541L4.14697 11.147L7.29492 8.00505L4.14697 4.8571L4.85408 4.14999L8.00203 7.29795L11.144 4.14999Z" fill="#6E6E6E"/>
+<path d="M3 13L13 3M13 13L3 3" stroke="#6C707E" stroke-linecap="round"/>
 </svg>

--- a/apps/intellij/src/main/resources/generate_ui_v2/icons/copy.svg
+++ b/apps/intellij/src/main/resources/generate_ui_v2/icons/copy.svg
@@ -1,0 +1,8 @@
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2.5" y="3.5" width="9" height="10" rx="1.5" stroke="#6C707E"/>
+<rect x="5" y="6" width="4" height="1" rx="0.5" fill="#6C707E"/>
+<rect x="5" y="8" width="4" height="1" rx="0.5" fill="#6C707E"/>
+<rect x="5" y="10" width="4" height="1" rx="0.5" fill="#6C707E"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.0017 2H11.5998C12.373 2 12.9998 2.6268 12.9998 3.4V3.91081C13.0011 3.94038 13.0017 3.97011 13.0017 4V11.5482C13.6063 11.1124 13.9998 10.4021 13.9998 9.6V3.4C13.9998 2.07452 12.9253 1 11.5998 1H6.39978C5.59677 1 4.88587 1.39437 4.4502 2H6.39978H11.0017Z" fill="#6C707E"/>
+</svg>

--- a/apps/intellij/src/main/resources/generate_ui_v2/icons/search.svg
+++ b/apps/intellij/src/main/resources/generate_ui_v2/icons/search.svg
@@ -1,4 +1,5 @@
-<!-- Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="#7F8B91" fill-opacity=".9" fill-rule="evenodd" d="M11.038136,9.94904865 L13.9980971,12.9090097 L12.9374369,13.9696699 L9.98176525,11.0139983 C9.14925083,11.6334368 8.11743313,12 7,12 C4.23857625,12 2,9.76142375 2,7 C2,4.23857625 4.23857625,2 7,2 C9.76142375,2 12,4.23857625 12,7 C12,8.1028408 11.642948,9.12228765 11.038136,9.94904865 Z M7,11 C9.209139,11 11,9.209139 11,7 C11,4.790861 9.209139,3 7,3 C4.790861,3 3,4.790861 3,7 C3,9.209139 4.790861,11 7,11 Z"/>
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="7" cy="7" r="4.5" stroke="#6C707E"/>
+<path d="M10.1992 10.2002L13.4992 13.4961" stroke="#6C707E" stroke-linecap="round"/>
 </svg>

--- a/libs/shared/generate-ui-types/src/lib/messages.ts
+++ b/libs/shared/generate-ui-types/src/lib/messages.ts
@@ -13,7 +13,8 @@ export type ValidationResults = Record<string, string | boolean>;
 export type GenerateUiOutputMessage =
   | GenerateUiFormInitOutputMessage
   | GenerateUiRunGeneratorOutputMessage
-  | GenerateUiRequestValidationOutputMessage;
+  | GenerateUiRequestValidationOutputMessage
+  | GenerateUiCopyToClipboardOutputMessage;
 
 export class GenerateUiFormInitOutputMessage {
   readonly payloadType = 'output-init';
@@ -36,6 +37,12 @@ export class GenerateUiRequestValidationOutputMessage {
   constructor(
     public readonly payload: { formValues: FormValues; schema: GeneratorSchema }
   ) {}
+}
+
+export class GenerateUiCopyToClipboardOutputMessage {
+  readonly payloadType = 'copy-to-clipboard';
+
+  constructor(public readonly payload: string) {}
 }
 
 /**


### PR DESCRIPTION
also updated icons to match the ones from the new ui instead of the old one. (`AllIcons/expui/general`)