### PR TITLE
fix(vscode): handle vcs integration click if user doesn't have access to workspace

### DIFF
--- a/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/nx-cloud-service/nx-cloud-service.ts
@@ -422,6 +422,20 @@ export class NxCloudService extends StateBaseService<InternalState> {
       );
       return;
     }
+    if (!this.state.canAccessCloudWorkspace) {
+      window
+        .showErrorMessage(
+          "You don't have access to this workspace. Log in to Nx Cloud in order to set up VCS integration.",
+          'Login',
+          'Cancel'
+        )
+        .then((value) => {
+          if (value === 'Login') {
+            commands.executeCommand('nxConsole.loginToNxCloud');
+          }
+        });
+      return;
+    }
     const orgId = this.state.cloudWorkspaceOrgId;
     const workspaceId = this.state.cloudWorkspaceId;
     const baseUrl = await this.getCloudRunnerUrl();


### PR DESCRIPTION
Make sure users can't try and connect to VSCode if they don't have access. The URL would have an undefined org and cause issues in the cloud app.
![image](https://github.com/nrwl/nx-console/assets/34165455/9aa63715-7f44-4382-8f5a-adcb171d546c)
