### PR TITLE
feat: write internal git clean startup message plugin & display startup messages in intellij

### DIFF
--- a/apps/generate-ui-v2/src/components/banner.ts
+++ b/apps/generate-ui-v2/src/components/banner.ts
@@ -28,7 +28,7 @@ export class Banner extends EditorContext(LitElement) {
         <div @click="${this.dismiss}" class="px-2 py-1">
           ${this.editor === 'intellij'
             ? html`x`
-            : html` <codicon-element icon="close"></codicon-element>`}
+            : html`<icon-element icon="close"></icon-element>`}
         </div>
       </div>
     `;

--- a/apps/generate-ui-v2/src/components/banner.ts
+++ b/apps/generate-ui-v2/src/components/banner.ts
@@ -17,6 +17,7 @@ export class Banner extends EditorContext(LitElement) {
   render() {
     const bannerClass =
       this.type === 'error' ? 'bg-bannerError' : 'bg-bannerWarning';
+
     if (this.dismissed) {
       return html``;
     }
@@ -27,7 +28,12 @@ export class Banner extends EditorContext(LitElement) {
         <p class="grow">${this.message}</p>
         <div @click="${this.dismiss}" class="px-2 py-1">
           ${this.editor === 'intellij'
-            ? html`x`
+            ? html`<icon-element
+                icon="close"
+                color="${getComputedStyle(this).getPropertyValue(
+                  '--banner-text-color'
+                )}"
+              ></icon-element>`
             : html`<icon-element icon="close"></icon-element>`}
         </div>
       </div>

--- a/apps/generate-ui-v2/src/components/icon.ts
+++ b/apps/generate-ui-v2/src/components/icon.ts
@@ -7,18 +7,47 @@ export class Icon extends EditorContext(LitElement) {
   @property()
   icon: string;
 
+  @property()
+  color = '';
+
   render() {
     if (this.editor === 'intellij') {
       return html`<img
         src="./icons/${this.icon}.svg"
         class="h-[1.25rem]"
+        @load="${this.applyColorToSVG}"
       ></img>`;
     } else {
       return html`<span
         class="codicon codicon-${this.icon}"
