### PR TITLE
fix(intellij): make workspace path setting relative to project base path

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/settings/options/WorkspacePathSetting.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/settings/options/WorkspacePathSetting.kt
@@ -12,6 +12,7 @@ import com.intellij.ui.dsl.builder.RowLayout
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import dev.nx.console.services.NxlsService
 import dev.nx.console.settings.NxConsoleSettingBase
+import java.nio.file.Paths
 
 class WorkspacePathSetting(val project: Project) : NxConsoleSettingBase<String?> {
 
@@ -19,7 +20,10 @@ class WorkspacePathSetting(val project: Project) : NxConsoleSettingBase<String?>
 
     init {
         val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
-        inputField = textFieldWithBrowseButton(project, "Nx workspace root", descriptor)
+        inputField =
+            textFieldWithBrowseButton(project, "Nx workspace root", descriptor) {
+                Paths.get(project.basePath ?: "").relativize(Paths.get(it.path)).toString()
+            }
     }
     override fun render(panel: Panel) {
         panel.apply {
@@ -28,10 +32,10 @@ class WorkspacePathSetting(val project: Project) : NxConsoleSettingBase<String?>
                     cell(inputField)
                         .horizontalAlign(HorizontalAlign.FILL)
                         .comment(
-                            "Set this if your Nx workspace is not at the root of the currently opened project.",
+                            "Set this if your Nx workspace is not at the root of the currently opened project. Relative to the project base path.",
                             MAX_LINE_LENGTH_WORD_WRAP
                         )
-                        .apply { component.emptyText.text = project.basePath ?: "" }
+                        .apply { component.emptyText.text = "./" }
                 }
                 .layout(RowLayout.PARENT_GRID)
         }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/settings/options/WorkspacePathSetting.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/settings/options/WorkspacePathSetting.kt
@@ -20,10 +20,7 @@ class WorkspacePathSetting(val project: Project) : NxConsoleSettingBase<String?>
 
     init {
         val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
-        inputField =
-            textFieldWithBrowseButton(project, "Nx workspace root", descriptor) {
-                Paths.get(project.basePath ?: "").relativize(Paths.get(it.path)).toString()
-            }
+        inputField = textFieldWithBrowseButton(project, "Nx workspace root", descriptor)
     }
     override fun render(panel: Panel) {
         panel.apply {
@@ -32,10 +29,10 @@ class WorkspacePathSetting(val project: Project) : NxConsoleSettingBase<String?>
                     cell(inputField)
                         .horizontalAlign(HorizontalAlign.FILL)
                         .comment(
-                            "Set this if your Nx workspace is not at the root of the currently opened project. Relative to the project base path.",
+                            "Set this if your Nx workspace is not at the root of the currently opened project.",
                             MAX_LINE_LENGTH_WORD_WRAP
                         )
-                        .apply { component.emptyText.text = "./" }
+                        .apply { component.emptyText.text = project.basePath ?: "" }
                 }
                 .layout(RowLayout.PARENT_GRID)
         }
@@ -47,10 +44,14 @@ class WorkspacePathSetting(val project: Project) : NxConsoleSettingBase<String?>
         }
     }
 
-    override fun getValue(): String? = inputField.text.ifEmpty { null }
+    override fun getValue(): String? =
+        inputField.text
+            .ifEmpty { null }
+            ?.let { Paths.get(project.basePath ?: "").relativize(Paths.get(it)).toString() }
 
     override fun setValue(value: String?) {
         if (value == null) return
-        this.inputField.text = value
+        val absolutePath = Paths.get(project.basePath ?: "").resolve(Paths.get(value))
+        this.inputField.text = absolutePath.toString()
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxBasePath.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxBasePath.kt
@@ -2,6 +2,7 @@ package dev.nx.console.utils
 
 import com.intellij.openapi.project.Project
 import dev.nx.console.settings.NxConsoleProjectSettingsProvider
+import java.nio.file.Paths
 
 /**
  * Get the base path of the current Nx project. Will get the settings first, then default to the
@@ -9,5 +10,12 @@ import dev.nx.console.settings.NxConsoleProjectSettingsProvider
  */
 val Project.nxBasePath: String
     get() =
-        NxConsoleProjectSettingsProvider.getInstance(this).workspacePath
+        basePath?.let {
+            val settingsPath = NxConsoleProjectSettingsProvider.getInstance(this).workspacePath
+            if (settingsPath == null) {
+                null
+            } else {
+                Paths.get(it).resolve(settingsPath).toString()
+            }
+        }
             ?: basePath ?: throw IllegalStateException("Base path is not found for project")


### PR DESCRIPTION
since the workspace path is a project setting and as such can be shared between team mates, it doesn't really make much sense to have absolute paths in here.

Now the settings takes a relative path which is then resolved to the full path when needed. The full path is still shown because it looks better but under the hood it's saved as a relative path to make the setting shareable.