### PR TITLE
feat(generate-ui): filter deprecated fields & move functionality to plugins

### DIFF
--- a/apps/generate-ui-v2-e2e/src/e2e/generator-context.cy.ts
+++ b/apps/generate-ui-v2-e2e/src/e2e/generator-context.cy.ts
@@ -1,10 +1,10 @@
+import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 import {
   expectConsoleLogToHaveBeenCalledWith,
   spyOnConsoleLog,
 } from '../support/console-spy';
-import { clickShowMore, getFieldByName } from '../support/get-elements';
+import { getFieldByName } from '../support/get-elements';
 import { visitGenerateUi } from '../support/visit-generate-ui';
-import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 
 const schemaProj: GeneratorSchema = {
   collectionName: '@nx/test',
@@ -28,25 +28,6 @@ const schemaDir: GeneratorSchema = {
   generatorName: 'test',
   description: 'description',
   options: [{ name: 'directory', isRequired: false, aliases: [] }],
-  context: {
-    project: 'project3',
-    directory: 'nested/nested2',
-  },
-};
-
-const schemaBoth: GeneratorSchema = {
-  collectionName: '@nx/test',
-  generatorName: 'test',
-  description: 'description',
-  options: [
-    {
-      name: 'project',
-      isRequired: true,
-      aliases: [],
-      items: ['project1', 'project2', 'project3'],
-    },
-    { name: 'directory', isRequired: false, aliases: [] },
-  ],
   context: {
     project: 'project3',
     directory: 'nested/nested2',
@@ -77,20 +58,6 @@ describe('generator context', () => {
         consoleLog,
         '--directory=nested/nested2'
       );
-    });
-  });
-
-  it('should only fill project if both directory and project exist', () => {
-    visitGenerateUi(schemaBoth);
-    clickShowMore();
-
-    getFieldByName('project').should('have.value', 'project3');
-    getFieldByName('directory').should('be.empty');
-
-    spyOnConsoleLog().then((consoleLog) => {
-      cy.get("[data-cy='generate-button']").click();
-      expectConsoleLogToHaveBeenCalledWith(consoleLog, 'run-generator');
-      expectConsoleLogToHaveBeenCalledWith(consoleLog, '--project=project3');
     });
   });
 

--- a/apps/generate-ui-v2/src/ide-communication.controller.ts
+++ b/apps/generate-ui-v2/src/ide-communication.controller.ts
@@ -10,7 +10,6 @@ import {
   GeneratorSchema,
   ValidationResults,
 } from '@nx-console/shared/generate-ui-types';
-import { Option } from '@nx-console/shared/schema';
 import { ReactiveController, ReactiveElement } from 'lit';
 
 import type { WebviewApi } from 'vscode-webview';
@@ -132,35 +131,11 @@ export class IdeCommunicationController implements ReactiveController {
   }
 
   private handleInputMessage(message: GenerateUiInputMessage) {
-    const optionFilter = (option: Option) =>
-      option['x-priority'] !== 'internal';
-
-    // THIS IS A FIX UNTIL DIR & PATH OPTIONS ARE PROPERLY HANDLED
-    // WE DON'T WANT TO PREFILL DIR WHEN THERE'S A PROJECT
-    const transformContext = (
-      schema: GeneratorSchema,
-      context: GeneratorContext | undefined
-    ) => {
-      if (schema.options.find((opt) => opt.name === 'project')) {
-        return {
-          ...context,
-          directory: undefined,
-        };
-      } else {
-        return context;
-      }
-    };
-
     switch (message.payloadType) {
       case 'generator': {
-        const schema = message.payload;
-        const schemaWithFilteredOptions = {
-          ...schema,
-          options: schema.options.filter(optionFilter),
-        };
-        this.generatorSchema = schemaWithFilteredOptions;
+        this.generatorSchema = message.payload;
         this.generatorContextContextProvider.setValue(
-          transformContext(schema, this.generatorSchema.context)
+          this.generatorSchema.context
         );
 
         this.host.requestUpdate();

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/filter-internal-and-deprecated-processor.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/filter-internal-and-deprecated-processor.ts
@@ -1,0 +1,18 @@
+import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
+
+export function filterInternalAndDeprecatedProcessor(
+  schema: GeneratorSchema
+): GeneratorSchema {
+  return {
+    ...schema,
+    options: (schema.options ?? []).filter((option) => {
+      if (option['x-priority'] === 'internal') {
+        return false;
+      }
+      if (option['x-deprecated']) {
+        return false;
+      }
+      return true;
+    }),
+  };
+}

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/index.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/index.ts
@@ -1,8 +1,14 @@
 import { NxConsolePluginsDefinition } from '../nx-console-plugin-types';
+import { filterInternalAndDeprecatedProcessor } from './filter-internal-and-deprecated-processor';
 import { projectNameAndRootProcessor } from './project-name-and-root-processor';
+import { tempNoProjectAndDirProcessor } from './temp-no-project-and-dir-processor';
 
 export const internalPlugins: NxConsolePluginsDefinition = {
-  schemaProcessors: [projectNameAndRootProcessor],
+  schemaProcessors: [
+    projectNameAndRootProcessor,
+    filterInternalAndDeprecatedProcessor,
+    tempNoProjectAndDirProcessor,
+  ],
   validators: [],
   startupMessages: [],
 };

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/temp-no-project-and-dir-processor.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/temp-no-project-and-dir-processor.ts
@@ -1,0 +1,18 @@
+import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
+
+// THIS IS A FIX UNTIL DIR & PATH OPTIONS ARE PROPERLY HANDLED
+// WE DON'T WANT TO PREFILL DIR WHEN THERE'S A PROJECT
+export function tempNoProjectAndDirProcessor(
+  schema: GeneratorSchema
+): GeneratorSchema {
+  if (!schema.options.find((opt) => opt.name === 'project')) {
+    return schema;
+  }
+  return {
+    ...schema,
+    context: {
+      ...(schema.context ?? {}),
+      directory: undefined,
+    },
+  };
+}


### PR DESCRIPTION
before, fields with `x-deprecated` set were mistakenly not filtered. I added this and also moved the filtering logic to internal plugins to simplify the app.