### PR TITLE
fix(intellij): make sure jcef is supported before opening

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/file/NxGenerateUiFileRenderer.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/file/NxGenerateUiFileRenderer.kt
@@ -1,6 +1,5 @@
 package dev.nx.console.generate.ui.file
 
-import com.intellij.notification.NotificationType
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.jcef.JBCefApp
@@ -17,11 +16,7 @@ class NxGenerateUiFileRenderer : NxGenerateUiRenderer {
         runGeneratorManager: RunGeneratorManager
     ) {
         if (!JBCefApp.isSupported()) {
-            Notifier.notifyAnything(
-                project,
-                "Can't open the Generate UI. Your IDE doesn't support JCEF - please use the bundled JetBrains Runtime (JBR) instead of an alternative OpenJDK.",
-                NotificationType.ERROR
-            )
+            Notifier.notifyJCEFNotEnabled(project)
             return
         }
         val virtualFile =

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/file/NxGenerateUiFileRenderer.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/file/NxGenerateUiFileRenderer.kt
@@ -1,11 +1,14 @@
 package dev.nx.console.generate.ui.file
 
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
+import com.intellij.ui.jcef.JBCefApp
 import dev.nx.console.generate.run_generator.RunGeneratorManager
 import dev.nx.console.generate.ui.NxGenerateUiRenderer
 import dev.nx.console.models.NxGenerator
 import dev.nx.console.settings.NxConsoleSettingsProvider
+import dev.nx.console.ui.Notifier
 
 class NxGenerateUiFileRenderer : NxGenerateUiRenderer {
     override fun openGenerateUi(
@@ -13,6 +16,14 @@ class NxGenerateUiFileRenderer : NxGenerateUiRenderer {
         nxGenerator: NxGenerator,
         runGeneratorManager: RunGeneratorManager
     ) {
+        if (!JBCefApp.isSupported()) {
+            Notifier.notifyAnything(
+                project,
+                "Can't open the Generate UI. Your IDE doesn't support JCEF - please use the bundled JetBrains Runtime (JBR) instead of an alternative OpenJDK.",
+                NotificationType.ERROR
+            )
+            return
+        }
         val virtualFile =
             if (NxConsoleSettingsProvider.getInstance().useNewGenerateUIPreview)
                 V2NxGenerateUiFile("Generate", project, runGeneratorManager)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/ui/Notifier.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/ui/Notifier.kt
@@ -1,6 +1,8 @@
 package dev.nx.console.ui
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
@@ -70,8 +72,10 @@ class Notifier {
 
         private val lspIssueExceptionThrottler =
             Throttler(1000L, CoroutineScope(Dispatchers.Default))
+
         fun notifyLspMessageIssueExceptionThrottled(project: Project, e: MessageIssueException) =
             lspIssueExceptionThrottler.throttle { notifyLSPMessageIssueException(project, e) }
+
         fun notifyLSPMessageIssueException(project: Project, e: MessageIssueException) {
             group
                 .createNotification(
@@ -86,6 +90,27 @@ class Notifier {
                 .addAction(AnalyzeNxConfigurationFilesNotificationAction())
                 .notify(project)
         }
+
+        fun notifyJCEFNotEnabled(project: Project) {
+            group
+                .createNotification(
+                    "Can't open the Generate UI - Your IDE doesn't support JCEF.",
+                    NotificationType.ERROR,
+                )
+                .setTitle("Nx Console")
+                .addAction(
+                    object : NotificationAction("Learn more") {
+                        override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                            BrowserUtil.browse(
+                                "https://plugins.jetbrains.com/docs/intellij/jcef.html"
+                            )
+                            notification.expire()
+                        }
+                    }
+                )
+                .notify(project)
+        }
+
         fun notifyAnything(
             project: Project,
             message: String,


### PR DESCRIPTION
Surfaces JCEF errors so the users knows what's going on.
![image](https://github.com/nrwl/nx-console/assets/34165455/acc7e10d-4e6d-4c23-a9ef-565194b4573a)

should fix https://github.com/nrwl/nx-console/issues/1903 
