### PR TITLE
feat(intellij): exclude .nx folder from js/ts service

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/ide/DotNxFolderExcludeContributor.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/ide/DotNxFolderExcludeContributor.kt
@@ -1,0 +1,11 @@
+package dev.nx.console.ide
+
+import com.intellij.javascript.library.exclude.JsExcludeContributor
+
+class DotNxFolderExcludeContributor : JsExcludeContributor() {
+    override val excludeFileOrDirName: String
+        get() = ".nx"
+
+    override val isDirectory: Boolean
+        get() = true
+}

--- a/apps/intellij/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij/src/main/resources/META-INF/plugin.xml
@@ -77,6 +77,9 @@
 
     <console.folding implementation="dev.nx.console.ide.ConsoleFolding"/>
   </extensions>
+  <extensions defaultExtensionNs="JavaScript">
+    <scanningFileListenerContributor implementation="dev.nx.console.ide.DotNxFolderExcludeContributor"/>
+  </extensions>
   <applicationListeners>
     <listener class="dev.nx.console.listeners.ProjectManagerListener"
               topic="com.intellij.openapi.project.ProjectManagerListener"/>
@@ -131,7 +134,7 @@
     >
       <add-to-group group-id="ProjectViewPopupMenuRunGroup"/>
     </action>
-    
+
     <action id="dev.nx.console.run.actions.NxRunAnythingAction" class="dev.nx.console.run.actions.NxRunAnythingAction"
             text="Nx: Run Anything" description="Run Nx targets in a CLI-like interface"
             icon="AllIcons.Actions.Run_anything"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,11 @@ pluginRepositoryUrl=https://github.com/nrwl/nx-console
 # SemVer format -> https://semver.org
 version=0.0.1
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild=223
+pluginSinceBuild=233
 pluginUntilBuild=*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IU
-platformVersion=2023.2
+platformVersion=2023.3
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=JavaScript, org.jetbrains.plugins.terminal


### PR DESCRIPTION
stuff in `.nx` isn't picked up anymore
![image](https://github.com/nrwl/nx-console/assets/34165455/e929f817-f768-432f-bd95-ff433fb43a61)

Bumps required version to `2023.3` (branch `233`)