### PR TITLE
fix(intellij): add shortcut to focus task action

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusProjectAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusProjectAction.kt
@@ -3,8 +3,11 @@ package dev.nx.console.graph.actions
 import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.CustomShortcutSet
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.DumbAwareAction
+import dev.nx.console.NxIcons
 import dev.nx.console.graph.NxGraphService
 import dev.nx.console.nx_toolwindow.tree.NxSimpleNode
 import dev.nx.console.nx_toolwindow.tree.NxTreeNodeKey
@@ -17,11 +20,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class NxGraphFocusProjectAction : DumbAwareAction("Nx Graph: Focus Project") {
+
+    init {
+        useKeyMapShortcutSetOrDefault()
+    }
     override fun update(e: AnActionEvent) {
+        useKeyMapShortcutSetOrDefault()
         val nxTreeNode = e.getData(NxTreeNodeKey) ?: return
         if (nxTreeNode !is NxSimpleNode.Project) {
             e.presentation.isEnabledAndVisible = false
         }
+        e.presentation.icon = NxIcons.Action
     }
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
@@ -71,5 +80,20 @@ class NxGraphFocusProjectAction : DumbAwareAction("Nx Graph: Focus Project") {
         val project = e.project ?: return null
 
         return selectNxProject(project, e.dataContext, currentlyOpenedProject)
+    }
+
+    private fun useKeyMapShortcutSetOrDefault() {
+        val keyMapSet = KeymapUtil.getActiveKeymapShortcuts(ID)
+
+        if (keyMapSet.shortcuts.isEmpty()) {
+            shortcutSet = CustomShortcutSet.fromString(DEFAULT_SHORTCUT)
+        } else {
+            shortcutSet = keyMapSet
+        }
+    }
+
+    companion object {
+        const val DEFAULT_SHORTCUT = "control shift G"
+        const val ID = "dev.nx.console.graph.actions.NxGraphFocusProjectAction"
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
@@ -3,6 +3,7 @@ package dev.nx.console.graph.actions
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAwareAction
+import dev.nx.console.NxIcons
 import dev.nx.console.graph.NxGraphService
 import dev.nx.console.nx_toolwindow.tree.NxSimpleNode
 import dev.nx.console.nx_toolwindow.tree.NxTreeNodeKey
@@ -32,6 +33,7 @@ class NxGraphFocusTaskAction(private val targetDescriptor: NxTargetDescriptor? =
         } else {
             e.presentation.text =
                 "Nx Graph: Focus ${targetDescriptor.nxProject}:${targetDescriptor.nxTarget} target"
+            e.presentation.icon = NxIcons.Action
         }
     }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
@@ -20,19 +20,10 @@ class NxGraphFocusTaskAction(private val targetDescriptor: NxTargetDescriptor? =
     DumbAwareAction() {
 
     init {
-        val keyMapSet =
-            KeymapUtil.getActiveKeymapShortcuts(
-                "dev.nx.console.graph.actions.NxGraphFocusTaskAction"
-            )
-
-        if (keyMapSet.shortcuts.isEmpty()) {
-            shortcutSet = CustomShortcutSet.fromString("control shift G")
-        } else {
-            shortcutSet = keyMapSet
-        }
+        useKeyMapShortcutSetOrDefault()
     }
-
     override fun update(e: AnActionEvent) {
+        useKeyMapShortcutSetOrDefault()
         if (e.place != "NxToolWindow" && targetDescriptor == null) {
             return
         }
@@ -98,5 +89,19 @@ class NxGraphFocusTaskAction(private val targetDescriptor: NxTargetDescriptor? =
         }
 
         return null
+    }
+
+    private fun useKeyMapShortcutSetOrDefault() {
+        val keyMapSet = KeymapUtil.getActiveKeymapShortcuts(ID)
+
+        if (keyMapSet.shortcuts.isEmpty()) {
+            shortcutSet = CustomShortcutSet.fromString(DEFAULT_SHORTCUT)
+        } else {
+            shortcutSet = keyMapSet
+        }
+    }
+    companion object {
+        const val DEFAULT_SHORTCUT = "control shift T"
+        const val ID = "dev.nx.console.graph.actions.NxGraphFocusTaskAction"
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
@@ -2,6 +2,7 @@ package dev.nx.console.graph.actions
 
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.DumbAwareAction
 import dev.nx.console.NxIcons
 import dev.nx.console.graph.NxGraphService
@@ -19,7 +20,16 @@ class NxGraphFocusTaskAction(private val targetDescriptor: NxTargetDescriptor? =
     DumbAwareAction() {
 
     init {
-        shortcutSet = CustomShortcutSet.fromString("control shift G")
+        val keyMapSet =
+            KeymapUtil.getActiveKeymapShortcuts(
+                "dev.nx.console.graph.actions.NxGraphFocusTaskAction"
+            )
+
+        if (keyMapSet.shortcuts.isEmpty()) {
+            shortcutSet = CustomShortcutSet.fromString("control shift G")
+        } else {
+            shortcutSet = keyMapSet
+        }
     }
 
     override fun update(e: AnActionEvent) {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskAction.kt
@@ -1,9 +1,6 @@
 package dev.nx.console.graph.actions
 
-import com.intellij.openapi.actionSystem.ActionPlaces
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAwareAction
 import dev.nx.console.graph.NxGraphService
@@ -19,6 +16,10 @@ import kotlinx.coroutines.*
 
 class NxGraphFocusTaskAction(private val targetDescriptor: NxTargetDescriptor? = null) :
     DumbAwareAction() {
+
+    init {
+        shortcutSet = CustomShortcutSet.fromString("control shift G")
+    }
 
     override fun update(e: AnActionEvent) {
         if (e.place != "NxToolWindow" && targetDescriptor == null) {
@@ -39,11 +40,13 @@ class NxGraphFocusTaskAction(private val targetDescriptor: NxTargetDescriptor? =
 
         TelemetryService.getInstance(project).featureUsed("Nx Graph Focus Task")
 
-        val path = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE)?.path ?: return
+        val path = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE)?.path
 
         CoroutineScope(Dispatchers.Default).launch {
             val currentlyOpenedProject =
-                NxlsService.getInstance(project).generatorContextFromPath(path = path)?.project
+                path?.let {
+                    NxlsService.getInstance(project).generatorContextFromPath(path = path)?.project
+                }
             val targetDescriptor: NxTargetDescriptor =
                 this@NxGraphFocusTaskAction.targetDescriptor
                     ?: if (e.place == "NxToolWindow") {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskGroupAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/actions/NxGraphFocusTaskGroupAction.kt
@@ -1,7 +1,10 @@
 package dev.nx.console.graph.actions
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CustomShortcutSet
+import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.DumbAwareAction
+import dev.nx.console.NxIcons
 import dev.nx.console.graph.NxGraphService
 import dev.nx.console.nx_toolwindow.tree.NxSimpleNode
 import dev.nx.console.nx_toolwindow.tree.NxTreeNodeKey
@@ -10,6 +13,7 @@ import dev.nx.console.telemetry.TelemetryService
 class NxGraphFocusTaskGroupAction : DumbAwareAction() {
 
     override fun update(e: AnActionEvent) {
+        useKeyMapShortcutSetOrDefault()
         val targetGroup: NxSimpleNode.TargetGroup? =
             e.getData(NxTreeNodeKey).let { it as? NxSimpleNode.TargetGroup }
 
@@ -17,6 +21,7 @@ class NxGraphFocusTaskGroupAction : DumbAwareAction() {
             e.presentation.isEnabledAndVisible = false
         } else {
             e.presentation.text = "Nx Graph: Focus ${targetGroup.name} targets"
+            e.presentation.icon = NxIcons.Action
         }
     }
     override fun actionPerformed(e: AnActionEvent) {
@@ -28,5 +33,19 @@ class NxGraphFocusTaskGroupAction : DumbAwareAction() {
         val graphService = NxGraphService.getInstance(project)
         graphService.showNxGraphInEditor()
         graphService.focusTaskGroup(targetGroup.name)
+    }
+
+    private fun useKeyMapShortcutSetOrDefault() {
+        val keyMapSet = KeymapUtil.getActiveKeymapShortcuts(ID)
+
+        if (keyMapSet.shortcuts.isEmpty()) {
+            shortcutSet = CustomShortcutSet.fromString(DEFAULT_SHORTCUT)
+        } else {
+            shortcutSet = keyMapSet
+        }
+    }
+    companion object {
+        const val DEFAULT_SHORTCUT = "control shift U"
+        const val ID = "dev.nx.console.graph.actions.NxGraphFocusTaskGroupAction"
     }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
@@ -457,7 +457,6 @@ class NxGraphBrowser(
             val js =
                 """
             window.externalApi?.registerFileClickCallback?.((message) => {
-            console.log("file click", message)
                     ${query.inject("message")}
             })
             """
@@ -487,8 +486,6 @@ class NxGraphBrowser(
             val js =
                 """
             window.externalApi?.registerOpenProjectConfigCallback?.((message) => {
-                    console.log("openProject click", message)
-
                     ${query.inject("message")}
             })
             """
@@ -511,8 +508,6 @@ class NxGraphBrowser(
             val js =
                 """
             window.externalApi?.registerRunTaskCallback?.((message) => {
-                    console.log("runtask click", message)
-
                     ${query.inject("message")}
             })
             """

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/ui/NxGraphBrowser.kt
@@ -51,7 +51,7 @@ class NxGraphBrowser(
     private val foregroundColor = getHexColor(UIUtil.getLabelForeground())
 
     init {
-        browser.jbCefClient.setProperty(JBCefClient.Properties.JS_QUERY_POOL_SIZE, 10)
+        browser.jbCefClient.setProperty(JBCefClient.Properties.JS_QUERY_POOL_SIZE, 100)
         browser.jbCefClient.addDownloadHandler(NxGraphDownloadHandler(), browser.cefBrowser)
         browser.jbCefClient.addContextMenuHandler(
             OpenDevToolsContextMenuHandler(),
@@ -457,6 +457,7 @@ class NxGraphBrowser(
             val js =
                 """
             window.externalApi?.registerFileClickCallback?.((message) => {
+            console.log("file click", message)
                     ${query.inject("message")}
             })
             """
@@ -486,6 +487,8 @@ class NxGraphBrowser(
             val js =
                 """
             window.externalApi?.registerOpenProjectConfigCallback?.((message) => {
+                    console.log("openProject click", message)
+
                     ${query.inject("message")}
             })
             """
@@ -508,6 +511,8 @@ class NxGraphBrowser(
             val js =
                 """
             window.externalApi?.registerRunTaskCallback?.((message) => {
+                    console.log("runtask click", message)
+
                     ${query.inject("message")}
             })
             """


### PR DESCRIPTION
there's now a shortcut in the gutter and the toolwindow
![image](https://github.com/nrwl/nx-console/assets/34165455/9e592ef3-bee5-4b44-b709-38f4ebf6c439)
![image](https://github.com/nrwl/nx-console/assets/34165455/e119baa9-3eb4-4177-ac55-5a3855baa130)

`ctrl shift g` because it's the same as `ctrl shift r` for running a target but `g` for graph.

There's something funky going on breaking shortcuts when you open the gutter actions with `option enter`... but that seems like a separate concern from this PR.

