### PR TITLE
fix: sort project tree view / nx toolwindow

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/tree/builder/NxTreeBuilderBase.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/tree/builder/NxTreeBuilderBase.kt
@@ -46,6 +46,7 @@ abstract class NxTreeBuilderBase(private val nxWorkspace: NxWorkspace?) {
         return nxWorkspace.workspace.projects.values
             .flatMap { p -> p.targets.keys.map { it to p.name } }
             .groupBy { it.first }
+            .toSortedMap()
             .map { NxSimpleNode.TargetGroup(it.key, targetsSectionNode) }
             .toTypedArray()
     }

--- a/libs/language-server/workspace/src/lib/get-project-folder-tree.ts
+++ b/libs/language-server/workspace/src/lib/get-project-folder-tree.ts
@@ -93,5 +93,8 @@ export async function getProjectFolderTree(workspacePath: string): Promise<{
       node,
     })
   );
-  return { serializedTreeMap, roots: [...roots] };
+  const sortedRoots = Array.from(roots).sort((a, b) => {
+    return a.dir.localeCompare(b.dir);
+  });
+  return { serializedTreeMap, roots: sortedRoots };
 }

--- a/libs/vscode/nx-project-view/src/lib/views/nx-project-tree-view.ts
+++ b/libs/vscode/nx-project-view/src/lib/views/nx-project-tree-view.ts
@@ -36,9 +36,16 @@ class TreeView extends BaseView {
     if (!element) {
       const { treeMap, roots } = await getProjectFolderTree();
       this.treeMap = treeMap;
-      return roots.map((root) =>
-        this.createFolderOrProjectTreeItemFromNode(root)
-      );
+      return roots
+        .sort((a, b) => {
+          // the VSCode tree view looks chaotic when folders and projects are on the same level
+          // so we sort the nodes to have folders first and projects after
+          if (!!a.projectName == !!b.projectName) {
+            return a.dir.localeCompare(b.dir);
+          }
+          return a.projectName ? 1 : -1;
+        })
+        .map((root) => this.createFolderOrProjectTreeItemFromNode(root));
     }
 
     if (element.contextValue === 'project') {


### PR DESCRIPTION
sort the tree view. VSCode is sorted to have root folders first and then root projects because it looks very chaotic otherwise.

Thx [@ctaepper](https://github.com/ctaepper) for pointing this out
## JetBrains
### Before
![image](https://github.com/nrwl/nx-console/assets/34165455/0518754a-42e0-4279-883b-e6cafe64e602)

### After
![image](https://github.com/nrwl/nx-console/assets/34165455/e68df40f-47cf-448f-b494-ac2dcf35014c)

## VSCode
### Before
![image](https://github.com/nrwl/nx-console/assets/34165455/176b5f83-1bcf-40f8-869f-2a0a96170a50)

### After
![image](https://github.com/nrwl/nx-console/assets/34165455/b2d16682-5d42-4bae-817b-4d8ec3a55f9f)
