### PR TITLE
fix: distinguish more cases when prefilling

### DIFF
--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/prefill-project-and-dir-processor.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/prefill-project-and-dir-processor.ts
@@ -6,6 +6,9 @@ export const prefillProjectAndDirProcessor: SchemaProcessor = (
   schema: GeneratorSchema,
   workspace: NxWorkspace
 ) => {
+  schema.context = schema.context ?? {};
+  schema.context.prefillValues = schema.context.prefillValues ?? {};
+
   // before nx 17, path/directory options are inconsistent so we don't prefill project & directory simultaneously
   if (workspace.nxVersion.major < 17) {
     if (schema.context?.project) {
@@ -23,14 +26,53 @@ export const prefillProjectAndDirProcessor: SchemaProcessor = (
     }
   }
 
-  // after nx 17, project option won't exist anymore and cwd-ing into directories will be the way to go
+  // after nx 18 the format options will be removed.
+  // That means we should prefill cwd unless there's still a project / projectName option
+  if (workspace.nxVersion.major >= 18) {
+    if (
+      schema.options.find(
+        (o) => o.name === 'project' || o.name === 'projectName'
+      )
+    ) {
+      prefillProject();
+    } else {
+      prefillDirectoryAsCwd();
+    }
+  }
 
-  if (schema.context?.directory) {
-    schema.context.prefillValues = {
-      ...(schema.context.prefillValues ?? {}),
-      cwd: schema.context.directory,
-    };
+  // after nx 17, most generators will have nameAndDirectory or projectNameAndRoot options.
+  // for those, we prefill the cwd
+  if (
+    schema.options.find(
+      (o) =>
+        o.name === 'nameAndDirectoryFormat' ||
+        o.name === 'projectNameAndRootFormat'
+    )
+  ) {
+    prefillDirectoryAsCwd();
+    // if they don't have this option, we prefill the project
+  } else {
+    prefillProject();
   }
 
   return schema;
+
+  function prefillDirectoryAsCwd() {
+    if (schema.context?.directory && schema.context?.prefillValues) {
+      schema.context.prefillValues = {
+        ...schema.context.prefillValues,
+        cwd: schema.context?.directory,
+      };
+    }
+  }
+
+  function prefillProject() {
+    if (schema.context?.project) {
+      schema.context.prefillValues = {
+        ...(schema.context.prefillValues ?? {}),
+        project: schema.context.project,
+        projectName: schema.context.project,
+      };
+    }
+  }
 };


### PR DESCRIPTION
Makes the prefilling logic smarter: 
- pre nx 17
  - `project` option exists: prefill `project` and set`directory` to empty string
  - `directory` option exists (and no `project`): prefill `directory`
- nx 17
  - `projectNameAndRootFormat` or `nameAndDirectoryFormat` exist: prefill `directory` as `cwd`
  - else: prefill `project`
- nx 18+ (when `as-provided` will become default and most `project` options will be removed)
  - if project exists: prefill `project`
  - else: prefill `directory` as `cwd`