### PR TITLE
feat(generate-ui): add cwd handling & prefilling

### DIFF
--- a/apps/generate-ui-v2/src/components/cwd-input.ts
+++ b/apps/generate-ui-v2/src/components/cwd-input.ts
@@ -1,0 +1,74 @@
+import { LitElement, PropertyValueMap, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { OptionChangedDetails } from './fields/mixins/field-mixin';
+import { GeneratorContext } from '@nx-console/shared/generate-ui-types';
+import { ContextConsumer } from '@lit-labs/context';
+import { generatorContextContext } from '../contexts/generator-context-context';
+import { EditorContext } from '../contexts/editor-context';
+
+@customElement('cwd-input-element')
+export class CwdInput extends EditorContext(LitElement) {
+  @state() generatorContext: GeneratorContext | undefined;
+
+  constructor() {
+    super();
+    new ContextConsumer(this, {
+      context: generatorContextContext,
+      callback: (context) => (this.generatorContext = context),
+      subscribe: false,
+    });
+  }
+
+  render() {
+    return html`
+      <div class="border-separator flex flex-col border-l-4 py-2 pl-3">
+        <div>cwd</div>
+        <p class="mb-2 text-gray-500">
+          The directory the generator will be executed from. Relative to the
+          workspace root.
+        </p>
+        <vscode-text-field type="text" @input="${this.handleChange}">
+        </vscode-text-field>
+      </div>
+    `;
+  }
+
+  private handleChange(e: Event) {
+    const value = (e.target as HTMLInputElement).value;
+
+    this.dispatchValue(value);
+  }
+
+  private dispatchValue(value: string) {
+    this.dispatchEvent(
+      new CustomEvent<string>('cwd-changed', {
+        bubbles: true,
+        composed: true,
+        detail: value,
+      })
+    );
+  }
+
+  protected firstUpdated(
+    _changedProperties: PropertyValueMap<unknown> | Map<PropertyKey, unknown>
+  ): void {
+    super.updated(_changedProperties);
+    if (this.generatorContext) {
+      const prefillValue = this.generatorContext.prefillValues?.cwd;
+      if (prefillValue) {
+        const inputNode = this.renderRoot.querySelector(
+          this.editor === 'intellij' ? 'input' : 'vscode-text-field'
+        );
+        if (!inputNode) {
+          return;
+        }
+        inputNode.value = prefillValue;
+        this.dispatchValue(prefillValue);
+      }
+    }
+  }
+
+  protected createRenderRoot(): Element | ShadowRoot {
+    return this;
+  }
+}

--- a/apps/generate-ui-v2/src/components/cwd-input.ts
+++ b/apps/generate-ui-v2/src/components/cwd-input.ts
@@ -3,32 +3,36 @@ import { customElement, state } from 'lit/decorators.js';
 import { OptionChangedDetails } from './fields/mixins/field-mixin';
 import { GeneratorContext } from '@nx-console/shared/generate-ui-types';
 import { ContextConsumer } from '@lit-labs/context';
-import { generatorContextContext } from '../contexts/generator-context-context';
+import { GeneratorContextContext } from '../contexts/generator-context-context';
 import { EditorContext } from '../contexts/editor-context';
+import {
+  intellijFieldColors,
+  intellijFieldPadding,
+  intellijFocusRing,
+} from '../utils/ui-utils';
 
 @customElement('cwd-input-element')
-export class CwdInput extends EditorContext(LitElement) {
-  @state() generatorContext: GeneratorContext | undefined;
-
-  constructor() {
-    super();
-    new ContextConsumer(this, {
-      context: generatorContextContext,
-      callback: (context) => (this.generatorContext = context),
-      subscribe: false,
-    });
-  }
-
+export class CwdInput extends GeneratorContextContext(
+  EditorContext(LitElement)
+) {
   render() {
     return html`
-      <div class="border-separator flex flex-col border-l-4 py-2 pl-3">
+      <div class="border-separator mb-4 flex flex-col border-l-4 py-2 pl-3">
         <div>cwd</div>
         <p class="mb-2 text-gray-500">
           The directory the generator will be executed from. Relative to the
           workspace root.
         </p>
-        <vscode-text-field type="text" @input="${this.handleChange}">
-        </vscode-text-field>
+        ${this.editor === 'intellij'
+          ? html`
+              <input
+                class="${intellijFieldColors} ${intellijFocusRing} ${intellijFieldPadding}  rounded"
+                type="text"
+                @input="${this.handleChange}"
+              />
+            `
+          : html` <vscode-text-field type="text" @input="${this.handleChange}">
+            </vscode-text-field>`}
       </div>
     `;
   }

--- a/apps/generate-ui-v2/src/components/field-list.ts
+++ b/apps/generate-ui-v2/src/components/field-list.ts
@@ -50,6 +50,7 @@ export class FieldList extends EditorContext(LitElement) {
             ? 'md:ml-52 md:p-6'
             : 'sm:ml-52 sm:p-6 md:ml-64'} w-full pt-6"
         >
+          <cwd-input-element></cwd-input-element>
           ${this.renderOptionsWithDivider(
             optionsWithMetadata,
             shouldShowMoreOptions,

--- a/apps/generate-ui-v2/src/components/field-list.ts
+++ b/apps/generate-ui-v2/src/components/field-list.ts
@@ -3,6 +3,7 @@ import { LitElement, TemplateResult, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { extractItemOptions } from '../utils/generator-schema-utils';
 import { EditorContext } from '../contexts/editor-context';
+import { GeneratorContextContext } from '../contexts/generator-context-context';
 
 type OptionWithMetadata = {
   option: Option;
@@ -11,7 +12,9 @@ type OptionWithMetadata = {
 };
 
 @customElement('field-list')
-export class FieldList extends EditorContext(LitElement) {
+export class FieldList extends GeneratorContextContext(
+  EditorContext(LitElement)
+) {
   @property()
   options: Option[];
 
@@ -50,7 +53,9 @@ export class FieldList extends EditorContext(LitElement) {
             ? 'md:ml-52 md:p-6'
             : 'sm:ml-52 sm:p-6 md:ml-64'} w-full pt-6"
         >
-          <cwd-input-element></cwd-input-element>
+          ${(this.generatorContext?.nxVersion?.major ?? 0) >= 17
+            ? html` <cwd-input-element></cwd-input-element> `
+            : ``}
           ${this.renderOptionsWithDivider(
             optionsWithMetadata,
             shouldShowMoreOptions,

--- a/apps/generate-ui-v2/src/components/field-list.ts
+++ b/apps/generate-ui-v2/src/components/field-list.ts
@@ -53,9 +53,6 @@ export class FieldList extends GeneratorContextContext(
             ? 'md:ml-52 md:p-6'
             : 'sm:ml-52 sm:p-6 md:ml-64'} w-full pt-6"
         >
-          ${(this.generatorContext?.nxVersion?.major ?? 0) >= 17
-            ? html` <cwd-input-element></cwd-input-element> `
-            : ``}
           ${this.renderOptionsWithDivider(
             optionsWithMetadata,
             shouldShowMoreOptions,
@@ -101,7 +98,7 @@ export class FieldList extends GeneratorContextContext(
     ) => {
       const componentTag = getFieldComponent(optionWithMetadata.option);
       return html` <div
-        class=" ${hidden ? 'hidden' : ''} mb-4"
+        class="${hidden ? 'hidden' : ''} mb-4"
         id="option-${optionWithMetadata.option.name}"
       >
         ${componentTag}
@@ -130,6 +127,12 @@ export class FieldList extends GeneratorContextContext(
         class="${shouldHideShowMoreButton ? 'hidden' : ''}"
       ></show-more-divider>
       ${otherOptions.map((opt) => renderOption(opt, !shouldShowMoreOptions))}
+      <cwd-input-element
+        class="${(this.generatorContext?.nxVersion?.major ?? 0) >= 17 &&
+        shouldShowMoreOptions
+          ? ''
+          : 'hidden'}"
+      ></cwd-input-element>
     `;
   }
 

--- a/apps/generate-ui-v2/src/components/index.ts
+++ b/apps/generate-ui-v2/src/components/index.ts
@@ -32,6 +32,7 @@ import './field-nav-item';
 import './show-more-divider';
 import './badge';
 import './popover';
+import './cwd-input';
 
 provideFASTDesignSystem().register(
   fastCombobox({

--- a/apps/generate-ui-v2/src/contexts/generator-context-context.ts
+++ b/apps/generate-ui-v2/src/contexts/generator-context-context.ts
@@ -1,6 +1,36 @@
-import { createContext } from '@lit-labs/context';
+import { ContextConsumer, createContext } from '@lit-labs/context';
 import { GeneratorContext } from '@nx-console/shared/generate-ui-types';
+import { LitElement } from 'lit';
+import { state } from 'lit/decorators.js';
 
 export const generatorContextContext = createContext<
   GeneratorContext | undefined
 >(Symbol('generatorContext'));
+
+export declare class GeneratorContextContextInterface {
+  generatorContext: GeneratorContext | undefined;
+}
+
+type Constructor<T> = new (...args: any[]) => T;
+
+export const GeneratorContextContext = <T extends Constructor<LitElement>>(
+  superClass: T
+) => {
+  class GeneratorContextContextElement extends superClass {
+    @state() generatorContext: GeneratorContext | undefined;
+
+    constructor(...rest: any[]) {
+      super();
+      // we can't use the @consume decorator due to mixin typing quirks
+      new ContextConsumer(this, {
+        context: generatorContextContext,
+        callback: (generatorContext) =>
+          (this.generatorContext = generatorContext),
+        subscribe: true,
+      });
+    }
+  }
+
+  return GeneratorContextContextElement as Constructor<GeneratorContextContextInterface> &
+    T;
+};

--- a/apps/generate-ui-v2/src/form-values.service.ts
+++ b/apps/generate-ui-v2/src/form-values.service.ts
@@ -22,6 +22,7 @@ export const formValuesServiceContext = createContext<FormValuesService>(
 );
 
 export class FormValuesService {
+  private cwdValue: string | undefined = undefined;
   private formValues: FormValues = {};
   private validationResults: ValidationResults = {};
 
@@ -47,6 +48,17 @@ export class FormValuesService {
         this.handleOptionChange(e.detail);
       }
     );
+    window.addEventListener('cwd-changed', (e: CustomEventInit<string>) => {
+      if (!e.detail) return;
+      const firstChange = this.cwdValue === undefined;
+      this.cwdValue = e.detail;
+      if (
+        !firstChange &&
+        this.icc.configuration?.enableTaskExecutionDryRunOnChange
+      ) {
+        this.debouncedRunGenerator(true);
+      }
+    });
   }
 
   private async handleOptionChange(details: OptionChangedDetails) {
@@ -127,6 +139,7 @@ export class FormValuesService {
       payload: {
         positional: getGeneratorIdentifier(this.icc.generatorSchema),
         flags: args,
+        cwd: this.cwdValue?.toString(),
       },
     });
   }

--- a/apps/generate-ui-v2/src/form-values.service.ts
+++ b/apps/generate-ui-v2/src/form-values.service.ts
@@ -49,7 +49,7 @@ export class FormValuesService {
       }
     );
     window.addEventListener('cwd-changed', (e: CustomEventInit<string>) => {
-      if (!e.detail) return;
+      if (e.detail === undefined) return;
       const firstChange = this.cwdValue === undefined;
       this.cwdValue = e.detail;
       if (

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
@@ -143,11 +143,12 @@ class NxGenerateService(val project: Project) {
         val generatorWithOptions = NxGenerator(generator, generatorOptions)
 
         val generatorContext =
-            contextPath?.let {
-                project
-                    .service<NxlsService>()
-                    .generatorContextFromPath(generatorWithOptions, nxlsWorkingPath(contextPath))
-            }
+            project
+                .service<NxlsService>()
+                .generatorContextFromPath(
+                    generatorWithOptions,
+                    contextPath?.let { nxlsWorkingPath(contextPath) }
+                )
 
         ApplicationManager.getApplication().invokeLater {
             val virtualFile =

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/GenerateUiMessages.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/GenerateUiMessages.kt
@@ -17,7 +17,11 @@ data class GenerateUiFormInitOutputMessage(override val payloadType: String) :
     GenerateUiOutputMessage {}
 
 @Serializable()
-data class GenerateUiRunGeneratorPayload(val positional: String, val flags: List<String>) {}
+data class GenerateUiRunGeneratorPayload(
+    val positional: String,
+    val flags: List<String>,
+    val cwd: String? = null
+) {}
 
 @Serializable()
 @SerialName("run-generator")

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/V2NxGenerateUiFile.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/V2NxGenerateUiFile.kt
@@ -102,7 +102,8 @@ class V2NxGenerateUiFile(name: String, private val project: Project) :
             if (messageParsed is GenerateUiRunGeneratorOutputMessage) {
                 runGeneratorManager.queueGeneratorToBeRun(
                     messageParsed.payload.positional,
-                    messageParsed.payload.flags
+                    messageParsed.payload.flags,
+                    messageParsed.payload.cwd
                 )
             }
         }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/models/NxGeneratorContext.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/models/NxGeneratorContext.kt
@@ -8,5 +8,7 @@ data class NxGeneratorContext(
     val projectName: String?,
     val directory: String?,
     val path: String?,
-    val fixedFormValues: Map<String, String>?
+    val fixedFormValues: Map<String, String>?,
+    val prefillValues: Map<String, String>?,
+    val nxVersion: NxVersion?
 )

--- a/apps/intellij/src/main/kotlin/dev/nx/console/models/NxVersion.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/models/NxVersion.kt
@@ -1,3 +1,5 @@
 package dev.nx.console.models
 
-data class NxVersion(val minor: Number, val major: Number, val full: String) {}
+import kotlinx.serialization.Serializable
+
+@Serializable() data class NxVersion(val minor: Int, val major: Int, val full: String) {}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/NxService.kt
@@ -34,7 +34,7 @@ interface NxService {
     }
 
     @JsonRequest
-    fun generatorContextFromPath(
+    fun generatorContextV2(
         generatorContextFromPathRequest: NxGetGeneratorContextFromPathRequest
     ): CompletableFuture<NxGeneratorContext> {
         throw UnsupportedOperationException()

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/requests/NxGetGeneratorContextFromPathRequest.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/server/requests/NxGetGeneratorContextFromPathRequest.kt
@@ -1,8 +1,3 @@
 package dev.nx.console.nxls.server.requests
 
-import dev.nx.console.models.NxGenerator
-
-data class NxGetGeneratorContextFromPathRequest(
-    val generator: NxGenerator? = null,
-    val path: String
-) {}
+data class NxGetGeneratorContextFromPathRequest(val path: String?) {}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/services/NxlsService.kt
@@ -90,11 +90,11 @@ class NxlsService(val project: Project) {
 
     suspend fun generatorContextFromPath(
         generator: NxGenerator? = null,
-        path: String
+        path: String?
     ): NxGeneratorContext? {
         return withMessageIssueCatch {
-            val request = NxGetGeneratorContextFromPathRequest(generator, path)
-            server()?.getNxService()?.generatorContextFromPath(request)?.await()
+            val request = NxGetGeneratorContextFromPathRequest(path)
+            server()?.getNxService()?.generatorContextV2(request)?.await()
         }()
     }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxGeneralCommandLine.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxGeneralCommandLine.kt
@@ -5,16 +5,20 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.javascript.nodejs.NodeCommandLineUtil
 import com.intellij.openapi.project.Project
+import java.nio.file.Path
 
 fun NxGeneralCommandLine(
     project: Project,
     args: List<String>,
-    environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
+    environmentVariables: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT,
+    cwd: String? = null
 ) =
     GeneralCommandLine().apply {
         exePath = NxExecutable.getExecutablePath(project.nxBasePath)
         addParameters(args)
-        setWorkDirectory(project.nxBasePath)
+        val workDirectory =
+            if (cwd !== null) Path.of(project.nxBasePath, cwd).toString() else project.nxBasePath
+        setWorkDirectory(workDirectory)
 
         environmentVariables.configureCommandLine(this, true)
 
@@ -26,7 +30,7 @@ fun NxGeneralCommandLine(
                 val options =
                     WSLCommandLineOptions().apply {
                         initShellCommands.add(it.prependNodeDirToPathCommand)
-                        remoteWorkingDirectory = nxlsWorkingPath(project.nxBasePath)
+                        remoteWorkingDirectory = nxlsWorkingPath(workDirectory)
                     }
 
                 it.distribution.patchCommandLine(this, project, options)

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -347,7 +347,7 @@ connection.onRequest(
 
 connection.onRequest(
   NxGeneratorContextV2Request,
-  async (args: { path: string }) => {
+  async (args: { path: string | undefined }) => {
     if (!WORKING_PATH) {
       return new ResponseError(
         1000,

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -80,7 +80,7 @@ export const NxGeneratorContextFromPathRequest: RequestType<
 
 export const NxGeneratorContextV2Request: RequestType<
   {
-    path: string;
+    path: string | undefined;
   },
   GeneratorContext,
   unknown

--- a/libs/language-server/workspace/src/lib/get-generator-context-v2.ts
+++ b/libs/language-server/workspace/src/lib/get-generator-context-v2.ts
@@ -5,24 +5,30 @@ import { getProjectByPath } from './get-project-by-path';
 import { nxWorkspace } from './workspace';
 
 export async function getGeneratorContextV2(
-  path: string,
+  path: string | undefined,
   workspacePath: string
 ): Promise<GeneratorContext> {
-  const normalizedPath = normalize(path);
-  const project = await getProjectByPath(normalizedPath, workspacePath);
+  let projectName: string | undefined = undefined;
+  let directory: string | undefined = undefined;
 
-  const projectName = (project && project.name) || undefined;
+  const { workspaceLayout, nxVersion } = await nxWorkspace(workspacePath);
+  if (path) {
+    const normalizedPath = normalize(path);
+    const project = await getProjectByPath(normalizedPath, workspacePath);
 
-  const { workspaceLayout } = await nxWorkspace(workspacePath);
-  const directory = getNormalizedDirectory(
-    normalizedPath,
-    workspaceLayout,
-    workspacePath
-  );
+    projectName = (project && project.name) || undefined;
+
+    directory = getNormalizedDirectory(
+      normalizedPath,
+      workspaceLayout,
+      workspacePath
+    );
+  }
 
   return {
     project: projectName,
     directory,
+    nxVersion,
   };
 }
 

--- a/libs/language-server/workspace/src/lib/nx-console-plugins.ts
+++ b/libs/language-server/workspace/src/lib/nx-console-plugins.ts
@@ -38,7 +38,10 @@ export async function getStartupMessage(
     undefined;
   try {
     for (const factory of plugins?.startupMessageFactories ?? []) {
-      startupMessageDefinition = await factory(schema, workspace, lspLogger);
+      const def = await factory(schema, workspace, lspLogger);
+      if (def) {
+        startupMessageDefinition = def;
+      }
     }
 
     return startupMessageDefinition;

--- a/libs/shared/generate-ui-types/src/lib/generator-schema.ts
+++ b/libs/shared/generate-ui-types/src/lib/generator-schema.ts
@@ -1,4 +1,5 @@
 import { Option } from '@nx-console/shared/schema';
+import { NxVersion } from '@nx-console/shared/types';
 
 export type GeneratorSchema = {
   collectionName: string;
@@ -13,4 +14,5 @@ export type GeneratorContext = {
   directory?: string;
   prefillValues?: Record<string, string>;
   fixedFormValues?: Record<string, string>;
+  nxVersion?: NxVersion;
 };

--- a/libs/shared/generate-ui-types/src/lib/messages.ts
+++ b/libs/shared/generate-ui-types/src/lib/messages.ts
@@ -29,6 +29,7 @@ export class GenerateUiRunGeneratorOutputMessage {
 export type GenerateUiRunGeneratorPayload = {
   readonly positional: string;
   readonly flags: string[];
+  readonly cwd?: string;
 };
 
 export class GenerateUiRequestValidationOutputMessage {

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/index.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/index.ts
@@ -1,9 +1,13 @@
 import { NxConsolePluginsDefinition } from '../nx-console-plugin-types';
 import { filterInternalAndDeprecatedProcessor } from './filter-internal-and-deprecated-processor';
 import { gitCleanMessageFactory } from './git-clean-message-factory';
+import {
+  nameAndDirectoryProcessor,
+  nameAndDirectoryStartupMessage,
+} from './name-and-directory.plugin';
 import { prefillProjectAndDirProcessor } from './prefill-project-and-dir-processor';
 import {
-  pluginNameAndRootStartupMessage,
+  projectNameAndRootStartupMessage,
   projectNameAndRootProcessor,
 } from './project-name-and-root-plugin';
 
@@ -12,10 +16,12 @@ export const internalPlugins: NxConsolePluginsDefinition = {
     projectNameAndRootProcessor,
     filterInternalAndDeprecatedProcessor,
     prefillProjectAndDirProcessor,
+    nameAndDirectoryProcessor,
   ],
   validators: [],
   startupMessageFactories: [
     gitCleanMessageFactory,
-    pluginNameAndRootStartupMessage,
+    projectNameAndRootStartupMessage,
+    nameAndDirectoryStartupMessage,
   ],
 };

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/name-and-directory.plugin.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/name-and-directory.plugin.ts
@@ -22,6 +22,8 @@ export const nameAndDirectoryProcessor: SchemaProcessor = (
         return {
           ...option,
           'x-priority': 'important',
+          'x-hint':
+            'You can provide a nested name instead of setting the directory option, e.g. my-dir/my-component',
         };
       }
       if (option.name === 'directory') {

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/name-and-directory.plugin.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/name-and-directory.plugin.ts
@@ -1,0 +1,69 @@
+import { NxWorkspace } from '@nx-console/shared/types';
+import {
+  SchemaProcessor,
+  StartupMessageFactory,
+} from '../nx-console-plugin-types';
+import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
+
+export const nameAndDirectoryProcessor: SchemaProcessor = (
+  schema: GeneratorSchema,
+  workspace: NxWorkspace
+) => {
+  if (
+    !schema?.options?.find((option) => option.name === 'nameAndDirectoryFormat')
+  ) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    options: schema.options.map((option) => {
+      if (option.name === 'name') {
+        return {
+          ...option,
+          'x-priority': 'important',
+        };
+      }
+      if (option.name === 'directory') {
+        return {
+          ...option,
+          'x-priority': 'important',
+        };
+      }
+      if (option.name === 'project') {
+        return {
+          ...option,
+          'x-priority': undefined,
+          tooltip:
+            'When nameAndDirectoryFormat is set to as-provided, the project option will be ignored.',
+        };
+      }
+
+      return option;
+    }),
+    context: {
+      ...schema.context,
+      prefillValues: {
+        ...(schema.context?.prefillValues ?? {}),
+        nameAndDirectoryFormat: 'as-provided',
+      },
+    },
+  };
+};
+
+export const nameAndDirectoryStartupMessage: StartupMessageFactory = (
+  schema: GeneratorSchema,
+  workspace: NxWorkspace
+) => {
+  if (
+    !schema?.options?.find((option) => option.name === 'nameAndDirectoryFormat')
+  ) {
+    return undefined;
+  }
+
+  return {
+    message:
+      'Starting with Nx 17, Nx Console will generate artifacts with the exact name and directory provided. Check the output files to make sure that they were created in the correct location. You can revert to the old behavior by updating nameAndDirectoryFormat',
+    type: 'warning',
+  };
+};

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/name-and-directory.plugin.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/name-and-directory.plugin.ts
@@ -65,7 +65,7 @@ export const nameAndDirectoryStartupMessage: StartupMessageFactory = (
 
   return {
     message:
-      'Starting with Nx 17, Nx Console will generate artifacts with the exact name and directory provided. Check the output files to make sure that they were created in the correct location. You can revert to the old behavior by updating nameAndDirectoryFormat',
+      'Starting with Nx 17, Nx Console will generate artifacts with the exact name and directory provided. Check the output files to make sure that they were created in the correct location. You can revert to the old behavior by updating the nameAndDirectoryFormat option below.',
     type: 'warning',
   };
 };

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/prefill-project-and-dir-processor.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/prefill-project-and-dir-processor.ts
@@ -22,30 +22,13 @@ export const prefillProjectAndDirProcessor: SchemaProcessor = (
       };
     }
   }
-  // with nameAndDirectoryFormat, the project option is ignored, so we don't prefill it
-  if (
-    schema?.options?.find((option) => option.name === 'nameAndDirectoryFormat')
-  ) {
-    if (schema.context?.directory) {
-      schema.context.prefillValues = {
-        ...(schema.context.prefillValues ?? {}),
-        directory: schema.context.directory,
-      };
-    }
-  }
 
-  // if we're >17 & without nameAndDirectoryFormat, we prefill all the info we have
-  if (schema.context?.project) {
-    schema.context.prefillValues = {
-      ...(schema.context.prefillValues ?? {}),
-      project: schema.context.project,
-      projectName: schema.context.project,
-    };
-  }
+  // after nx 17, project option won't exist anymore and cwd-ing into directories will be the way to go
+
   if (schema.context?.directory) {
     schema.context.prefillValues = {
       ...(schema.context.prefillValues ?? {}),
-      directory: schema.context.directory,
+      cwd: schema.context.directory,
     };
   }
 

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/prefill-project-and-dir-processor.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/prefill-project-and-dir-processor.ts
@@ -1,21 +1,53 @@
 import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 import { SchemaProcessor } from '../nx-console-plugin-types';
+import { NxWorkspace } from '@nx-console/shared/types';
 
 export const prefillProjectAndDirProcessor: SchemaProcessor = (
-  schema: GeneratorSchema
+  schema: GeneratorSchema,
+  workspace: NxWorkspace
 ) => {
+  // before nx 17, path/directory options are inconsistent so we don't prefill project & directory simultaneously
+  if (workspace.nxVersion.major < 17) {
+    if (schema.context?.project) {
+      schema.context.prefillValues = {
+        ...(schema.context.prefillValues ?? {}),
+        project: schema.context.project,
+        projectName: schema.context.project,
+        directory: '',
+      };
+    } else if (schema.context?.directory) {
+      schema.context.prefillValues = {
+        ...(schema.context.prefillValues ?? {}),
+        directory: schema.context.directory,
+      };
+    }
+  }
+  // with nameAndDirectoryFormat, the project option is ignored, so we don't prefill it
+  if (
+    schema?.options?.find((option) => option.name === 'nameAndDirectoryFormat')
+  ) {
+    if (schema.context?.directory) {
+      schema.context.prefillValues = {
+        ...(schema.context.prefillValues ?? {}),
+        directory: schema.context.directory,
+      };
+    }
+  }
+
+  // if we're >17 & without nameAndDirectoryFormat, we prefill all the info we have
   if (schema.context?.project) {
     schema.context.prefillValues = {
       ...(schema.context.prefillValues ?? {}),
       project: schema.context.project,
       projectName: schema.context.project,
-      directory: '',
     };
-  } else if (schema.context?.directory) {
+  }
+  if (schema.context?.directory) {
     schema.context.prefillValues = {
       ...(schema.context.prefillValues ?? {}),
       directory: schema.context.directory,
     };
   }
+
   return schema;
 };

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/project-name-and-root-plugin.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/project-name-and-root-plugin.ts
@@ -64,7 +64,7 @@ export const projectNameAndRootProcessor: SchemaProcessor = (
   };
 };
 
-export const pluginNameAndRootStartupMessage: StartupMessageFactory = (
+export const projectNameAndRootStartupMessage: StartupMessageFactory = (
   schema: GeneratorSchema,
   workspace: NxWorkspace
 ) => {

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/project-name-and-root-plugin.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/project-name-and-root-plugin.ts
@@ -43,6 +43,8 @@ export const projectNameAndRootProcessor: SchemaProcessor = (
         return {
           ...option,
           'x-priority': 'important',
+          'x-hint':
+            'You can provide a nested name instead of setting the directory option, e.g. my-dir/my-app',
         };
       }
       if (option.name === 'directory') {
@@ -66,7 +68,8 @@ export const projectNameAndRootProcessor: SchemaProcessor = (
 
 export const projectNameAndRootStartupMessage: StartupMessageFactory = (
   schema: GeneratorSchema,
-  workspace: NxWorkspace
+  workspace: NxWorkspace,
+  lspLogger: Logger
 ) => {
   if (
     !schema?.options?.find(
@@ -75,8 +78,6 @@ export const projectNameAndRootStartupMessage: StartupMessageFactory = (
   ) {
     return undefined;
   }
-  // if they have explicitly set the option, we don't need to educate users about the change
-
   // TODO: remove any after update
   if ((workspace.workspace.workspaceLayout as any)?.projectNameAndRootFormat) {
     return undefined;

--- a/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
@@ -29,9 +29,7 @@ export async function openGenerateUi(
     return;
   }
 
-  let generatorContext = contextUri
-    ? await getGeneratorContextV2(contextUri.fsPath)
-    : {};
+  let generatorContext = await getGeneratorContextV2(contextUri?.fsPath);
 
   if (projectName) {
     generatorContext = {

--- a/libs/vscode/nx-workspace/src/lib/get-generator-context-v2.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-generator-context-v2.ts
@@ -3,7 +3,7 @@ import { GeneratorContext } from '@nx-console/shared/generate-ui-types';
 import { sendRequest } from '@nx-console/vscode/lsp-client';
 
 export async function getGeneratorContextV2(
-  path: string
+  path: string | undefined
 ): Promise<GeneratorContext> {
   return sendRequest(NxGeneratorContextV2Request, { path });
 }

--- a/libs/vscode/tasks/src/lib/cli-task-definition.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-definition.ts
@@ -2,4 +2,5 @@ export interface CliTaskDefinition {
   positional: string;
   command: string;
   flags: Array<string>;
+  cwd?: string;
 }

--- a/libs/vscode/tasks/src/lib/cli-task-provider.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-provider.ts
@@ -90,6 +90,7 @@ export class CliTaskProvider implements TaskProvider {
         command: `workspace-${positionals[1]}`,
         positional: positionals[2],
         flags: definition.flags,
+        cwd: definition.cwd,
       });
     } else {
       task = await CliTask.create(definition);

--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -8,6 +8,7 @@ import {
   getPackageManagerCommand,
   PackageManagerCommands,
 } from 'nx/src/utils/package-manager';
+import { join } from 'path';
 
 export class CliTask extends Task {
   /**
@@ -37,7 +38,9 @@ export class CliTask extends Task {
       getShellExecutionForConfig(
         {
           displayCommand,
-          cwd: workspacePath,
+          cwd: definition.cwd
+            ? join(workspacePath, definition.cwd)
+            : workspacePath,
           encapsulatedNx: isEncapsulatedNx,
         },
         packageManagerCommands

--- a/libs/vscode/tasks/src/lib/nx-task.ts
+++ b/libs/vscode/tasks/src/lib/nx-task.ts
@@ -1,16 +1,18 @@
 import { getNxWorkspace } from '@nx-console/vscode/nx-workspace';
 import { getShellExecutionForConfig } from '@nx-console/vscode/utils';
+import { join } from 'path';
 import { Task, TaskScope } from 'vscode';
 
 export interface NxTaskDefinition {
   positional?: string;
   command: string;
   flags: Array<string>;
+  cwd?: string;
 }
 
 export class NxTask extends Task {
   static async create(definition: NxTaskDefinition): Promise<NxTask> {
-    const { command, flags, positional } = definition;
+    const { command, flags, positional, cwd } = definition;
 
     const args: string[] = [
       command,
@@ -29,7 +31,7 @@ export class NxTask extends Task {
       // execution
       getShellExecutionForConfig({
         displayCommand,
-        cwd: workspacePath,
+        cwd: cwd ? join(workspacePath, cwd) : workspacePath,
         encapsulatedNx: isEncapsulatedNx,
       })
     );


### PR DESCRIPTION
This PR sets up Nx Console to better deal with the new generator setup in Nx 17. 
- We can set a cwd value in the form and pass it along to VSCode & IntelliJ
- The cwd value will be prefilled instead of the directory
- The nameAndDirectoryFormat option will be prefilled to as-provided and a banner message for information will be shown
- hints on the name property let users know you can provide nested names