### PR TITLE
feat(vscode): show node version loaded by vscode on startup

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -667,6 +667,12 @@
           "scope": "application",
           "default": true,
           "description": "Use the new Generate UI - still in development."
+        },
+        "nxConsole.showNodeVersionOnStartup": {
+          "type": "boolean",
+          "scope": "application",
+          "default": true,
+          "description": "Show a notification with the current Node version on startup - useful for debugging nvm issues."
         }
       }
     },

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -66,6 +66,7 @@ import {
   REFRESH_WORKSPACE,
   refreshWorkspace,
 } from './commands/refresh-workspace';
+import { initNvmTip } from '@nx-console/vscode/nvm-tip';
 
 let runTargetTreeView: TreeView<RunTargetTreeItem>;
 let nxHelpAndFeedbackTreeView: TreeView<NxHelpAndFeedbackTreeItem | TreeItem>;
@@ -133,6 +134,7 @@ export async function activate(c: ExtensionContext) {
 
     await enableTypeScriptPlugin(context);
     initNxCommandsView(context);
+    initNvmTip(context);
 
     currentRunTargetTreeProvider = new RunTargetTreeProvider(context);
     runTargetTreeView = window.createTreeView('nxRunTarget', {

--- a/libs/vscode/configuration/src/lib/configuration-keys.ts
+++ b/libs/vscode/configuration/src/lib/configuration-keys.ts
@@ -10,6 +10,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'projectViewingStyle',
   'moveGeneratorPatterns',
   'useNewGenerateUiPreview',
+  'showNodeVersionOnStartup',
 ] as const;
 
 export type GlobalConfig = {
@@ -24,6 +25,7 @@ export type GlobalConfig = {
   projectViewingStyle: 'list' | 'tree' | 'automatic';
   moveGeneratorPatterns: Record<string, string>;
   useNewGenerateUiPreview: boolean;
+  showNodeVersionOnStartup: boolean;
 };
 
 /**

--- a/libs/vscode/configuration/src/lib/global-configuration-store.ts
+++ b/libs/vscode/configuration/src/lib/global-configuration-store.ts
@@ -49,8 +49,12 @@ export class GlobalConfigurationStore implements Store {
     return typeof value === 'undefined' ? defaultValue || null : value;
   }
 
-  set<T>(key: GlobalConfigKeys, value: T): void {
-    this.storage(key).update(key, value);
+  set<T>(
+    key: GlobalConfigKeys,
+    value: T,
+    configurationTarget?: ConfigurationTarget
+  ): void {
+    this.storage(key).update(key, value, configurationTarget);
     this._onConfigurationChange.fire();
   }
 

--- a/libs/vscode/nvm-tip/.eslintrc.json
+++ b/libs/vscode/nvm-tip/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/vscode/nvm-tip/project.json
+++ b/libs/vscode/nvm-tip/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "vscode-nvm-tip",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/vscode/nvm-tip/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/vscode/nvm-tip/**/*.ts"]
+      }
+    }
+  },
+  "tags": ["type:vscode"]
+}

--- a/libs/vscode/nvm-tip/src/index.ts
+++ b/libs/vscode/nvm-tip/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/nvm-tip';

--- a/libs/vscode/nvm-tip/src/lib/nvm-tip.ts
+++ b/libs/vscode/nvm-tip/src/lib/nvm-tip.ts
@@ -3,7 +3,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { ConfigurationTarget, ExtensionContext, window } from 'vscode';
 
-export async function initNvmTip(context: ExtensionContext) {
+export async function initNvmTip(_: ExtensionContext) {
   const showTip = GlobalConfigurationStore.instance.get(
     'showNodeVersionOnStartup'
   );
@@ -14,7 +14,7 @@ export async function initNvmTip(context: ExtensionContext) {
   const nodeVersion = stdout.trim();
   window
     .showInformationMessage(
-      `VSCode loaded Node ${nodeVersion}. [That's wrong?](https://google.com)`,
+      `VSCode loaded Node ${nodeVersion}. [That's wrong?](https://nx.dev/recipes/nx-console/console-troubleshooting#vscode-nvm-issues)`,
       'OK',
       "Don't show again"
     )

--- a/libs/vscode/nvm-tip/src/lib/nvm-tip.ts
+++ b/libs/vscode/nvm-tip/src/lib/nvm-tip.ts
@@ -1,0 +1,30 @@
+import { GlobalConfigurationStore } from '@nx-console/vscode/configuration';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { ConfigurationTarget, ExtensionContext, window } from 'vscode';
+
+export async function initNvmTip(context: ExtensionContext) {
+  const showTip = GlobalConfigurationStore.instance.get(
+    'showNodeVersionOnStartup'
+  );
+  if (!showTip) {
+    return;
+  }
+  const { stdout } = await promisify(exec)('node -v');
+  const nodeVersion = stdout.trim();
+  window
+    .showInformationMessage(
+      `VSCode loaded Node ${nodeVersion}. [That's wrong?](https://google.com)`,
+      'OK',
+      "Don't show again"
+    )
+    .then((value) => {
+      if (value != 'OK') {
+        GlobalConfigurationStore.instance.set(
+          'showNodeVersionOnStartup',
+          false,
+          ConfigurationTarget.Global
+        );
+      }
+    });
+}

--- a/libs/vscode/nvm-tip/tsconfig.json
+++ b/libs/vscode/nvm-tip/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/vscode/nvm-tip/tsconfig.lib.json
+++ b/libs/vscode/nvm-tip/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -113,7 +113,8 @@
       "@nx-console/vscode/webview": ["libs/vscode/webview/src/index.ts"],
       "shared/nx-console-plugins": [
         "libs/shared/nx-console-plugins/src/index.ts"
-      ]
+      ],
+      "@nx-console/vscode/nvm-tip": ["libs/vscode/nvm-tip/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
Shows a notification on startup alerting users about the currently loaded node version.
![image](https://github.com/nrwl/nx-console/assets/34165455/e8d6d515-b387-4a26-891d-faf9dcceefcf)

Also links to the new [Troubleshooting Recipe](https://nx.dev/recipes/nx-console/console-troubleshooting#vscode-nvm-issues) so folks can fix things before digging through GitHub issues. 
Can be turned on/off via settings.