### PR TITLE
fix(vscode): handle missing node_module states more gracefully

### DIFF
--- a/libs/vscode/generate-ui-webview/src/lib/generate-commands.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/generate-commands.ts
@@ -54,83 +54,75 @@ export async function registerGenerateCommands(context: ExtensionContext) {
     }
   );
 
-  /**
-   * move and remove were release in patch 8.11
-   */
-  const version = await getNxVersion();
-  if (version.major >= 8) {
-    commands.registerCommand(`nx.move`, async (uri?: Uri) => {
-      getTelemetry().featureUsed('nx.move');
-      const generator = await selectReMoveGenerator(uri?.toString(), 'move');
+  commands.registerCommand(`nx.move`, async (uri?: Uri) => {
+    getTelemetry().featureUsed('nx.move');
+    const generator = await selectReMoveGenerator(uri?.toString(), 'move');
+    if (!generator) {
+      return;
+    }
+
+    openReMoveGenerator(generator, uri, undefined);
+  });
+
+  commands.registerCommand(`nx.remove`, async (uri?: Uri) => {
+    getTelemetry().featureUsed('nx.remove');
+    const generator = await selectReMoveGenerator(uri?.toString(), 'remove');
+    if (!generator) {
+      return;
+    }
+
+    openReMoveGenerator(generator, uri, undefined);
+  });
+
+  commands.registerCommand(
+    `nx.move.projectView`,
+    async (treeItem?: NxTreeItem) => {
+      getTelemetry().featureUsed('nx.move.projectView');
+      const generator = await selectReMoveGenerator(undefined, 'move');
       if (!generator) {
         return;
       }
 
-      openReMoveGenerator(generator, uri, undefined);
-    });
+      const projectName = (treeItem?.item as ProjectViewItem).nxProject.project;
 
-    commands.registerCommand(`nx.remove`, async (uri?: Uri) => {
-      getTelemetry().featureUsed('nx.remove');
-      const generator = await selectReMoveGenerator(uri?.toString(), 'remove');
+      openReMoveGenerator(generator, undefined, projectName);
+    }
+  );
+
+  commands.registerCommand(
+    `nx.remove.projectView`,
+    async (treeItem?: NxTreeItem) => {
+      getTelemetry().featureUsed('nx.remove.projectView');
+      const generator = await selectReMoveGenerator(undefined, 'remove');
       if (!generator) {
         return;
       }
 
-      openReMoveGenerator(generator, uri, undefined);
-    });
+      const projectName = (treeItem?.item as ProjectViewItem).nxProject.project;
 
-    commands.registerCommand(
-      `nx.move.projectView`,
-      async (treeItem?: NxTreeItem) => {
-        getTelemetry().featureUsed('nx.move.projectView');
-        const generator = await selectReMoveGenerator(undefined, 'move');
-        if (!generator) {
-          return;
-        }
+      openReMoveGenerator(generator, undefined, projectName);
+    }
+  );
 
-        const projectName = (treeItem?.item as ProjectViewItem).nxProject
-          .project;
-
-        openReMoveGenerator(generator, undefined, projectName);
-      }
+  const openReMoveGenerator = (
+    generator: string,
+    uri: Uri | undefined,
+    projectName: string | undefined
+  ) => {
+    const newGenUi = GlobalConfigurationStore.instance.get(
+      'useNewGenerateUiPreview'
     );
-
-    commands.registerCommand(
-      `nx.remove.projectView`,
-      async (treeItem?: NxTreeItem) => {
-        getTelemetry().featureUsed('nx.remove.projectView');
-        const generator = await selectReMoveGenerator(undefined, 'remove');
-        if (!generator) {
-          return;
-        }
-
-        const projectName = (treeItem?.item as ProjectViewItem).nxProject
-          .project;
-
-        openReMoveGenerator(generator, undefined, projectName);
-      }
-    );
-
-    const openReMoveGenerator = (
-      generator: string,
-      uri: Uri | undefined,
-      projectName: string | undefined
-    ) => {
-      const newGenUi = GlobalConfigurationStore.instance.get(
-        'useNewGenerateUiPreview'
+    if (newGenUi) {
+      openGenerateUi(uri, generator, projectName);
+    } else {
+      showGenerateUi(
+        context.extensionPath,
+        uri,
+        GeneratorType.Other,
+        generator
       );
-      if (newGenUi) {
-        openGenerateUi(uri, generator, projectName);
-      } else {
-        showGenerateUi(
-          context.extensionPath,
-          uri,
-          GeneratorType.Other,
-          generator
-        );
-      }
-    };
-  }
+    }
+  };
 }
 
 async function showGenerateUi(

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-generator.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-generator.ts
@@ -12,6 +12,7 @@ import {
 } from '@nx-console/vscode/nx-workspace';
 import { QuickPickItem, window } from 'vscode';
 import { selectFlags } from './select-flags';
+import { showNoGeneratorsMessage } from '@nx-console/vscode/utils';
 
 export async function selectGenerator(
   generatorType?: GeneratorType,
@@ -67,32 +68,34 @@ export async function selectGenerator(
     });
   }
 
-  if (generators) {
-    const selection = generator
-      ? generatorsQuickPicks.find(
-          (quickPick) =>
-            quickPick.generator.collection === generator.collection &&
-            quickPick.generator.name === generator.name
-        )
-      : generatorsQuickPicks.length > 1
-      ? await window.showQuickPick(generatorsQuickPicks)
-      : generatorsQuickPicks[0];
-    if (selection) {
-      const options =
-        selection.generator.options ||
-        (await getGeneratorOptions({
-          collection: selection.collectionName,
-          name: selection.generator.name,
-          path: selection.collectionPath,
-        }));
-      const positional = selection.generatorName;
-      return {
-        ...selection.generator,
-        options,
-        command: 'generate',
-        positional,
-      };
-    }
+  if (!generators || !generators.length) {
+    showNoGeneratorsMessage();
+    return;
+  }
+  const selection = generator
+    ? generatorsQuickPicks.find(
+        (quickPick) =>
+          quickPick.generator.collection === generator.collection &&
+          quickPick.generator.name === generator.name
+      )
+    : generatorsQuickPicks.length > 1
+    ? await window.showQuickPick(generatorsQuickPicks)
+    : generatorsQuickPicks[0];
+  if (selection) {
+    const options =
+      selection.generator.options ||
+      (await getGeneratorOptions({
+        collection: selection.collectionName,
+        name: selection.generator.name,
+        path: selection.collectionPath,
+      }));
+    const positional = selection.generatorName;
+    return {
+      ...selection.generator,
+      options,
+      command: 'generate',
+      positional,
+    };
   }
 }
 

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-re-move-generator.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-re-move-generator.ts
@@ -9,6 +9,13 @@ export async function selectReMoveGenerator(
 ): Promise<string | undefined> {
   const generators = await getGenerators();
 
+  if (!generators || !generators.length) {
+    window.showWarningMessage(
+      `No ${target} generator found. Did you run npm/pnpm/yarn install?`
+    );
+    return;
+  }
+
   const reMoveGenerators = generators.filter(
     (generator) => generator.data?.name === target
   );

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-run-information.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-run-information.ts
@@ -3,6 +3,7 @@ import { getNxWorkspace } from '@nx-console/vscode/nx-workspace';
 import { verifyBuilderDefinition } from '@nx-console/vscode/verify';
 import { window } from 'vscode';
 import { selectFlags } from './select-flags';
+import { showNoProjectsMessage } from '@nx-console/vscode/utils';
 
 export async function selectRunInformation(
   projectName?: string,
@@ -98,6 +99,10 @@ async function selectProjectAndThenTarget(
   let t = targetName;
   if (!p) {
     const projects = await getProjects(t);
+    if (!projects || !projects.length) {
+      showNoProjectsMessage();
+      return;
+    }
     p = await selectProject(projects);
     if (!p) {
       return;
@@ -123,6 +128,10 @@ async function selectTargetAndThenProject(
   let t = targetName;
   if (!t) {
     const targets = await getTargets(p);
+    if (!targets || !targets.length) {
+      showNoProjectsMessage();
+      return;
+    }
     t = (await selectTarget(targets)) as string;
     if (!t) {
       return;

--- a/libs/vscode/project-graph/src/lib/graph-webview.ts
+++ b/libs/vscode/project-graph/src/lib/graph-webview.ts
@@ -1,10 +1,15 @@
 import {
+  getNxWorkspace,
   getNxWorkspacePath,
   getNxWorkspaceProjects,
   getProjectGraphOutput,
   hasAffectedProjects,
 } from '@nx-console/vscode/nx-workspace';
-import { getOutputChannel, getTelemetry } from '@nx-console/vscode/utils';
+import {
+  getOutputChannel,
+  getTelemetry,
+  showNoProjectsMessage,
+} from '@nx-console/vscode/utils';
 import {
   commands,
   Disposable,
@@ -192,6 +197,14 @@ export class GraphWebView implements Disposable {
 
   async showAffectedProjects() {
     getOutputChannel().appendLine(`Graph - Opening affected projects`);
+    const {
+      workspace: { projects },
+    } = await getNxWorkspace();
+
+    if (!projects || !projects.length) {
+      showNoProjectsMessage();
+      return;
+    }
     const hasAffected = await hasAffectedProjects();
 
     if (!hasAffected) {

--- a/libs/vscode/project-graph/src/lib/project-graph.ts
+++ b/libs/vscode/project-graph/src/lib/project-graph.ts
@@ -9,9 +9,9 @@ import {
   getNxWorkspace,
   getProjectByPath,
 } from '@nx-console/vscode/nx-workspace';
-import { getTelemetry } from '@nx-console/vscode/utils';
+import { getTelemetry, showNoProjectsMessage } from '@nx-console/vscode/utils';
 import { ProjectConfiguration } from 'nx/src/devkit-exports';
-import { commands, Disposable, Uri, window } from 'vscode';
+import { Disposable, Uri, commands, window } from 'vscode';
 import { MessageType } from './graph-message-type';
 import { GraphWebView } from './graph-webview';
 
@@ -119,7 +119,14 @@ async function openProjectWithFile(
       workspace: { projects },
     } = await getNxWorkspace();
 
-    const selectedProjectName = await selectProject(Object.keys(projects));
+    const projectNames = Object.keys(projects);
+
+    if (projectNames.length === 0) {
+      showNoProjectsMessage();
+      return;
+    }
+
+    const selectedProjectName = await selectProject(projectNames);
     if (!selectedProjectName) {
       return;
     }

--- a/libs/vscode/utils/src/index.ts
+++ b/libs/vscode/utils/src/index.ts
@@ -2,6 +2,7 @@ export * from './lib/abstract-tree-provider';
 export * from './lib/telemetry';
 export * from './lib/output-channel';
 export * from './lib/read-projects';
+export * from './lib/empty-state-messages';
 export { watchFile } from './lib/watch-file';
 export { getShellExecutionForConfig } from './lib/shell-execution';
 export { getWorkspacePath } from './lib/get-workspace-path';

--- a/libs/vscode/utils/src/lib/empty-state-messages.ts
+++ b/libs/vscode/utils/src/lib/empty-state-messages.ts
@@ -1,0 +1,13 @@
+import { window } from 'vscode';
+
+export function showNoProjectsMessage() {
+  window.showWarningMessage(
+    'No projects found. Did you run npm/pnpm/yarn install?'
+  );
+}
+
+export function showNoGeneratorsMessage() {
+  window.showWarningMessage(
+    'No generators found. Did you run npm/pnpm/yarn install?'
+  );
+}


### PR DESCRIPTION
This PR adds some checks to make sure we don't get empty quickpicks or just nothing happening when users haven't installed dependencies yet.
<img width="538" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/ab4e8c4f-ba3c-4e89-b1c6-cea7dde999c9">
