### PR TITLE
fix(vscode): enhance graph/task focus commands to fallback to manual selection

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -351,7 +351,7 @@
       },
       {
         "category": "Nx",
-        "title": "Focus in Nx Graph",
+        "title": "Focus Project in Nx Graph",
         "command": "nx.graph.focus"
       },
       {


### PR DESCRIPTION
Before, if you wanted to focus a project from the command prompt, it would only look for the currently opened file and fail otherwise. 
Now it will fall back to showing a quickpick and letting the user manually select a project if the currently opened file doesn't belong to a project.

This is not the same as the intellij behavior but it's a step in the right direction and more robust.