### PR TITLE
feat: show keyboard shortcut indicator in generate ui search bar

### DIFF
--- a/apps/generate-ui-v2/src/components/search-bar.ts
+++ b/apps/generate-ui-v2/src/components/search-bar.ts
@@ -21,8 +21,9 @@ export class SearchBar extends EditorContext(LitElement) {
             class="absolute left-2 top-[0.7rem]"
           ></icon-element>
           <div class="absolute right-2 top-2.5">
-            <kbd class="border-fieldBorder rounded-md border p-1 drop-shadow-lg whitespace-nowrap"
-              >${this.getKeyboardShortcutSymbol()} S</kbd
+            <kbd
+              class="border-fieldBorder bg-selectFieldBackground whitespace-nowrap rounded-md border p-1 shadow"
+              >${this.getKeyboardShortcutSymbol()}S</kbd
             >
           </div>
         </div>
@@ -41,7 +42,7 @@ export class SearchBar extends EditorContext(LitElement) {
           </span>
           <div slot="end">
             <kbd class="bg-background whitespace-nowrap"
-              >${this.getKeyboardShortcutSymbol()} S</kbd
+              >${this.getKeyboardShortcutSymbol()}S</kbd
             >
           </div>
         </vscode-text-field>
@@ -53,7 +54,7 @@ export class SearchBar extends EditorContext(LitElement) {
     if (window.navigator.platform.toLowerCase().includes('mac')) {
       return '⌘';
     } else {
-      return 'Ctrl';
+      return 'Ctrl ';
     }
   }
 

--- a/apps/generate-ui-v2/src/components/search-bar.ts
+++ b/apps/generate-ui-v2/src/components/search-bar.ts
@@ -20,6 +20,11 @@ export class SearchBar extends EditorContext(LitElement) {
             icon="search"
             class="absolute left-2 top-[0.7rem]"
           ></icon-element>
+          <div class="absolute right-2 top-2.5">
+            <kbd class="border-fieldBorder rounded-md border p-1 drop-shadow-lg"
+              >⌘S</kbd
+            >
+          </div>
         </div>
       `;
     } else {
@@ -34,9 +39,16 @@ export class SearchBar extends EditorContext(LitElement) {
           <span slot="start">
             <icon-element icon="search"></icon-element>
           </span>
+          <div slot="end">
+            <kbd class="bg-background">⌘S</kbd>
+          </div>
         </vscode-text-field>
       `;
     }
+  }
+
+  protected createRenderRoot(): Element | ShadowRoot {
+    return this;
   }
 
   private handleInput(e: Event) {
@@ -44,9 +56,5 @@ export class SearchBar extends EditorContext(LitElement) {
       detail: (e.target as HTMLInputElement).value,
     });
     this.dispatchEvent(event);
-  }
-
-  protected createRenderRoot(): Element | ShadowRoot {
-    return this;
   }
 }

--- a/apps/generate-ui-v2/src/components/search-bar.ts
+++ b/apps/generate-ui-v2/src/components/search-bar.ts
@@ -21,8 +21,8 @@ export class SearchBar extends EditorContext(LitElement) {
             class="absolute left-2 top-[0.7rem]"
           ></icon-element>
           <div class="absolute right-2 top-2.5">
-            <kbd class="border-fieldBorder rounded-md border p-1 drop-shadow-lg"
-              >${this.getKeyboardShortcutSymbol()}S</kbd
+            <kbd class="border-fieldBorder rounded-md border p-1 drop-shadow-lg whitespace-nowrap"
+              >${this.getKeyboardShortcutSymbol()} S</kbd
             >
           </div>
         </div>
@@ -40,8 +40,8 @@ export class SearchBar extends EditorContext(LitElement) {
             <icon-element icon="search"></icon-element>
           </span>
           <div slot="end">
-            <kbd class="bg-background"
-              >${this.getKeyboardShortcutSymbol()}S</kbd
+            <kbd class="bg-background whitespace-nowrap"
+              >${this.getKeyboardShortcutSymbol()} S</kbd
             >
           </div>
         </vscode-text-field>

--- a/apps/generate-ui-v2/src/components/search-bar.ts
+++ b/apps/generate-ui-v2/src/components/search-bar.ts
@@ -22,7 +22,7 @@ export class SearchBar extends EditorContext(LitElement) {
           ></icon-element>
           <div class="absolute right-2 top-2.5">
             <kbd class="border-fieldBorder rounded-md border p-1 drop-shadow-lg"
-              >⌘S</kbd
+              >${this.getKeyboardShortcutSymbol()}S</kbd
             >
           </div>
         </div>
@@ -40,10 +40,20 @@ export class SearchBar extends EditorContext(LitElement) {
             <icon-element icon="search"></icon-element>
           </span>
           <div slot="end">
-            <kbd class="bg-background">⌘S</kbd>
+            <kbd class="bg-background"
+              >${this.getKeyboardShortcutSymbol()}S</kbd
+            >
           </div>
         </vscode-text-field>
       `;
+    }
+  }
+
+  getKeyboardShortcutSymbol() {
+    if (window.navigator.platform.toLowerCase().includes('mac')) {
+      return '⌘';
+    } else {
+      return 'Ctrl';
     }
   }
 

--- a/libs/vscode/generate-ui-webview/src/lib/generate-ui-webview.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/generate-ui-webview.ts
@@ -225,6 +225,7 @@ export class GenerateUiWebview {
       --foreground-color: var(--vscode-editor-foreground);
       --background-color: var(--vscode-editor-background);
       --primary-color: var(--button-primary-background);
+      --secondary-color: var(--button-secondary-background);
       --error-color: var(--vscode-inputValidation-errorBorder);
       --field-border-color: var(--panel-view-border);
       --focus-border-color: var(--vscode-focusBorder);


### PR DESCRIPTION
Some examples of how it looks:
![image](https://github.com/nrwl/nx-console/assets/34165455/163a84fe-a9ce-465d-8d5a-bbd98a0ad2f8)
![image](https://github.com/nrwl/nx-console/assets/34165455/cbb121cb-548c-439e-8a9e-7bf27e9c8351)
<img width="100" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/9a726cc5-44fc-4070-a390-2786664aff85">

