### PR TITLE
fix(intellij): fix running nx targets in wsl

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandLineState.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/NxCommandLineState.kt
@@ -6,6 +6,7 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.target.value.TargetValue
+import com.intellij.execution.wsl.WslPath
 import com.intellij.javascript.debugger.CommandLineDebugConfigurator
 import com.intellij.javascript.nodejs.NodeCommandLineUtil
 import com.intellij.javascript.nodejs.NodeCommandLineUtil.createConsole
@@ -86,7 +87,10 @@ class NxCommandLineState(
                     *(ParametersListUtil.parseToArray(nxRunSettings.arguments)),
                 )
             )
-            setWorkingDirectory(project.nxBasePath)
+
+            setWorkingDirectory(
+                WslPath.parseWindowsUncPath(project.nxBasePath)?.linuxPath ?: project.nxBasePath
+            )
         }
 
         return targetRun.startProcess()


### PR DESCRIPTION
This makes sure that when running Nx targets in wsl, that we use the correct linux path, rather than the Windows one (ie, use `/home/users/.../` rather than `//wsl$/home/users/..`)