-        style="text-align: center; font-size: 0.9rem;"
+        style="text-align: center; font-size: 0.9rem; color: ${this.color}"
       ></span>`;
     }
+  }
+
+  // we have to parse the svg file and forcefully update the color for intellij
+  async applyColorToSVG() {
+    if (!this.color) {
+      return;
+    }
+    const svgResponse = await fetch(`./icons/${this.icon}.svg`);
+    const svgData = await svgResponse.text();
+    const parser = new DOMParser();
+    const parsedSvg = parser.parseFromString(svgData, 'image/svg+xml');
+
+    const allPaths = parsedSvg.querySelectorAll('path');
+    allPaths.forEach((path) => {
+      path.setAttribute('fill', this.color);
+      path.setAttribute('stroke', this.color);
+    });
+
+    const imgElement = this.querySelector('img');
+    if (imgElement) {
+      imgElement.remove();
+    }
+
+    parsedSvg.documentElement.classList.add('h-[1.25rem]');
+    this.appendChild(parsedSvg.documentElement);
   }
 
   protected createRenderRoot(): Element | ShadowRoot {

--- a/apps/generate-ui-v2/src/ide-communication.controller.ts
+++ b/apps/generate-ui-v2/src/ide-communication.controller.ts
@@ -184,6 +184,7 @@ export class IdeCommunicationController implements ReactiveController {
       --active-selection-background-color: ${styles.activeSelectionBackgroundColor};
       --focus-border-color: ${styles.focusBorderColor};
       --banner-warning-color: ${styles.bannerWarningBackgroundColor};
+      --banner-text-color: ${styles.bannerTextColor};
       --badge-background-color: ${styles.badgeBackgroundColor};
       --separator-color: ${styles.separatorColor};
       --field-nav-hover-color: ${styles.fieldNavHoverColor};

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/GenerateUiMessages.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/GenerateUiMessages.kt
@@ -85,6 +85,7 @@ data class GenerateUiStyles(
     val focusBorderColor: String,
     val badgeBackgroundColor: String,
     val bannerWarningBackgroundColor: String,
+    val bannerTextColor: String,
     val separatorColor: String,
     val fieldNavHoverColor: String,
     val scrollbarThumbColor: String,
@@ -94,11 +95,12 @@ data class GenerateUiStyles(
 
 @Serializable
 @SerialName("banner")
-data class GenerateUiBannerInputMessage(override val payload: GenerateUiBanner) :
-    GenerateUiInputMessage {}
+data class GenerateUiStartupMessageDefinitionInputMessage(
+    override val payload: GenerateUiStartupMessageDefinition
+) : GenerateUiInputMessage {}
 
 @Serializable
-data class GenerateUiBanner(val message: String, val type: String) {
+data class GenerateUiStartupMessageDefinition(val message: String, val type: String) {
     init {
         require(type == "warning" || type == "error")
     }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/V2NxGenerateUiFile.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/V2NxGenerateUiFile.kt
@@ -85,11 +85,17 @@ class V2NxGenerateUiFile(name: String, private val project: Project) :
         if (messageParsed.payloadType == "output-init") {
             this.generatorToDisplay?.let { schema ->
                 CoroutineScope(Dispatchers.Default).launch {
-                    val transformedSchema =
-                        NxlsService.getInstance(project).transformedGeneratorSchema(schema)
-                    postMessageToBrowser(GenerateUiGeneratorSchemaInputMessage(transformedSchema))
+                    NxlsService.getInstance(project).transformedGeneratorSchema(schema).apply {
+                        postMessageToBrowser(GenerateUiGeneratorSchemaInputMessage(this))
+                    }
+                }
+                CoroutineScope(Dispatchers.Default).launch {
+                    NxlsService.getInstance(project).startupMessage(schema)?.apply {
+                        postMessageToBrowser(GenerateUiStartupMessageDefinitionInputMessage(this))
+                    }
                 }
             }
+
             return
         }
         if (messageParsed.payloadType == "run-generator") {
@@ -137,6 +143,7 @@ class V2NxGenerateUiFile(name: String, private val project: Project) :
         val badgeBackgroundColor = selectFieldBackgroundColor
         val bannerWarningBackgroundColor =
             getHexColor(UIManager.getColor("Component.warningFocusColor"))
+        val bannerTextColor = getHexColor(UIManager.getColor("Button.foreground"))
         val statusBarBorderColor = getHexColor(UIManager.getColor("StatusBar.borderColor"))
         val fieldNavHoverColor = getHexColor(UIManager.getColor("TabbedPane.hoverColor"))
 
@@ -157,6 +164,7 @@ class V2NxGenerateUiFile(name: String, private val project: Project) :
             focusBorderColor = focusBorderColor,
             badgeBackgroundColor = badgeBackgroundColor,
             bannerWarningBackgroundColor = bannerWarningBackgroundColor,
+            bannerTextColor = bannerTextColor,
             separatorColor = statusBarBorderColor,
             fieldNavHoverColor = fieldNavHoverColor,
             scrollbarThumbColor = scrollbarThumbColor,

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
@@ -1,5 +1,6 @@
 package dev.nx.console.nxls.server
 
+import dev.nx.console.generate.ui.GenerateUiStartupMessageDefinition
 import dev.nx.console.generate.ui.GeneratorSchema
 import dev.nx.console.models.*
 import dev.nx.console.nxls.server.requests.*
@@ -62,6 +63,13 @@ interface NxService {
     }
     @JsonRequest
     fun transformedGeneratorSchema(schema: GeneratorSchema): CompletableFuture<GeneratorSchema> {
+        throw UnsupportedOperationException()
+    }
+
+    @JsonRequest
+    fun startupMessage(
+        schema: GeneratorSchema
+    ): CompletableFuture<GenerateUiStartupMessageDefinition> {
         throw UnsupportedOperationException()
     }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.Topic
+import dev.nx.console.generate.ui.GenerateUiStartupMessageDefinition
 import dev.nx.console.generate.ui.GeneratorSchema
 import dev.nx.console.models.*
 import dev.nx.console.nxls.NxlsWrapper
@@ -132,6 +133,10 @@ class NxlsService(val project: Project) {
             server()?.getNxService()?.transformedGeneratorSchema(schema)?.await()
         }()
             ?: schema
+    }
+
+    suspend fun startupMessage(schema: GeneratorSchema): GenerateUiStartupMessageDefinition? {
+        return withMessageIssueCatch { server()?.getNxService()?.startupMessage(schema)?.await() }()
     }
 
     suspend fun nxVersion(): NxVersion? {

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -14,6 +14,7 @@ import {
   NxProjectFolderTreeRequest,
   NxProjectGraphOutputRequest,
   NxProjectsByPathsRequest,
+  NxStartupMessageRequest,
   NxTransformedGeneratorSchemaRequest,
   NxVersionRequest,
   NxWorkspaceRefreshNotification,
@@ -43,6 +44,7 @@ import {
   getProjectFolderTree,
   getProjectsByPaths,
   getTransformedGeneratorSchema,
+  getStartupMessage,
 } from '@nx-console/language-server/workspace';
 import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 import {
@@ -396,6 +398,19 @@ connection.onRequest(
       );
     }
     return getTransformedGeneratorSchema(WORKING_PATH, schema);
+  }
+);
+
+connection.onRequest(
+  NxStartupMessageRequest,
+  async (schema: GeneratorSchema) => {
+    if (!WORKING_PATH) {
+      return new ResponseError(
+        1000,
+        'Unable to get Nx info: no workspace path'
+      );
+    }
+    return getStartupMessage(WORKING_PATH, schema);
   }
 );
 

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -10,6 +10,7 @@ import {
 import { NxWorkspace, TreeNode } from '@nx-console/shared/types';
 import type { ProjectConfiguration } from 'nx/src/devkit-exports';
 import { SemVer } from 'semver';
+import { StartupMessageDefinition } from 'shared/nx-console-plugins';
 import { NotificationType, RequestType } from 'vscode-languageserver/node';
 
 export const NxChangeWorkspace: NotificationType<string> = new NotificationType(
@@ -118,3 +119,9 @@ export const NxTransformedGeneratorSchemaRequest: RequestType<
   GeneratorSchema,
   unknown
 > = new RequestType('nx/transformedGeneratorSchema');
+
+export const NxStartupMessageRequest: RequestType<
+  GeneratorSchema,
+  StartupMessageDefinition | undefined,
+  unknown
+> = new RequestType('nx/startupMessage');

--- a/libs/language-server/workspace/src/index.ts
+++ b/libs/language-server/workspace/src/index.ts
@@ -9,5 +9,5 @@ export * from './lib/get-nx-version';
 export * from './lib/get-project-graph-output';
 export * from './lib/create-project-graph';
 export * from './lib/get-project-folder-tree';
-export * from './lib/get-transformed-generator-schema';
+export * from './lib/nx-console-plugins';
 export { getNxDaemonClient } from './lib/get-nx-workspace-package';

--- a/libs/language-server/workspace/src/lib/nx-console-plugins.ts
+++ b/libs/language-server/workspace/src/lib/nx-console-plugins.ts
@@ -66,16 +66,16 @@ async function loadPlugins(
 
   return {
     schemaProcessors: [
-      ...(workspacePlugins?.schemaProcessors ?? []),
       ...(internalPlugins.schemaProcessors ?? []),
+      ...(workspacePlugins?.schemaProcessors ?? []),
     ],
     validators: [
-      ...(workspacePlugins?.validators ?? []),
       ...(internalPlugins.validators ?? []),
+      ...(workspacePlugins?.validators ?? []),
     ],
     startupMessageFactories: [
-      ...(workspacePlugins?.startupMessageFactories ?? []),
       ...(internalPlugins.startupMessageFactories ?? []),
+      ...(workspacePlugins?.startupMessageFactories ?? []),
     ],
   };
 }

--- a/libs/language-server/workspace/src/lib/nx-console-plugins.ts
+++ b/libs/language-server/workspace/src/lib/nx-console-plugins.ts
@@ -4,6 +4,7 @@ import { nxWorkspace } from './workspace';
 import { lspLogger } from '@nx-console/language-server/utils';
 import {
   NxConsolePluginsDefinition,
+  StartupMessageDefinition,
   internalPlugins,
 } from 'shared/nx-console-plugins';
 
@@ -23,6 +24,27 @@ export async function getTransformedGeneratorSchema(
   } catch (e) {
     lspLogger.log('error while applying schema processors' + e);
     return modifiedSchema;
+  }
+}
+
+export async function getStartupMessage(
+  workspacePath: string,
+  schema: GeneratorSchema
+): Promise<StartupMessageDefinition | undefined> {
+  const plugins = await loadPlugins(workspacePath);
+  const workspace = await nxWorkspace(workspacePath);
+
+  let startupMessageDefinition: StartupMessageDefinition | undefined =
+    undefined;
+  try {
+    for (const factory of plugins?.startupMessageFactories ?? []) {
+      startupMessageDefinition = await factory(schema, workspace);
+    }
+
+    return startupMessageDefinition;
+  } catch (e) {
+    lspLogger.log('error while getting startup message' + e);
+    return startupMessageDefinition;
   }
 }
 
@@ -51,9 +73,9 @@ async function loadPlugins(
       ...(workspacePlugins?.validators ?? []),
       ...(internalPlugins.validators ?? []),
     ],
-    startupMessages: [
-      ...(workspacePlugins?.startupMessages ?? []),
-      ...(internalPlugins.startupMessages ?? []),
+    startupMessageFactories: [
+      ...(workspacePlugins?.startupMessageFactories ?? []),
+      ...(internalPlugins.startupMessageFactories ?? []),
     ],
   };
 }

--- a/libs/shared/generate-ui-types/src/lib/messages.ts
+++ b/libs/shared/generate-ui-types/src/lib/messages.ts
@@ -89,6 +89,7 @@ export type GenerateUiStyles = {
   selectFieldBackgroundColor: string;
   activeSelectionBackgroundColor: string;
   bannerWarningBackgroundColor: string;
+  bannerTextColor: string;
   badgeBackgroundColor: string;
   separatorColor: string;
   fieldNavHoverColor: string;

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/git-clean-message-factory.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/git-clean-message-factory.ts
@@ -1,0 +1,24 @@
+import { NxWorkspace } from '@nx-console/shared/types';
+import { StartupMessageDefinition } from '../nx-console-plugin-types';
+import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
+import { promisify } from 'util';
+import { exec } from 'child_process';
+
+export async function gitCleanMessageFactory(
+  _: GeneratorSchema,
+  workspace: NxWorkspace
+): Promise<StartupMessageDefinition | undefined> {
+  const workspacePath = workspace.workspacePath;
+  try {
+    await promisify(exec)('git diff --quiet', {
+      cwd: workspacePath,
+    });
+  } catch (e) {
+    return {
+      message:
+        'You have uncommitted changes in your workspace. We recommend that you commit any previous changes before running a generator, so that you can easily undo changes if necessary.',
+      type: 'warning',
+    };
+  }
+  return undefined;
+}

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/git-clean-message-factory.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/git-clean-message-factory.ts
@@ -12,6 +12,7 @@ export async function gitCleanMessageFactory(
   try {
     await promisify(exec)('git diff --quiet', {
       cwd: workspacePath,
+      windowsHide: true,
     });
   } catch (e) {
     return {

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/index.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/index.ts
@@ -1,5 +1,6 @@
 import { NxConsolePluginsDefinition } from '../nx-console-plugin-types';
 import { filterInternalAndDeprecatedProcessor } from './filter-internal-and-deprecated-processor';
+import { gitCleanMessageFactory } from './git-clean-message-factory';
 import { projectNameAndRootProcessor } from './project-name-and-root-processor';
 import { tempNoProjectAndDirProcessor } from './temp-no-project-and-dir-processor';
 
@@ -10,5 +11,5 @@ export const internalPlugins: NxConsolePluginsDefinition = {
     tempNoProjectAndDirProcessor,
   ],
   validators: [],
-  startupMessages: [],
+  startupMessageFactories: [gitCleanMessageFactory],
 };

--- a/libs/shared/nx-console-plugins/src/lib/nx-console-plugin-types.ts
+++ b/libs/shared/nx-console-plugins/src/lib/nx-console-plugin-types.ts
@@ -4,10 +4,23 @@ import { NxWorkspace } from '@nx-console/shared/types';
 export type NxConsolePluginsDefinition = {
   schemaProcessors?: SchemaProcessor[];
   validators?: any[];
-  startupMessages?: any[];
+  startupMessageFactories?: StartupMessageFactory[];
 };
 
 export type SchemaProcessor = (
   schema: GeneratorSchema,
   workspace: NxWorkspace
 ) => GeneratorSchema;
+
+export type StartupMessageDefinition = {
+  message: string;
+  type: 'warning' | 'error';
+};
+
+export type StartupMessageFactory = (
+  schema: GeneratorSchema,
+  workspace: NxWorkspace
+) =>
+  | StartupMessageDefinition
+  | undefined
+  | Promise<StartupMessageDefinition | undefined>;

--- a/libs/vscode/generate-ui-webview/src/lib/generate-ui-webview.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/generate-ui-webview.ts
@@ -11,6 +11,7 @@ import {
 import { GlobalConfigurationStore } from '@nx-console/vscode/configuration';
 import {
   getNxWorkspace,
+  getStartupMessage,
   getTransformedGeneratorSchema,
 } from '@nx-console/vscode/nx-workspace';
 import { CliTaskProvider } from '@nx-console/vscode/tasks';
@@ -154,12 +155,10 @@ export class GenerateUiWebview {
           new GenerateUiGeneratorSchemaInputMessage(this.generatorToDisplay)
         );
 
-        const nxWorkspace = await getNxWorkspace();
-        this.plugins?.startupMessages?.forEach((messageFunction) => {
-          const message = messageFunction(nxWorkspace);
-          if (message) {
+        getStartupMessage(this.generatorToDisplay).then((startupMessage) => {
+          if (startupMessage) {
             this.postMessageToWebview(
-              new GenerateUiBannerInputMessage(message)
+              new GenerateUiBannerInputMessage(startupMessage)
             );
           }
         });

--- a/libs/vscode/nx-workspace/src/lib/nx-console-plugin-requests.ts
+++ b/libs/vscode/nx-workspace/src/lib/nx-console-plugin-requests.ts
@@ -1,9 +1,19 @@
-import { NxTransformedGeneratorSchemaRequest } from '@nx-console/language-server/types';
+import {
+  NxStartupMessageRequest,
+  NxTransformedGeneratorSchemaRequest,
+} from '@nx-console/language-server/types';
 import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 import { sendRequest } from '@nx-console/vscode/lsp-client';
+import { StartupMessageDefinition } from 'shared/nx-console-plugins';
 
 export function getTransformedGeneratorSchema(
   schema: GeneratorSchema
 ): Promise<GeneratorSchema> {
   return sendRequest(NxTransformedGeneratorSchemaRequest, schema);
+}
+
+export function getStartupMessage(
+  schema: GeneratorSchema
+): Promise<StartupMessageDefinition | undefined> {
+  return sendRequest(NxStartupMessageRequest, schema);
 }


### PR DESCRIPTION
moves startup message plugin handling to nxls to enable it in both vscode & intellij. You can write plugins to display startup messages in 
Creates an internal plugin to dynamically display a warning message when generating with unstaged files.

<img width="839" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/78eb510e-05ed-4702-940f-1bd327d72c8d">
<img width="865" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/e3d2fb97-b056-46de-9db5-52be1fbdf039">

