### PR TITLE
fix(vscode): show pdv open to side button on all files that define a project

### DIFF
--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -20,6 +20,7 @@ import {
   NxProjectFolderTreeRequest,
   NxProjectGraphOutputRequest,
   NxProjectsByPathsRequest,
+  NxSourceMapFilesToProjectMapRequest,
   NxStartupMessageRequest,
   NxTransformedGeneratorSchemaRequest,
   NxVersionRequest,
@@ -47,6 +48,7 @@ import {
   getProjectFolderTree,
   getProjectGraphOutput,
   getProjectsByPaths,
+  getSourceMapFilesToProjectMap,
   getStartupMessage,
   getTransformedGeneratorSchema,
   hasAffectedProjects,
@@ -473,6 +475,13 @@ connection.onRequest(NxHasAffectedProjectsRequest, async () => {
     return new ResponseError(1000, 'Unable to get Nx info: no workspace path');
   }
   return hasAffectedProjects(WORKING_PATH, lspLogger);
+});
+
+connection.onRequest(NxSourceMapFilesToProjectMapRequest, async () => {
+  if (!WORKING_PATH) {
+    return new ResponseError(1000, 'Unable to get Nx info: no workspace path');
+  }
+  return getSourceMapFilesToProjectMap(WORKING_PATH);
 });
 
 connection.onNotification(NxWorkspaceRefreshNotification, async () => {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -207,7 +207,7 @@
         {
           "command": "nx.project-details.openToSide",
           "group": "navigation",
-          "when": "(resourceFilename === project.json || resourceFilename === package.json) && resourcePath not in nxConsole.ignoredPDVPaths && config.nxConsole.showProjectDetailsView"
+          "when": "resourcePath in nxConsole.pdvPaths && config.nxConsole.showProjectDetailsView"
         }
       ],
       "commandPalette": [

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -134,3 +134,9 @@ export const NxHasAffectedProjectsRequest: RequestType<
   boolean,
   unknown
 > = new RequestType('nx/hasAffectedProjects');
+
+export const NxSourceMapFilesToProjectMapRequest: RequestType<
+  undefined,
+  Record<string, string>,
+  unknown
+> = new RequestType('nx/sourceMapFilesToProjectMap');

--- a/libs/language-server/workspace/src/index.ts
+++ b/libs/language-server/workspace/src/index.ts
@@ -11,4 +11,5 @@ export * from './lib/create-project-graph';
 export * from './lib/get-project-folder-tree';
 export * from './lib/nx-console-plugins';
 export * from './lib/has-affected-projects';
+export * from './lib/get-source-map';
 export { getNxDaemonClient } from './lib/get-nx-workspace-package';

--- a/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
@@ -19,7 +19,8 @@ import {
 import { performance } from 'perf_hooks';
 
 let projectGraph: ProjectGraph | null = null;
-let sourceMaps: Record<string, Record<string, string[]>> | null = null;
+let sourceMaps: Record<string, Record<string, string[]>> | undefined =
+  undefined;
 
 export async function getNxWorkspaceConfig(
   workspacePath: string,
@@ -116,7 +117,8 @@ export async function getNxWorkspaceConfig(
     workspaceConfiguration = createNxWorkspaceConfiguration(
       workspaceConfiguration,
       projectGraph,
-      projectFileMap
+      projectFileMap,
+      sourceMaps
     );
 
     // for (const project in workspaceConfiguration.projects) {

--- a/libs/language-server/workspace/src/lib/get-source-map.ts
+++ b/libs/language-server/workspace/src/lib/get-source-map.ts
@@ -1,0 +1,24 @@
+import { lspLogger } from '@nx-console/language-server/utils';
+import { nxWorkspace } from './workspace';
+
+/**
+ * iterate over sourcemaps and return all files that were involved in creating a project along with the project name
+ */
+export async function getSourceMapFilesToProjectMap(
+  workingPath: string
+): Promise<Record<string, string>> {
+  const { workspace } = await nxWorkspace(workingPath);
+  const sourceMapFilesToProjectMap: Record<string, string> = {};
+
+  Object.entries(workspace.sourceMaps ?? {}).forEach(
+    ([projectName, sourceMap]) => {
+      Object.values(sourceMap).forEach(([file]) => {
+        if (!sourceMapFilesToProjectMap[file]) {
+          sourceMapFilesToProjectMap[file] = projectName;
+        }
+      });
+    }
+  );
+
+  return sourceMapFilesToProjectMap;
+}

--- a/libs/vscode/nx-workspace/src/index.ts
+++ b/libs/vscode/nx-workspace/src/index.ts
@@ -12,3 +12,4 @@ export * from './lib/create-project-graph';
 export * from './lib/get-project-folder-tree';
 export * from './lib/nx-console-plugin-requests';
 export * from './lib/has-affected-projects';
+export * from './lib/get-source-map';

--- a/libs/vscode/nx-workspace/src/lib/get-source-map.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-source-map.ts
@@ -1,0 +1,8 @@
+import { NxSourceMapFilesToProjectMapRequest } from '@nx-console/language-server/types';
+import { sendRequest } from '@nx-console/vscode/lsp-client';
+
+export async function getSourceMapFilesToProjectMap(): Promise<
+  Record<string, string>
+> {
+  return sendRequest(NxSourceMapFilesToProjectMapRequest, undefined);
+}

--- a/libs/vscode/project-details/src/lib/project-details-manager.ts
+++ b/libs/vscode/project-details/src/lib/project-details-manager.ts
@@ -27,8 +27,9 @@ export class ProjectDetailsManager {
     document: TextDocument,
     expandedTarget?: string
   ) {
-    const project = await getProjectNameFromUri(document);
+    const project = await getProjectByPath(document.uri.path);
     if (!project) {
+      showNoProjectAtPathMessage(document.uri.path);
       return;
     }
 
@@ -50,53 +51,4 @@ export class ProjectDetailsManager {
 
     preview.reveal(ViewColumn.Beside);
   }
-}
-
-async function getProjectNameFromUri(
-  document: TextDocument
-): Promise<{ name?: string; root: string } | undefined> {
-  if (document.fileName.endsWith('project.json')) {
-    try {
-      JSON.parse(document.getText());
-    } catch (e) {
-      window.showErrorMessage(
-        `Error parsing ${document.fileName}. Please make sure the JSON is valid. `
-      );
-      return;
-    }
-    const json = parseJsonText(document.fileName, document.getText());
-
-    const properties = getProperties(json.statements[0].expression);
-
-    let name: string | undefined = undefined;
-    const nameProperty = properties?.find(
-      (prop) => getPropertyName(prop) === 'name'
-    );
-
-    if (
-      nameProperty &&
-      isPropertyAssignment(nameProperty) &&
-      isStringLiteral(nameProperty.initializer)
-    ) {
-      name = nameProperty.initializer.text;
-    }
-    const sourceRootProperty = properties?.find(
-      (prop) => getPropertyName(prop) === 'sourceRoot'
-    );
-    if (
-      sourceRootProperty &&
-      isPropertyAssignment(sourceRootProperty) &&
-      isStringLiteral(sourceRootProperty.initializer)
-    ) {
-      return {
-        root: sourceRootProperty.initializer.text,
-        name,
-      };
-    }
-  }
-  const project = await getProjectByPath(document.uri.path);
-  if (!project) {
-    showNoProjectAtPathMessage(document.uri.path);
-  }
-  return;
 }


### PR DESCRIPTION
Any file that contributes to a project will get a `Open PDV to Side` button (before just project.json & package.json).
In order to include all `package.json` files as a natural entry point, all `package.json` files that are siblings of a file that contributes to a project also get the same button.