### PR TITLE
fix(intellij): save and load run configurations that have a nx target configuration set

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowFactory.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowFactory.kt
@@ -18,9 +18,9 @@ class NxToolWindowFactory : ToolWindowFactory, DumbAware {
 data class NxTaskSet(
     val nxProject: String,
     val nxTarget: String,
-    val nxTargetConfiguration: String?
+    val nxTargetConfiguration: String
 ) {
-    constructor(nxProject: String, nxTarget: String) : this(nxProject, nxTarget, null) {}
+    constructor(nxProject: String, nxTarget: String) : this(nxProject, nxTarget, "") {}
     val suggestedName =
-        "${nxProject}:${nxTarget}${if(nxTargetConfiguration.isNullOrBlank().not()) ":$nxTargetConfiguration" else ""}"
+        "${nxProject}:${nxTarget}${if(nxTargetConfiguration.isBlank().not()) ":$nxTargetConfiguration" else ""}"
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
@@ -26,6 +26,7 @@ class NxCommandConfiguration(project: Project, factory: ConfigurationFactory) :
         super.writeExternal(element)
         element.writeString("nx-projects", nxRunSettings.nxProjects)
         element.writeString("nx-targets", nxRunSettings.nxTargets)
+        element.writeString("nx-target-configuration", nxRunSettings.nxTargetsConfiguration)
         nxRunSettings.environmentVariables.writeExternal(element)
         element.writeString("arguments", nxRunSettings.arguments)
     }
@@ -36,6 +37,7 @@ class NxCommandConfiguration(project: Project, factory: ConfigurationFactory) :
             NxRunSettings(
                 nxProjects = element.readString("nx-projects") ?: return,
                 nxTargets = element.readString("nx-targets") ?: return,
+                nxTargetsConfiguration = element.readString("nx-target-configuration") ?: return,
                 environmentVariables = EnvironmentVariablesData.readExternal(element),
                 arguments = element.readString("arguments") ?: return,
             )
@@ -47,10 +49,10 @@ class NxCommandConfiguration(project: Project, factory: ConfigurationFactory) :
         }
 
         if (',' in nxRunSettings.nxTargets) {
-            return "${nxRunSettings.nxProjects} --targets=${nxRunSettings.nxTargets} ${if(nxRunSettings.nxTargetsConfiguration.isNullOrBlank().not()) "-c ${nxRunSettings.nxTargetsConfiguration}" else ""}"
+            return "${nxRunSettings.nxProjects} --targets=${nxRunSettings.nxTargets} ${if(nxRunSettings.nxTargetsConfiguration.isBlank().not()) "-c ${nxRunSettings.nxTargetsConfiguration}" else ""}"
         }
 
-        return "${nxRunSettings.nxProjects}:${nxRunSettings.nxTargets}${if(nxRunSettings.nxTargetsConfiguration.isNullOrBlank().not()) ":${nxRunSettings.nxTargetsConfiguration}" else ""}"
+        return "${nxRunSettings.nxProjects}:${nxRunSettings.nxTargets}${if(nxRunSettings.nxTargetsConfiguration.isBlank().not()) ":${nxRunSettings.nxTargetsConfiguration}" else ""}"
     }
 }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandConfiguration.kt
@@ -37,7 +37,7 @@ class NxCommandConfiguration(project: Project, factory: ConfigurationFactory) :
             NxRunSettings(
                 nxProjects = element.readString("nx-projects") ?: return,
                 nxTargets = element.readString("nx-targets") ?: return,
-                nxTargetsConfiguration = element.readString("nx-target-configuration") ?: return,
+                nxTargetsConfiguration = element.readString("nx-target-configuration") ?: "",
                 environmentVariables = EnvironmentVariablesData.readExternal(element),
                 arguments = element.readString("arguments") ?: return,
             )

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandRunAnythingProvider.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandRunAnythingProvider.kt
@@ -53,7 +53,7 @@ class NxCommandRunAnythingProvider : RunAnythingCommandLineProvider() {
                     project,
                     nxProject,
                     nxTarget,
-                    null,
+                    "",
                     args,
                 )
                 .also { runManager.addConfiguration(it) }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationProducer.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationProducer.kt
@@ -12,7 +12,7 @@ import dev.nx.console.utils.getPropertyNodeFromLeafNode
 data class NxRunSettings(
     val nxProjects: String = "",
     val nxTargets: String = "",
-    val nxTargetsConfiguration: String? = "",
+    val nxTargetsConfiguration: String = "",
     val arguments: String = "",
     var environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 )

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxTaskExecutionManager.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxTaskExecutionManager.kt
@@ -11,9 +11,9 @@ import com.intellij.openapi.project.Project
 class NxTaskExecutionManager(val project: Project) {
 
     fun execute(nxProject: String, nxTarget: String) {
-        execute(nxProject, nxTarget, null)
+        execute(nxProject, nxTarget, "")
     }
-    fun execute(nxProject: String, nxTarget: String, nxTargetConfiguration: String?) {
+    fun execute(nxProject: String, nxTarget: String, nxTargetConfiguration: String) {
         val runManager = project.service<RunManager>()
 
         val runnerAndConfigurationSettings: RunnerAndConfigurationSettings =
@@ -28,7 +28,7 @@ class NxTaskExecutionManager(val project: Project) {
                 }
                 ?: runManager
                     .createConfiguration(
-                        "$nxProject:$nxTarget${if(nxTargetConfiguration.isNullOrBlank().not()) ":$nxTargetConfiguration" else ""}",
+                        "$nxProject:$nxTarget${if(nxTargetConfiguration.isBlank().not()) ":$nxTargetConfiguration" else ""}",
                         NxCommandConfigurationType::class.java
                     )
                     .apply {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
@@ -8,7 +8,7 @@ fun getOrCreateRunnerConfigurationSettings(
     project: Project,
     nxProject: String,
     nxTarget: String,
-    nxTargetConfiguration: String? = "",
+    nxTargetConfiguration: String = "",
     args: List<String> = listOf()
 ): RunnerAndConfigurationSettings {
     val runManager = RunManager.getInstance(project)
@@ -24,7 +24,7 @@ fun getOrCreateRunnerConfigurationSettings(
         }
         ?: runManager
             .createConfiguration(
-                "$nxProject:$nxTarget${if(nxTargetConfiguration.isNullOrBlank().not()) ":$nxTargetConfiguration" else ""}",
+                "$nxProject:$nxTarget${if(nxTargetConfiguration.isBlank().not()) ":$nxTargetConfiguration" else ""}",
                 NxCommandConfigurationType::class.java
             )
             .apply {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/ProjectJsonPSIUtils.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/ProjectJsonPSIUtils.kt
@@ -18,7 +18,7 @@ import kotlin.contracts.contract
 data class NxTargetDescriptor(
     val nxProject: String,
     val nxTarget: String,
-    val nxTargetConfiguration: String? = null
+    val nxTargetConfiguration: String = ""
 ) {}
 
 // we should only provide gutters for leaf nodes (see LineMarkerProvider comment)


### PR DESCRIPTION
## What it does
When we build an Intellij Run Configuration with an nx target that has a configuration (ie, `nx run project:target:configuration`) the saved Intellij Run Configuration goes missing when restarting the IDE.

Now everything should be saved properly and a previously created run configuration can run properly. 
