### PR TITLE
fix: stringify prompt items to avoid [object Object]

### DIFF
--- a/apps/generate-ui-v2/src/components/fields/multiselect-field.ts
+++ b/apps/generate-ui-v2/src/components/fields/multiselect-field.ts
@@ -58,7 +58,8 @@ export class MultiselectField extends FieldWrapper(Field(LitElement)) {
         </option>
         ${map(
           this.extractItemOptions(this.option),
-          (item) => html`<option value="${item}">${item}</option>`
+          (item) =>
+            html`<option value="${item}" title="${item}">${item}</option>`
         )}
       </select>`;
     } else {
@@ -74,7 +75,10 @@ export class MultiselectField extends FieldWrapper(Field(LitElement)) {
         </vscode-option>
         ${map(
           this.extractItemOptions(this.option),
-          (item) => html`<vscode-option value="${item}">${item}</vscode-option>`
+          (item) =>
+            html`<vscode-option value="${item}" title="${item}"
+              >${item}</vscode-option
+            >`
         )}
       </vscode-dropdown>`;
     }

--- a/apps/generate-ui-v2/src/components/fields/select-field.ts
+++ b/apps/generate-ui-v2/src/components/fields/select-field.ts
@@ -42,7 +42,8 @@ export class SelectField extends FieldWrapper(Field(LitElement)) {
         )}
         ${map(
           extractItemOptions(this.option),
-          (item) => html`<option value="${item}">${item}</option>`
+          (item) =>
+            html`<option value="${item}" title="${item}">${item}</option>`
         )}
       </select>
     `;
@@ -61,7 +62,10 @@ export class SelectField extends FieldWrapper(Field(LitElement)) {
         )}
         ${map(
           extractItemOptions(this.option),
-          (item) => html`<vscode-option value="${item}">${item}</vscode-option>`
+          (item) =>
+            html`<vscode-option value="${item}" title="${item}"
+              >${item}</vscode-option
+            >`
         )}
       </vscode-dropdown>
     `;

--- a/libs/shared/schema/src/normalize-schema.ts
+++ b/libs/shared/schema/src/normalize-schema.ts
@@ -45,7 +45,11 @@ export async function normalizeSchema(
       nxOption.itemTooltips = getEnumTooltips(xPrompt);
       if (isLongFormXPrompt(xPrompt) && !nxOption.items) {
         const items = (xPrompt.items || []).map((item) =>
-          isOptionItemLabelValue(item) ? item.value : item
+          isOptionItemLabelValue(item)
+            ? typeof item.value === 'string'
+              ? item.value
+              : JSON.stringify(item.value)
+            : item
         );
         if (items.length > 0) {
           nxOption.items = items;


### PR DESCRIPTION

<img width="494" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/1822277c-46fb-4dc4-ac94-f20d12708af3">

fixes https://github.com/nrwl/nx-console/issues/1919
I know this is more of a bandaid than an actual fix but since it's quite an edge case, I won't do the complicated fix with Labels.  If the objects are too long to fit in the field, you can hover over it. 

If it's super important to you, I'd be glad to help with a contribution!