### PR TITLE
feat: consume new graph events to open files in the ide

### DIFF
--- a/apps/generate-ui-v2-e2e/src/support/visit-generate-ui.ts
+++ b/apps/generate-ui-v2-e2e/src/support/visit-generate-ui.ts
@@ -3,7 +3,6 @@ import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 export const visitGenerateUi = (schema: GeneratorSchema) =>
   cy.visit('/', {
     onBeforeLoad: (win: any) => {
-      console.log('win', win);
       const postToWebviewCallbacks: any[] = [];
       win.intellijApi = {
         postToWebview(message: string) {
@@ -30,7 +29,6 @@ export const visitGenerateUi = (schema: GeneratorSchema) =>
           }
         },
         registerPostToWebviewCallback(callback: any) {
-          console.log('registering post to webview callback', callback);
           postToWebviewCallbacks.push(callback);
         },
       };

--- a/apps/intellij/build.gradle.kts
+++ b/apps/intellij/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
+
+    implementation("io.github.z4kn4fein:semver:1.4.2")
 }
 
 ktfmt { kotlinLangStyle() }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
@@ -155,8 +155,7 @@ class NxGraphBrowser(
 
         val nxConsoleEnvironmentScriptTag: String =
             NxlsService.getInstance(project).nxVersion()?.let {
-                // TODO: once this is released on the nx side, replace with the proper version check
-                if (it.full.toVersion(strict = false) >= "17.0.0".toVersion(strict = false)) {
+                if (it.full.toVersion(strict = false) >= "16.6.0".toVersion(strict = false)) {
                     "<script> window.environment = 'nx-console' </script>"
                 } else {
                     ""

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
@@ -194,6 +194,13 @@ class NxGraphBrowser(
           """
                 )
                 .replace(
+                    "</head>",
+                    """
+                     <script> window.environment = 'nx-console' </script>
+                     </head>
+                    """
+                )
+                .replace(
                     Regex("</body>"),
                     """
           <script>

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
@@ -52,6 +52,7 @@ interface NxService {
     fun projectFolderTree(): CompletableFuture<SerializedNxFolderTreeData> {
         throw UnsupportedOperationException()
     }
+
     @JsonNotification
     fun changeWorkspace(workspacePath: String) {
         throw UnsupportedOperationException()

--- a/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
@@ -117,6 +117,10 @@ class NxlsService(val project: Project) {
         }()
     }
 
+    suspend fun nxVersion(): NxVersion? {
+        return this.workspace()?.nxVersion
+    }
+
     fun addDocument(editor: Editor) {
         wrapper.connect(editor)
     }

--- a/libs/generate-ui/feature-task-execution-form/src/lib/ide-communication/ide-communication.service.ts
+++ b/libs/generate-ui/feature-task-execution-form/src/lib/ide-communication/ide-communication.service.ts
@@ -122,7 +122,6 @@ export class IdeCommunicationService {
         (option.items as string[]).length === 0
       ) && option['x-priority'] !== 'internal';
 
-    console.log(TaskExecutionInputMessageType);
     switch (message.payloadType) {
       case TaskExecutionInputMessageType.SetTaskExecutionSchema: {
         const schema = message.payload;

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace.ts
@@ -21,7 +21,7 @@ export async function getNxWorkspaceProjects(reset?: boolean): Promise<{
 }
 
 export async function getNxWorkspacePath(): Promise<string> {
-  const { workspacePath } = await getNxWorkspace();
+  const { workspacePath, nxVersion } = await getNxWorkspace();
   return workspacePath;
 }
 

--- a/libs/vscode/project-graph/src/lib/graph-webview.ts
+++ b/libs/vscode/project-graph/src/lib/graph-webview.ts
@@ -1,4 +1,7 @@
-import { getProjectGraphOutput } from '@nx-console/vscode/nx-workspace';
+import {
+  getNxWorkspacePath,
+  getProjectGraphOutput,
+} from '@nx-console/vscode/nx-workspace';
 import { getOutputChannel } from '@nx-console/vscode/utils';
 import {
   commands,
@@ -12,6 +15,7 @@ import { waitFor } from 'xstate/lib/waitFor';
 import { MessageType } from './graph-message-type';
 import { graphService } from './graph.machine';
 import { loadError, loadHtml, loadNoProject, loadSpinner } from './load-html';
+import { join } from 'node:path';
 
 export class GraphWebView implements Disposable {
   panel: WebviewPanel | undefined;
@@ -57,6 +61,7 @@ export class GraphWebView implements Disposable {
       return;
     }
 
+    const workspacePath = await getNxWorkspacePath();
     const { directory } = await getProjectGraphOutput();
 
     this.panel = window.createWebviewPanel(
@@ -82,6 +87,12 @@ export class GraphWebView implements Disposable {
       }
       if (event.command === 'refresh') {
         commands.executeCommand('nxConsole.refreshWorkspace');
+      }
+      if (event.command === 'fileClick') {
+        commands.executeCommand(
+          'vscode.open',
+          Uri.file(join(workspacePath, event.data))
+        );
       }
     });
 

--- a/libs/vscode/project-graph/src/lib/load-html.ts
+++ b/libs/vscode/project-graph/src/lib/load-html.ts
@@ -390,10 +390,7 @@ function injectedScript() {
 
 async function setNxConsoleEnvironment() {
   const nxVersion = await getNxVersion();
-  console.log(nxVersion);
-  // TODO: once this is released on the nx side, replace with the proper version check
-  if (gte(nxVersion.version, '17.0.0')) {
-    console.log('hello');
+  if (gte(nxVersion.version, '16.6.0')) {
     return '<script> window.environment = "nx-console"</script>';
   } else {
     return '';

--- a/libs/vscode/project-graph/src/lib/load-html.ts
+++ b/libs/vscode/project-graph/src/lib/load-html.ts
@@ -1,7 +1,11 @@
-import { getProjectGraphOutput } from '@nx-console/vscode/nx-workspace';
+import {
+  getNxVersion,
+  getProjectGraphOutput,
+} from '@nx-console/vscode/nx-workspace';
 import { getOutputChannel } from '@nx-console/vscode/utils';
 import { Uri, WebviewPanel, workspace } from 'vscode';
 import { MessageType } from './graph-message-type';
+import { SemVer, coerce, gte } from 'semver';
 
 const html = String.raw;
 
@@ -221,7 +225,7 @@ export async function loadHtml(panel: WebviewPanel) {
         }
       </style>
       <script>${injectedScript()}</script>
-      <script> window.environment = 'nx-console'</script>
+      ${await setNxConsoleEnvironment()}
 
       </head>`
   );
@@ -382,6 +386,18 @@ function injectedScript() {
       })
     }())
   `;
+}
+
+async function setNxConsoleEnvironment() {
+  const nxVersion = await getNxVersion();
+  console.log(nxVersion);
+  // TODO: once this is released on the nx side, replace with the proper version check
+  if (gte(nxVersion.version, '17.0.0')) {
+    console.log('hello');
+    return '<script> window.environment = "nx-console"</script>';
+  } else {
+    return '';
+  }
 }
 
 function registerFileClickListener() {

--- a/libs/vscode/project-graph/src/lib/load-html.ts
+++ b/libs/vscode/project-graph/src/lib/load-html.ts
@@ -223,15 +223,23 @@ export async function loadHtml(panel: WebviewPanel) {
       <script>${injectedScript()}</script>
       </head>`
   );
+  projectGraphHtml = projectGraphHtml.replace(
+    '</body>',
+    html`
+    <script>
+      ${registerFileClickListener()};
+    </script>
+   </body>`
+  );
 
   return projectGraphHtml;
 }
 
 function injectedScript() {
-  // language=JavaScript
   return `
     (function() {
       const vscode = acquireVsCodeApi();
+      window.vscode = vscode;
 
       const noProjectElement = document.createElement('p');
       noProjectElement.classList.add('nx-select-project');
@@ -372,4 +380,16 @@ function injectedScript() {
       })
     }())
   `;
+}
+
+function registerFileClickListener() {
+  return `
+  window.externalApi?.registerFileClickCallback?.((message) => {
+    window.vscode.postMessage({
+      command: 'fileClick',
+      data: message
+    })
+ })
+ 
+ `;
 }

--- a/libs/vscode/project-graph/src/lib/load-html.ts
+++ b/libs/vscode/project-graph/src/lib/load-html.ts
@@ -221,6 +221,8 @@ export async function loadHtml(panel: WebviewPanel) {
         }
       </style>
       <script>${injectedScript()}</script>
+      <script> window.environment = 'nx-console'</script>
+
       </head>`
   );
   projectGraphHtml = projectGraphHtml.replace(


### PR DESCRIPTION
This will enable the opening of files by clicking on project edge links in the integrated graph.
We set `window.environment = 'nx-console'` to let the graph know it's rendered in nx console. 
Because this wasn't the case before and would break some things, it's only enabled from 17.0.0.

Once the nx change is released, we can change this number to reflect the actual release.

Corresponding nx PR: https://github.com/nrwl/nx/pull/18113

Let's wait until it's reviewed before merging.