### PR TITLE
fix(generate-ui): make sure arguments with spaces or quotes are handled correctly

### DIFF
--- a/apps/generate-ui-v2/src/form-values.service.ts
+++ b/apps/generate-ui-v2/src/form-values.service.ts
@@ -157,7 +157,16 @@ export class FormValuesService {
       );
       const defaultValue = extractDefaultValue(option);
       if (compareWithDefaultValue(value, defaultValue)) return;
-      args.push(`--${key}=${value}`);
+      const valueString = value?.toString() ?? '';
+      if (valueString.includes(' ')) {
+        if (valueString.includes('"')) {
+          args.push(`--${key}='${value}'`);
+        } else {
+          args.push(`--${key}="${value}"`);
+        }
+      } else {
+        args.push(`--${key}=${value}`);
+      }
     });
     return args;
   }


### PR DESCRIPTION
fixes https://github.com/nrwl/nx-console/issues/1851

Also handles some more cases. Let's assume an option description: 
- `test with spaces` becomes `--description="test with spaces"`
- `hey what's up` becomes `--description="hey what's up"`
- `test with "spaces"` becomes `--description='test with "spaces"'`(<- note the outside single quotes to make sure the whole string is in the arg)

If you use both `"` and `'` in your arg I can't help you and you have to escape it manually. 

Are there any other cases that come to mind?
