### PR TITLE
fix(vscode): handle new nx cloud access token format in v17

### DIFF
--- a/libs/vscode/nx-cloud-view/src/lib/config.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/config.ts
@@ -15,7 +15,7 @@ export const stagingConfig = {
     domain: 'https://auth.staging.nx.app/login',
   },
   endpoint: 'https://staging.nx.app/api',
-  appUrl: 'http://staging.nx.app',
+  appUrl: 'https://staging.nx.app',
 };
 
 export const prodConfig = {

--- a/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
@@ -10,7 +10,7 @@ import {
   getWorkspacePath,
   watchFile,
 } from '@nx-console/vscode/utils';
-import { exec, spawn } from 'child_process';
+import { exec, execSync, spawn } from 'child_process';
 import {
   debounceTime,
   distinctUntilChanged,
@@ -264,7 +264,7 @@ export class NxCloudService extends StateBaseService<InternalState> {
                 'nx',
                 // https://github.com/nrwl/nx/pull/12942
                 ...(gte(coerce(nxVersion.full) ?? '', '15.0.7')
-                  ? ['connect', '--interactive', 'false']
+                  ? ['connect']
                   : ['connect-to-nx-cloud']),
               ],
               { cwd: getWorkspacePath(), env, shell: true }

--- a/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
@@ -422,6 +422,20 @@ export class NxCloudService extends StateBaseService<InternalState> {
       );
       return;
     }
+    if (!this.state.canAccessCloudWorkspace) {
+      window
+        .showErrorMessage(
+          "You don't have access to this workspace. Log in to Nx Cloud in order to set up VCS integration.",
+          'Login',
+          'Cancel'
+        )
+        .then((value) => {
+          if (value === 'Login') {
+            commands.executeCommand('nxConsole.loginToNxCloud');
+          }
+        });
+      return;
+    }
     const orgId = this.state.cloudWorkspaceOrgId;
     const workspaceId = this.state.cloudWorkspaceId;
     const baseUrl = await this.getCloudRunnerUrl();

--- a/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
@@ -1,6 +1,7 @@
 import { getPackageManagerCommand } from 'nx/src/devkit-exports';
 import { EXECUTE_ARBITRARY_COMMAND } from '@nx-console/vscode/nx-commands-view';
 import {
+  getCacheableOperations,
   getNxCloudRunnerOptions,
   getNxWorkspace,
 } from '@nx-console/vscode/nx-workspace';
@@ -208,7 +209,7 @@ export class NxCloudService extends StateBaseService<InternalState> {
   private async setupCloudRunner() {
     getTelemetry().featureUsed('nxConsole.cloud.setupRunner');
 
-    const isConnected = await this.isUsingCloudRunner();
+    const isConnected = Boolean(await getNxCloudRunnerOptions());
     if (isConnected) {
       window.showInformationMessage('You are already connected to Nx Cloud');
       return;
@@ -262,9 +263,9 @@ export class NxCloudService extends StateBaseService<InternalState> {
               [
                 'nx',
                 // https://github.com/nrwl/nx/pull/12942
-                gte(coerce(nxVersion.full) ?? '', '15.0.7')
-                  ? 'connect'
-                  : 'connect-to-nx-cloud',
+                ...(gte(coerce(nxVersion.full) ?? '', '15.0.7')
+                  ? ['connect', '--interactive', 'false']
+                  : ['connect-to-nx-cloud']),
               ],
               { cwd: getWorkspacePath(), env, shell: true }
             );
@@ -459,27 +460,22 @@ export class NxCloudService extends StateBaseService<InternalState> {
   }
 
   private async loadAndSetIsUsingCloudRunner(reset = false) {
-    const isConnected = await this.isUsingCloudRunner(reset);
+    const isConnected = Boolean(await getNxCloudRunnerOptions(reset));
     this.setState({ isUsingCloudRunner: isConnected });
   }
 
   private async loadAndSetIsPrivateCloud() {
     const nxWorkspaceConfig = (await getNxWorkspace()).workspace;
-    const cloudRunnerUrl =
-      nxWorkspaceConfig.tasksRunnerOptions?.default?.runner ===
-        '@nrwl/nx-cloud' ||
-      nxWorkspaceConfig.tasksRunnerOptions?.default?.runner == 'nx-cloud'
-        ? nxWorkspaceConfig.tasksRunnerOptions?.default?.options?.url
-        : undefined;
+    const cloudRunnerOptions = await getNxCloudRunnerOptions();
 
-    this.setState({ cloudRunnerUrl });
+    this.setState({ cloudRunnerUrl: cloudRunnerOptions?.url });
   }
 
   private async generateListOfFirstCommands(): Promise<void> {
     const generateAndSetFirstCommands = async () => {
       const nxConfig = (await getNxWorkspace()).workspace;
-      const cacheableOperations =
-        nxConfig.tasksRunnerOptions?.default?.options.cacheableOperations;
+      const cacheableOperations = await getCacheableOperations();
+
       const commands: string[] = [];
       // get cacheable operations from default project
       if (nxConfig.defaultProject && cacheableOperations) {
@@ -655,21 +651,6 @@ export class NxCloudService extends StateBaseService<InternalState> {
           this.setState({ vcsIntegrationStatus: undefined });
         }
       });
-  }
-
-  /**
-   * Helpers
-   */
-
-  private async isUsingCloudRunner(reset = false): Promise<boolean> {
-    const nxConfig = (await getNxWorkspace(reset)).workspace;
-
-    if (!nxConfig.tasksRunnerOptions) {
-      return false;
-    }
-    return !!Object.values(nxConfig.tasksRunnerOptions).find(
-      (r) => r.runner == '@nrwl/nx-cloud' || r.runner == 'nx-cloud'
-    );
   }
 
   private async getCloudRunnerUrl(): Promise<string> {

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace.ts
@@ -82,16 +82,10 @@ export async function getCacheableOperations(): Promise<string[]> {
   const { workspace } = await getNxWorkspace();
   const cacheableOperations = new Set<string>();
   for (const key in workspace.projects) {
-    if (!workspace.projects.hasOwnProperty(key)) {
-      continue;
-    }
     const targets = workspace.projects[key].targets;
     for (const targetKey in targets) {
-      if (!targets?.hasOwnProperty(targetKey)) {
-        continue;
-      }
       // TODO: remove type cast after update
-      const target = targets?.[targetKey] as TargetConfiguration & {
+      const target = targets[targetKey] as TargetConfiguration & {
         cache?: boolean;
       };
 

--- a/libs/vscode/nx-workspace/src/lib/get-nx-workspace.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-nx-workspace.ts
@@ -80,6 +80,11 @@ function getNxCloudEnv(workspacePath: string): any {
 
 export async function getCacheableOperations(): Promise<string[]> {
   const { workspace } = await getNxWorkspace();
+
+  if (workspace.tasksRunnerOptions?.default?.options.cacheableOperations) {
+    return workspace.tasksRunnerOptions.default.options.cacheableOperations;
+  }
+
   const cacheableOperations = new Set<string>();
   for (const key in workspace.projects) {
     const targets = workspace.projects[key].targets;


### PR DESCRIPTION
In nx17, nx cloud can be configured without the `taskRunnerOptions` object. Nx Console can now deal with this format.