### PR TITLE
feat: go to executor definition

### DIFF
--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -4,6 +4,7 @@ import {
   getCompletionItems,
   projectSchemaIsRegistered,
 } from '@nx-console/language-server/capabilities/code-completion';
+import { getDefinition } from '@nx-console/language-server/capabilities/definition';
 import { getDocumentLinks } from '@nx-console/language-server/capabilities/document-links';
 import { getHover } from '@nx-console/language-server/capabilities/hover';
 import {
@@ -154,6 +155,7 @@ connection.onInitialize(async (params) => {
         triggerCharacters: ['"', ':'],
       },
       hoverProvider: true,
+      definitionProvider: true,
       documentLinkProvider: {
         resolveProvider: false,
         workDoneProgress: false,
@@ -259,6 +261,18 @@ connection.onHover(async (hoverParams) => {
 
   const { jsonAst, document } = getJsonDocument(hoverDocument);
   return await getHover(hoverParams, jsonAst, document);
+});
+
+connection.onDefinition((definitionParams) => {
+  const definitionDocument = documents.get(definitionParams.textDocument.uri);
+
+  if (!definitionDocument || !WORKING_PATH) {
+    return null;
+  }
+
+  const { jsonAst, document } = getJsonDocument(definitionDocument);
+
+  return getDefinition(WORKING_PATH, definitionParams, jsonAst, document);
 });
 
 connection.onDocumentLinks(async (params) => {

--- a/libs/language-server/capabilities/code-completion/src/lib/schema-completion.ts
+++ b/libs/language-server/capabilities/code-completion/src/lib/schema-completion.ts
@@ -172,8 +172,8 @@ async function getProjectSchema(
     }
     const schemaRef =
       platform() === 'win32'
-        ? matchingCollection?.path
-        : `file://${matchingCollection?.path}`;
+        ? matchingCollection.schemaPath
+        : `file://${matchingCollection.schemaPath}`;
 
     targetsProperties[key] = {
       properties: {

--- a/libs/language-server/capabilities/definition/.eslintrc.json
+++ b/libs/language-server/capabilities/definition/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/language-server/capabilities/definition/README.md
+++ b/libs/language-server/capabilities/definition/README.md
@@ -1,0 +1,11 @@
+# language-server-capabilities-hover
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build language-server-capabilities-definition` to build the library.
+
+## Running unit tests
+
+Run `nx test language-server-capabilities-definition` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/language-server/capabilities/definition/jest.config.ts
+++ b/libs/language-server/capabilities/definition/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'language-server-capabilities-definition',
+  preset: '../../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory:
+    '../../../../coverage/libs/language-server/capabilities/definition',
+};

--- a/libs/language-server/capabilities/definition/package.json
+++ b/libs/language-server/capabilities/definition/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@nx-console/language-server/capabilities/definition",
+  "version": "0.0.1",
+  "type": "commonjs"
+}

--- a/libs/language-server/capabilities/definition/project.json
+++ b/libs/language-server/capabilities/definition/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "language-server-capabilities-definition",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/language-server/capabilities/definition/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "libs/language-server/capabilities/definition/**/*.ts"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/language-server/capabilities/definition/jest.config.ts"
+      }
+    }
+  },
+  "tags": ["type:lsp"]
+}

--- a/libs/language-server/capabilities/definition/src/index.ts
+++ b/libs/language-server/capabilities/definition/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/get-definition';

--- a/libs/language-server/capabilities/definition/src/lib/get-definition.ts
+++ b/libs/language-server/capabilities/definition/src/lib/get-definition.ts
@@ -1,0 +1,69 @@
+import { isExecutorStringNode } from '@nx-console/language-server/utils';
+import { getExecutors } from '@nx-console/language-server/workspace';
+import { resolveImplementation } from 'nx/src/config/schema-utils';
+import { dirname } from 'path';
+import { JSONDocument } from 'vscode-json-languageservice';
+import { DefinitionParams, LocationLink } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+
+export async function getDefinition(
+  workingPath: string,
+  definitionParams: DefinitionParams,
+  jsonAst: JSONDocument,
+  document: TextDocument
+): Promise<LocationLink[] | undefined> {
+  const offset = document.offsetAt(definitionParams.position);
+  const node = jsonAst.getNodeFromOffset(offset);
+
+  if (!node || !isExecutorStringNode(node)) {
+    return undefined;
+  }
+
+  const executors = await getExecutors(workingPath);
+
+  const executor = executors.find((e) => e.name === node.value);
+
+  if (!executor) {
+    return undefined;
+  }
+
+  const executorFile = resolveImplementation(
+    executor.implementationPath,
+    dirname(executor.configPath)
+  );
+
+  return [
+    LocationLink.create(
+      URI.file(executorFile).toString(),
+      // Link to start of file because we cannot find the exact location without parsing the file
+      {
+        start: {
+          line: 0,
+          character: 0,
+        },
+        end: {
+          line: 0,
+          character: 0,
+        },
+      },
+      {
+        start: {
+          line: 0,
+          character: 0,
+        },
+        end: {
+          line: 0,
+          character: 0,
+        },
+      },
+      {
+        // So that the underline is
+        // "executor": "nx:build"
+        //              ^^^^^^^^
+        start: document.positionAt(node.offset + 1),
+        end: document.positionAt(node.offset + node.length - 1),
+      }
+    ),
+  ];
+}

--- a/libs/language-server/capabilities/definition/tsconfig.json
+++ b/libs/language-server/capabilities/definition/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/language-server/capabilities/definition/tsconfig.lib.json
+++ b/libs/language-server/capabilities/definition/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/language-server/capabilities/definition/tsconfig.spec.json
+++ b/libs/language-server/capabilities/definition/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/language-server/capabilities/hover/src/lib/get-hover.ts
+++ b/libs/language-server/capabilities/hover/src/lib/get-hover.ts
@@ -7,8 +7,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import {
   getJsonLanguageService,
-  isPropertyNode,
-  isStringNode,
+  isExecutorStringNode,
 } from '@nx-console/language-server/utils';
 
 export async function getHover(
@@ -33,7 +32,7 @@ export async function getHover(
     return hover;
   }
 
-  if (isExecutorStringNode(node)) {
+  if (isNxExecutorStringNode(node)) {
     hover.contents = {
       kind: 'markdown',
       value: `[View executor documentation on nx.dev](${constructExecutorUrl(
@@ -45,11 +44,9 @@ export async function getHover(
   return hover;
 }
 
-function isExecutorStringNode(node: ASTNode): node is StringASTNode {
+function isNxExecutorStringNode(node: ASTNode): node is StringASTNode {
   return (
-    isStringNode(node) &&
-    isPropertyNode(node.parent) &&
-    node.parent.keyNode.value === 'executor' &&
+    isExecutorStringNode(node) &&
     (RegExp(/@nx|@nrwl\/\w+:\w+/).test(node.value) ||
       RegExp(/nx:\w+/).test(node.value))
   );

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -3,7 +3,7 @@ import {
   GeneratorSchema,
 } from '@nx-console/shared/generate-ui-types';
 import {
-  CollectionInfo,
+  GeneratorCollectionInfo,
   Option,
   TaskExecutionSchema,
 } from '@nx-console/shared/schema';
@@ -41,7 +41,7 @@ export const NxGeneratorsRequest: RequestType<
   {
     options?: NxGeneratorsRequestOptions;
   },
-  CollectionInfo[],
+  GeneratorCollectionInfo[],
   unknown
 > = new RequestType('nx/generators');
 

--- a/libs/language-server/utils/src/index.ts
+++ b/libs/language-server/utils/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/default-completion';
 export * from './lib/lsp-log';
 export * from './lib/json-language-service';
 export * from './lib/find-property';
+export * from './lib/executor';

--- a/libs/language-server/utils/src/lib/executor.ts
+++ b/libs/language-server/utils/src/lib/executor.ts
@@ -1,0 +1,10 @@
+import { ASTNode, StringASTNode } from 'vscode-json-languageservice';
+import { isPropertyNode, isStringNode } from './node-types';
+
+export function isExecutorStringNode(node: ASTNode): node is StringASTNode {
+  return (
+    isStringNode(node) &&
+    isPropertyNode(node.parent) &&
+    node.parent.keyNode.value === 'executor'
+  );
+}

--- a/libs/language-server/workspace/src/lib/get-executors.ts
+++ b/libs/language-server/workspace/src/lib/get-executors.ts
@@ -1,4 +1,4 @@
-import { CollectionInfo } from '@nx-console/shared/schema';
+import { ExecutorCollectionInfo } from '@nx-console/shared/schema';
 import { readCollections } from './read-collections';
 
 export type GetExecutorsOptions = {
@@ -12,11 +12,14 @@ export async function getExecutors(
     includeHidden: false,
     clearPackageJsonCache: false,
   }
-): Promise<CollectionInfo[]> {
+): Promise<ExecutorCollectionInfo[]> {
   return (
     await readCollections(workspacePath, {
       clearPackageJsonCache: options.clearPackageJsonCache,
       includeHidden: options.includeHidden,
     })
-  ).filter((collection) => collection.type === 'executor');
+  ).filter(
+    (collection): collection is ExecutorCollectionInfo =>
+      collection.type === 'executor'
+  );
 }

--- a/libs/language-server/workspace/src/lib/get-generators.ts
+++ b/libs/language-server/workspace/src/lib/get-generators.ts
@@ -5,7 +5,11 @@ import {
   listFiles,
   readAndCacheJsonFile,
 } from '@nx-console/shared/file-system';
-import { CollectionInfo, GeneratorType } from '@nx-console/shared/schema';
+import {
+  CollectionInfo,
+  GeneratorCollectionInfo,
+  GeneratorType,
+} from '@nx-console/shared/schema';
 import { normalizeSchema } from '@nx-console/shared/schema/normalize';
 import { basename, join } from 'path';
 import { getCollectionInfo, readCollections } from './read-collections';
@@ -16,7 +20,7 @@ export async function getGenerators(
     includeHidden: false,
     includeNgAdd: false,
   }
-): Promise<CollectionInfo[]> {
+): Promise<GeneratorCollectionInfo[]> {
   const basedir = workspacePath;
   const collections = await readCollections(workspacePath, {
     clearPackageJsonCache: false,
@@ -33,7 +37,8 @@ export async function getGenerators(
     ...(await checkAndReadWorkspaceGenerators(basedir, 'generators', options)),
   ];
   return generatorCollections.filter(
-    (collection): collection is CollectionInfo => !!collection.data
+    (collection): collection is GeneratorCollectionInfo =>
+      collection.type === 'generator'
   );
 }
 
@@ -94,7 +99,7 @@ async function readWorkspaceGeneratorsCollection(
           return {
             name: collectionName,
             type: 'generator',
-            path: schemaJsonPath,
+            schemaPath: schemaJsonPath,
             data: {
               name,
               collection: collectionName,

--- a/libs/shared/json-schema/src/lib/create-builders-and-executors-schema.ts
+++ b/libs/shared/json-schema/src/lib/create-builders-and-executors-schema.ts
@@ -17,7 +17,9 @@ export function createBuildersAndExecutorsSchema(
   return collections.reduce<[BuildersSchema[], ExecutorsSchema[]]>(
     (acc, collection) => {
       const schemaRef =
-        platform() === 'win32' ? collection.path : `file://${collection.path}`;
+        platform() === 'win32'
+          ? collection.schemaPath
+          : `file://${collection.schemaPath}`;
 
       acc[0].push({
         if: {

--- a/libs/shared/schema/src/schema.ts
+++ b/libs/shared/schema/src/schema.ts
@@ -76,11 +76,28 @@ export interface TaskExecutionSchema {
   };
 }
 
-export interface CollectionInfo {
+export type CollectionInfo = GeneratorCollectionInfo | ExecutorCollectionInfo;
+
+export interface GeneratorCollectionInfo {
+  type: 'generator';
   name: string;
-  path: string;
-  type: 'executor' | 'generator';
+  /**
+   * The path to the file that lists all generators in the collection.
+   */
+  configPath: string;
+  schemaPath: string;
   data?: Generator;
+}
+
+export interface ExecutorCollectionInfo {
+  type: 'executor';
+  name: string;
+  /**
+   * The path to the file that lists all executors in the collection.
+   */
+  configPath: string;
+  schemaPath: string;
+  implementationPath: string;
 }
 
 export enum GeneratorType {

--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -176,7 +176,7 @@ async function executeInitGenerator(dependency: string, workspacePath: string) {
   const opts = await getGeneratorOptions({
     collection: initGenerator.data.collection,
     name: initGenerator.name,
-    path: initGenerator.path,
+    path: initGenerator.schemaPath,
   });
   let selectedFlags;
   if (opts.length) {

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-generator.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-generator.ts
@@ -36,7 +36,7 @@ export async function selectGenerator(
         label: `${generatorData.collection} - ${generatorData.name}`,
         generatorName: `${generatorData.collection}:${generatorData.name}`,
         collectionName: generatorData.collection,
-        collectionPath: collection.path,
+        collectionPath: collection.schemaPath,
         generator: generatorData,
       };
     });
@@ -157,7 +157,7 @@ export async function getGenerator(
       const options = await getGeneratorOptions({
         collection: generatorInfo.collection,
         name: generatorInfo.name,
-        path: foundGenerator.path,
+        path: foundGenerator.schemaPath,
       });
       return {
         collectionName: foundGenerator.data?.collection ?? '',

--- a/libs/vscode/nx-workspace/src/lib/get-generators.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-generators.ts
@@ -1,12 +1,12 @@
 import {
-  NxGeneratorsRequestOptions,
   NxGeneratorsRequest,
+  NxGeneratorsRequestOptions,
 } from '@nx-console/language-server/types';
-import { CollectionInfo } from '@nx-console/shared/schema';
+import { GeneratorCollectionInfo } from '@nx-console/shared/schema';
 import { sendRequest } from '@nx-console/vscode/lsp-client';
 
 export function getGenerators(
   options?: NxGeneratorsRequestOptions
-): Promise<CollectionInfo[]> {
+): Promise<GeneratorCollectionInfo[]> {
   return sendRequest(NxGeneratorsRequest, { options });
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "vscode-json-languageservice": "^5.1.0",
     "vscode-languageclient": "^8.0.2",
     "vscode-languageserver": "^8.0.2",
+    "vscode-uri": "^3.0.8",
     "xstate": "^4.32.1"
   },
   "devDependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,9 @@
       "@nx-console/language-server/capabilities/code-completion": [
         "libs/language-server/capabilities/code-completion/src/index.ts"
       ],
+      "@nx-console/language-server/capabilities/definition": [
+        "libs/language-server/capabilities/definition/src/index.ts"
+      ],
       "@nx-console/language-server/capabilities/document-links": [
         "libs/language-server/capabilities/document-links/src/index.ts"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -25208,6 +25208,7 @@ __metadata:
     vscode-json-languageservice: ^5.1.0
     vscode-languageclient: ^8.0.2
     vscode-languageserver: ^8.0.2
+    vscode-uri: ^3.0.8
     wdio-vscode-service: ^4.2.1
     webdriverio: ^7.26.0
     webpack: 5.88.2
@@ -32166,6 +32167,13 @@ __metadata:
   version: 3.0.6
   resolution: "vscode-uri@npm:3.0.6"
   checksum: 8b6a36553d089309c09f7aa2ca8dae321a1cb7ff5dcab35f0914d5155d3110722bdb6de67dcb727df15fecd83221d11bb4ab1274a9116b9ccc05b86cefe60dfc
+  languageName: node
+  linkType: hard
+
+"vscode-uri@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "vscode-uri@npm:3.0.8"
+  checksum: 514249126850c0a41a7d8c3c2836cab35983b9dc1938b903cfa253b9e33974c1416d62a00111385adcfa2b98df456437ab704f709a2ecca76a90134ef5eb4832
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implements the Go To Definition functionality requested in https://github.com/nrwl/nx-console/issues/1936 for VSCode

### Changes

1. Refactored `CollectionInfo` to a union type for better typing
2. Duplicated the `hover` package and changed references to `definition`
3. Implemented the `goToDefinition` capability 

### Testing

Verified that it worked in the nx repo and my own repo

https://github.com/nrwl/nx-console/assets/20645805/8c814979-3f9e-4b3c-ac42-8d0165f66c49

