### PR TITLE
fix: take nx.json projectNameAndRootFormat config into account in generate ui

### DIFF
--- a/libs/language-server/workspace/src/lib/nx-console-plugins.ts
+++ b/libs/language-server/workspace/src/lib/nx-console-plugins.ts
@@ -18,7 +18,7 @@ export async function getTransformedGeneratorSchema(
   let modifiedSchema = schema;
   try {
     plugins?.schemaProcessors?.forEach((processor) => {
-      modifiedSchema = processor(modifiedSchema, workspace);
+      modifiedSchema = processor(modifiedSchema, workspace, lspLogger);
     });
     return modifiedSchema;
   } catch (e) {
@@ -38,7 +38,7 @@ export async function getStartupMessage(
     undefined;
   try {
     for (const factory of plugins?.startupMessageFactories ?? []) {
-      startupMessageDefinition = await factory(schema, workspace);
+      startupMessageDefinition = await factory(schema, workspace, lspLogger);
     }
 
     return startupMessageDefinition;

--- a/libs/shared/nx-console-plugins/src/lib/nx-console-plugin-types.ts
+++ b/libs/shared/nx-console-plugins/src/lib/nx-console-plugin-types.ts
@@ -1,4 +1,5 @@
 import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
+import { Logger } from '@nx-console/shared/schema';
 import { NxWorkspace } from '@nx-console/shared/types';
 
 export type NxConsolePluginsDefinition = {
@@ -9,7 +10,8 @@ export type NxConsolePluginsDefinition = {
 
 export type SchemaProcessor = (
   schema: GeneratorSchema,
-  workspace: NxWorkspace
+  workspace: NxWorkspace,
+  lspLogger: Logger
 ) => GeneratorSchema;
 
 export type StartupMessageDefinition = {
@@ -19,7 +21,8 @@ export type StartupMessageDefinition = {
 
 export type StartupMessageFactory = (
   schema: GeneratorSchema,
-  workspace: NxWorkspace
+  workspace: NxWorkspace,
+  lspLogger: Logger
 ) =>
   | StartupMessageDefinition
   | undefined

--- a/libs/shared/types/src/lib/nx-workspace.ts
+++ b/libs/shared/types/src/lib/nx-workspace.ts
@@ -33,5 +33,6 @@ export interface NxWorkspace {
   workspaceLayout: {
     appsDir?: string;
     libsDir?: string;
+    projectNameAndRootFormat?: 'as-provided' | 'derived';
   };
 }


### PR DESCRIPTION
You can toggle `projectNameAndRootFormat` globally using `nx.json -> workspaceLayout`. Nx Console wasn't taking this into account. Now it is