### PR TITLE
fix: enable gutter actions in project.json without name & refactor project by path request

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/ProjectPostStartup.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/ProjectPostStartup.kt
@@ -8,6 +8,7 @@ import dev.nx.console.services.NxlsService
 import dev.nx.console.settings.NxConsoleSettingsProvider
 import dev.nx.console.telemetry.TelemetryService
 import dev.nx.console.ui.Notifier
+import dev.nx.console.utils.NxProjectJsonToProjectMap
 
 private val logger = logger<ProjectPostStartup>()
 
@@ -22,5 +23,7 @@ class ProjectPostStartup : ProjectPostStartupActivity {
         }
 
         TelemetryService.getInstance(project).extensionActivated(0)
+
+        service.runAfterStarted { NxProjectJsonToProjectMap.getInstance(project).init() }
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxFocusTargetInGraphLineMarkerContributor.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxFocusTargetInGraphLineMarkerContributor.kt
@@ -11,7 +11,8 @@ import dev.nx.console.utils.getPropertyNodeFromLeafNode
 class NxFocusTargetInGraphLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? {
         val targetNode = getPropertyNodeFromLeafNode(element) ?: return null
-        val targetDescriptor = getNxTargetDescriptorFromNode(targetNode) ?: return null
+        val targetDescriptor =
+            getNxTargetDescriptorFromNode(targetNode, element.project) ?: return null
 
         return Info(
             AllIcons.RunConfigurations.TestState.Run,

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
@@ -34,8 +34,8 @@ class NxlsWrapper(val project: Project) {
 
     var languageServer: NxlsLanguageServer? = null
     var languageClient: NxlsLanguageClient? = null
+    var initializeFuture: CompletableFuture<InitializeResult>? = null
     private var initializeResult: InitializeResult? = null
-    private var initializeFuture: CompletableFuture<InitializeResult>? = null
 
     private var connectedEditors = HashMap<String, DocumentManager>()
 
@@ -172,14 +172,6 @@ class NxlsWrapper(val project: Project) {
         connectedEditors.put(getFilePath(editor.document), documentManager)
     }
 
-    private fun connectTextService(documentManager: DocumentManager) {
-        log.info("Connecting textService to ${documentManager.documentPath}")
-        val textService =
-            languageServer?.textDocumentService ?: return log.info("text service not ready")
-        documentManager.addTextDocumentService(textService)
-        documentManager.documentOpened()
-    }
-
     fun disconnect(editor: Editor) {
         val filePath = getFilePath(editor.document)
         val documentManager =
@@ -195,7 +187,15 @@ class NxlsWrapper(val project: Project) {
         return connectedEditors.contains(filePath)
     }
 
-    fun getInitParams(): InitializeParams {
+    private fun connectTextService(documentManager: DocumentManager) {
+        log.info("Connecting textService to ${documentManager.documentPath}")
+        val textService =
+            languageServer?.textDocumentService ?: return log.info("text service not ready")
+        documentManager.addTextDocumentService(textService)
+        documentManager.documentOpened()
+    }
+
+    private fun getInitParams(): InitializeParams {
         val initParams = InitializeParams()
         initParams.workspaceFolders = listOf(WorkspaceFolder(nxlsWorkingPath(project.nxBasePath)))
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
@@ -39,6 +39,13 @@ interface NxService {
     }
 
     @JsonRequest
+    fun projectsByPaths(
+        projectsByPathsRequest: NxProjectsByPathsRequest
+    ): CompletableFuture<Map<String, NxProject>> {
+        throw UnsupportedOperationException()
+    }
+
+    @JsonRequest
     fun projectGraphOutput(): CompletableFuture<ProjectGraphOutput> {
         throw UnsupportedOperationException()
     }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/requests/NxProjectsByPathsRequest.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/requests/NxProjectsByPathsRequest.kt
@@ -1,0 +1,3 @@
+package dev.nx.console.nxls.server.requests
+
+data class NxProjectsByPathsRequest(val paths: Array<String>)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationProducer.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxRunConfigurationProducer.kt
@@ -48,7 +48,8 @@ class NxRunConfigurationProducer : LazyRunConfigurationProducer<NxCommandConfigu
     ): NxRunSettings? {
         val element = getElement(context) ?: return null
         val targetNode = getPropertyNodeFromLeafNode(element) ?: return null
-        val targetDescriptor = getNxTargetDescriptorFromNode(targetNode) ?: return null
+        val targetDescriptor =
+            getNxTargetDescriptorFromNode(targetNode, context.project) ?: return null
         sourceElement?.set(element)
         return runSettings.copy(
             nxProjects = targetDescriptor.nxProject,

--- a/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
@@ -12,6 +12,7 @@ import dev.nx.console.nxls.server.requests.NxGeneratorOptionsRequest
 import dev.nx.console.nxls.server.requests.NxGeneratorOptionsRequestOptions
 import dev.nx.console.nxls.server.requests.NxGetGeneratorContextFromPathRequest
 import dev.nx.console.ui.Notifier
+import dev.nx.console.nxls.server.requests.NxProjectsByPathsRequest
 import dev.nx.console.utils.nxlsWorkingPath
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -95,6 +96,11 @@ class NxlsService(val project: Project) {
         }()
     }
 
+    suspend fun projectsByPaths(paths: Array<String>): Map<String, NxProject> {
+        val request = NxProjectsByPathsRequest(paths)
+        return server()?.getNxService()?.projectsByPaths(request)?.await() ?: emptyMap()
+    }
+
     suspend fun projectGraphOutput(): ProjectGraphOutput? {
         return withMessageIssueCatch { server()?.getNxService()?.projectGraphOutput()?.await() }()
     }
@@ -133,6 +139,10 @@ class NxlsService(val project: Project) {
         return wrapper.isEditorConnected(editor)
     }
 
+    fun runAfterStarted(block: Runnable) {
+        wrapper.initializeFuture?.thenRun(block)
+    }
+
     private fun <T> withMessageIssueCatch(block: suspend () -> T): suspend () -> T? {
         return {
             try {
@@ -143,6 +153,7 @@ class NxlsService(val project: Project) {
             }
         }
     }
+    
 
     companion object {
         fun getInstance(project: Project): NxlsService = project.getService(NxlsService::class.java)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
@@ -11,8 +11,8 @@ import dev.nx.console.nxls.server.*
 import dev.nx.console.nxls.server.requests.NxGeneratorOptionsRequest
 import dev.nx.console.nxls.server.requests.NxGeneratorOptionsRequestOptions
 import dev.nx.console.nxls.server.requests.NxGetGeneratorContextFromPathRequest
-import dev.nx.console.ui.Notifier
 import dev.nx.console.nxls.server.requests.NxProjectsByPathsRequest
+import dev.nx.console.ui.Notifier
 import dev.nx.console.utils.nxlsWorkingPath
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -98,7 +98,10 @@ class NxlsService(val project: Project) {
 
     suspend fun projectsByPaths(paths: Array<String>): Map<String, NxProject> {
         val request = NxProjectsByPathsRequest(paths)
-        return server()?.getNxService()?.projectsByPaths(request)?.await() ?: emptyMap()
+        return withMessageIssueCatch {
+            server()?.getNxService()?.projectsByPaths(request)?.await()
+        }()
+            ?: emptyMap()
     }
 
     suspend fun projectGraphOutput(): ProjectGraphOutput? {
@@ -153,7 +156,6 @@ class NxlsService(val project: Project) {
             }
         }
     }
-    
 
     companion object {
         fun getInstance(project: Project): NxlsService = project.getService(NxlsService::class.java)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxProjectJsonToProjectMap.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxProjectJsonToProjectMap.kt
@@ -1,0 +1,83 @@
+package dev.nx.console.utils
+
+import com.intellij.json.psi.JsonFile
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileVisitor
+import com.intellij.psi.PsiFile
+import dev.nx.console.models.NxProject
+import dev.nx.console.services.NxWorkspaceRefreshListener
+import dev.nx.console.services.NxlsService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Service(Service.Level.PROJECT)
+class NxProjectJsonToProjectMap(val project: Project) {
+    private val pathsToProjectsMap: MutableMap<String, NxProject> = mutableMapOf()
+
+    fun init() {
+        CoroutineScope(Dispatchers.Default).launch { populateMap() }
+        with(project.messageBus.connect()) {
+            subscribe(
+                NxlsService.NX_WORKSPACE_REFRESH_TOPIC,
+                object : NxWorkspaceRefreshListener {
+                    override fun onNxWorkspaceRefresh() {
+                        CoroutineScope(Dispatchers.Default).launch { populateMap() }
+                    }
+                }
+            )
+        }
+    }
+
+    fun getProjectForProjectJson(projectJsonFile: PsiFile): NxProject? {
+        if (projectJsonFile !is JsonFile) {
+            return null
+        }
+        if (projectJsonFile.name != "project.json") {
+            return null
+        }
+        return pathsToProjectsMap[projectJsonFile.virtualFile.path]
+    }
+
+    private suspend fun populateMap() {
+        val paths = findProjectJsonFiles()
+        logger<NxProjectJsonToProjectMap>().info("loading projects by path")
+        val projectsMap = NxlsService.getInstance(project).projectsByPaths(paths.toTypedArray())
+        logger<NxProjectJsonToProjectMap>().info("loaded projects by path")
+
+        pathsToProjectsMap.clear()
+        pathsToProjectsMap.putAll(projectsMap)
+    }
+
+    private fun findProjectJsonFiles(): List<String> {
+        val paths: MutableList<String> = ArrayList()
+        ReadAction.run<RuntimeException> {
+            val startDirectory = LocalFileSystem.getInstance().findFileByPath(project.nxBasePath)
+            if (startDirectory != null) {
+                VfsUtilCore.visitChildrenRecursively(
+                    startDirectory,
+                    object : VirtualFileVisitor<Any?>() {
+                        override fun visitFile(file: VirtualFile): Boolean {
+                            if (!file.isDirectory && file.name == "project.json") {
+                                paths.add(file.path)
+                            }
+                            return true
+                        }
+                    }
+                )
+            }
+        }
+        return paths
+    }
+
+    companion object {
+        fun getInstance(project: Project): NxProjectJsonToProjectMap =
+            project.getService(NxProjectJsonToProjectMap::class.java)
+    }
+}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxProjectJsonToProjectMap.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxProjectJsonToProjectMap.kt
@@ -3,7 +3,6 @@ package dev.nx.console.utils
 import com.intellij.json.psi.JsonFile
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
@@ -47,9 +46,7 @@ class NxProjectJsonToProjectMap(val project: Project) {
 
     private suspend fun populateMap() {
         val paths = findProjectJsonFiles()
-        logger<NxProjectJsonToProjectMap>().info("loading projects by path")
         val projectsMap = NxlsService.getInstance(project).projectsByPaths(paths.toTypedArray())
-        logger<NxProjectJsonToProjectMap>().info("loaded projects by path")
 
         pathsToProjectsMap.clear()
         pathsToProjectsMap.putAll(projectsMap)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/ProjectJsonPSIUtils.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/ProjectJsonPSIUtils.kt
@@ -5,6 +5,7 @@ import com.intellij.json.psi.JsonFile
 import com.intellij.json.psi.JsonObject
 import com.intellij.json.psi.JsonProperty
 import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -29,7 +30,7 @@ fun getPropertyNodeFromLeafNode(element: PsiElement): JsonProperty? {
     return parent.parentOfType()
 }
 
-fun getNxTargetDescriptorFromNode(element: PsiElement): NxTargetDescriptor? {
+fun getNxTargetDescriptorFromNode(element: PsiElement, project: Project): NxTargetDescriptor? {
     if (element.isValid.not()) {
         return null
     }
@@ -40,13 +41,16 @@ fun getNxTargetDescriptorFromNode(element: PsiElement): NxTargetDescriptor? {
         val childPropertyLiteral = element.firstChild as? JsonStringLiteral ?: return null
         val nxTarget = childPropertyLiteral.value
         val nxProject =
-            (element
-                    ?.parentOfType<JsonObject>()
-                    ?.parentOfType<JsonObject>()
-                    ?.findProperty("name")
-                    ?.value as? JsonStringLiteral)
-                ?.value
-                ?: return null
+            NxProjectJsonToProjectMap.getInstance(project)
+                .getProjectForProjectJson(element.containingFile)
+                ?.name
+                ?: (element
+                        .parentOfType<JsonObject>()
+                        ?.parentOfType<JsonObject>()
+                        ?.findProperty("name")
+                        ?.value as? JsonStringLiteral)
+                    ?.value
+                    ?: return null
 
         return NxTargetDescriptor(nxProject, nxTarget)
     }

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -13,6 +13,7 @@ import {
   NxProjectByPathRequest,
   NxProjectFolderTreeRequest,
   NxProjectGraphOutputRequest,
+  NxProjectsByPathsRequest,
   NxVersionRequest,
   NxWorkspaceRefreshNotification,
   NxWorkspaceRequest,
@@ -39,6 +40,7 @@ import {
   createProjectGraph,
   getGeneratorContextV2,
   getProjectFolderTree,
+  getProjectsByPaths,
 } from '@nx-console/language-server/workspace';
 import {
   getNxJsonSchema,
@@ -306,6 +308,19 @@ connection.onRequest(
       );
     }
     return getProjectByPath(args.projectPath, WORKING_PATH);
+  }
+);
+
+connection.onRequest(
+  NxProjectsByPathsRequest,
+  async (args: { projectPaths: string[] }) => {
+    if (!WORKING_PATH) {
+      return new ResponseError(
+        1000,
+        'Unable to get Nx info: no workspace path'
+      );
+    }
+    return getProjectsByPaths(args.projectPaths, WORKING_PATH);
   }
 );
 

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -313,14 +313,16 @@ connection.onRequest(
 
 connection.onRequest(
   NxProjectsByPathsRequest,
-  async (args: { projectPaths: string[] }) => {
+  async (args: { paths: string[] }) => {
     if (!WORKING_PATH) {
       return new ResponseError(
         1000,
         'Unable to get Nx info: no workspace path'
       );
     }
-    return getProjectsByPaths(args.projectPaths, WORKING_PATH);
+    const projectsByPath = await getProjectsByPaths(args.paths, WORKING_PATH);
+    lspLogger.log(JSON.stringify(projectsByPath));
+    return projectsByPath;
   }
 );
 

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -320,9 +320,7 @@ connection.onRequest(
         'Unable to get Nx info: no workspace path'
       );
     }
-    const projectsByPath = await getProjectsByPaths(args.paths, WORKING_PATH);
-    lspLogger.log(JSON.stringify(projectsByPath));
-    return projectsByPath;
+    return getProjectsByPaths(args.paths, WORKING_PATH);
   }
 );
 

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -58,7 +58,7 @@ export const NxProjectByPathRequest: RequestType<
 > = new RequestType('nx/projectByPath');
 
 export const NxProjectsByPathsRequest: RequestType<
-  { projectPaths: string[] },
+  { paths: string[] },
   { [path: string]: ProjectConfiguration | undefined },
   unknown
 > = new RequestType('nx/projectsByPaths');

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -57,6 +57,12 @@ export const NxProjectByPathRequest: RequestType<
   unknown
 > = new RequestType('nx/projectByPath');
 
+export const NxProjectsByPathsRequest: RequestType<
+  { projectPaths: string[] },
+  { [path: string]: ProjectConfiguration | undefined },
+  unknown
+> = new RequestType('nx/projectsByPaths');
+
 export const NxGeneratorContextFromPathRequest: RequestType<
   {
     generator?: TaskExecutionSchema;

--- a/libs/language-server/workspace/src/lib/get-project-by-path.ts
+++ b/libs/language-server/workspace/src/lib/get-project-by-path.ts
@@ -1,8 +1,7 @@
-import type { ProjectConfiguration } from 'nx/src/devkit-exports';
 import { directoryExists } from '@nx-console/shared/file-system';
+import type { ProjectConfiguration } from 'nx/src/devkit-exports';
 import { isAbsolute, join, normalize, relative, sep } from 'path';
 import { nxWorkspace } from './workspace';
-import { lspLogger } from '@nx-console/language-server/utils';
 
 export async function getProjectByPath(
   path: string,
@@ -86,8 +85,6 @@ export async function getProjectsByPaths(
       break;
     }
   }
-
-  lspLogger.log('map ' + JSON.stringify(foundProjects));
   return Object.fromEntries(foundProjects);
 }
 

--- a/libs/language-server/workspace/src/lib/get-project-by-path.ts
+++ b/libs/language-server/workspace/src/lib/get-project-by-path.ts
@@ -2,6 +2,7 @@ import type { ProjectConfiguration } from 'nx/src/devkit-exports';
 import { directoryExists } from '@nx-console/shared/file-system';
 import { isAbsolute, join, normalize, relative, sep } from 'path';
 import { nxWorkspace } from './workspace';
+import { lspLogger } from '@nx-console/language-server/utils';
 
 export async function getProjectByPath(
   path: string,
@@ -86,6 +87,7 @@ export async function getProjectsByPaths(
     }
   }
 
+  lspLogger.log('map ' + JSON.stringify(foundProjects));
   return Object.fromEntries(foundProjects);
 }
 

--- a/libs/language-server/workspace/src/lib/get-project-by-path.ts
+++ b/libs/language-server/workspace/src/lib/get-project-by-path.ts
@@ -4,53 +4,89 @@ import { isAbsolute, join, normalize, relative, sep } from 'path';
 import { nxWorkspace } from './workspace';
 
 export async function getProjectByPath(
-  selectedPath: string | undefined,
+  path: string,
   workspacePath: string
-): Promise<ProjectConfiguration | null> {
-  if (!selectedPath) {
-    return null;
+): Promise<ProjectConfiguration | undefined> {
+  const projectsMap = await getProjectsByPaths([path], workspacePath);
+  return projectsMap?.[path] || undefined;
+}
+
+export async function getProjectsByPaths(
+  paths: string[] | undefined,
+  workspacePath: string
+): Promise<Record<string, ProjectConfiguration> | undefined> {
+  if (!paths) {
+    return undefined;
   }
 
   const { workspace } = await nxWorkspace(workspacePath);
-
-  const relativeFilePath = relative(workspacePath, selectedPath);
-  const isDirectory = await directoryExists(selectedPath);
+  const pathsMap = new Map<
+    string,
+    { relativePath: string; isDirectory: boolean }
+  >();
+  for (const path of paths) {
+    pathsMap.set(path, {
+      relativePath: relative(workspacePath, path),
+      isDirectory: await directoryExists(path),
+    });
+  }
 
   const projectEntries = Object.entries(workspace.projects);
-  let foundProject: ProjectConfiguration | null = null;
+  const foundProjects: Map<string, ProjectConfiguration> = new Map();
 
   for (const [projectName, projectConfig] of projectEntries) {
-    const isChildOfRoot = isChildOrEqual(projectConfig.root, relativeFilePath);
-    const relativeRootConfig = projectConfig.sourceRoot
-      ? relative(workspacePath, projectConfig.sourceRoot)
-      : undefined;
-    const isChildOfRootConfig =
-      relativeRootConfig &&
-      isChildOrEqual(relativeRootConfig, relativeFilePath);
-
+    // If there is no files array, it's an old version of Nx and we need backwards compatibility
     if (!projectConfig.files) {
-      foundProject = findByFilePath(
-        [projectName, projectConfig],
-        workspacePath,
-        selectedPath
-      );
-    } else if (isDirectory && (isChildOfRoot || isChildOfRootConfig)) {
-      foundProject = projectConfig;
-    } else if (
-      !isDirectory &&
-      projectConfig.files.some(
-        ({ file }) => normalize(file) === relativeFilePath
-      )
-    ) {
-      foundProject = projectConfig;
+      new Map(pathsMap).forEach((_, path) => {
+        const foundProject = findByFilePath(
+          [projectName, projectConfig],
+          workspacePath,
+          path
+        );
+        if (foundProject) {
+          foundProjects.set(path, foundProject);
+          pathsMap.delete(path);
+        }
+      });
+      continue;
     }
 
-    if (foundProject) {
+    // project check for directories
+    new Map(pathsMap).forEach(({ relativePath, isDirectory }, path) => {
+      if (!isDirectory) return;
+
+      const isChildOfRoot = isChildOrEqual(projectConfig.root, relativePath);
+      const relativeRootConfig = projectConfig.sourceRoot
+        ? relative(workspacePath, projectConfig.sourceRoot)
+        : undefined;
+      const isChildOfRootConfig =
+        relativeRootConfig && isChildOrEqual(relativeRootConfig, relativePath);
+
+      if (isChildOfRoot || isChildOfRootConfig) {
+        foundProjects.set(path, projectConfig);
+        pathsMap.delete(path);
+      }
+    });
+
+    // iterate over the project files once and find all the paths that match
+    const nonDirectoryPaths = [...pathsMap.entries()].filter(
+      ([_, { isDirectory }]) => !isDirectory
+    );
+    projectConfig.files?.forEach(({ file }) => {
+      for (const [path, { relativePath }] of nonDirectoryPaths) {
+        if (file === relativePath) {
+          foundProjects.set(path, projectConfig);
+          pathsMap.delete(path);
+        }
+      }
+    });
+
+    if (pathsMap.size === 0) {
       break;
     }
   }
 
-  return foundProject;
+  return Object.fromEntries(foundProjects);
 }
 
 /** This is only used for backwards compatibility  */


### PR DESCRIPTION
- I implemented a `NxProjectJsonToProjectMap` that keeps track of all projects matching the project.json files. When we create gutter actions, we can synchronously read from that map to find out what project the file belongs to without relying on the optional name property
- the map is prefilled with values at startup or when the workspace changes
- we fall back to the name property if the map is empty for some reason (maybe race conditions or the nxls is gone)
- to scale this for bigger workspaces, this required a new nxls request to efficiently find projects for multiple paths