### PR TITLE
fix(vscode): improve broken project graph error handling across the board

### DIFF
--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -52,13 +52,13 @@ import {
   getProjectsByPaths,
   getSourceMapFilesToProjectMap,
   getStartupMessage,
+  getTargetsForConfigFile,
   getTransformedGeneratorSchema,
   hasAffectedProjects,
-  resetNxVersionCache,
   nxWorkspace,
+  resetNxVersionCache,
   resetProjectPathCache,
   resetSourceMapFilesToProjectCache,
-  getTargetsForConfigFile,
 } from '@nx-console/language-server/workspace';
 import { GeneratorSchema } from '@nx-console/shared/generate-ui-types';
 import { TaskExecutionSchema } from '@nx-console/shared/schema';
@@ -67,8 +67,6 @@ import { dirname, relative } from 'node:path';
 import {
   ClientCapabilities,
   CompletionList,
-  PropertyASTNode,
-  StringASTNode,
   TextDocument,
 } from 'vscode-json-languageservice';
 import {

--- a/libs/language-server/watcher/src/lib/watcher.ts
+++ b/libs/language-server/watcher/src/lib/watcher.ts
@@ -22,6 +22,8 @@ const NX_PLUGIN_PATTERNS_TO_WATCH = [
   '**/webpack.config.{js,ts,mjs,cjs}',
   '**/jest.preset.js',
   '**/tsconfig.*.json',
+  // nx-dotnet
+  '*{.csproj,fsproj,vbproj}',
 ];
 
 export async function languageServerWatcher(

--- a/libs/language-server/watcher/src/lib/watcher.ts
+++ b/libs/language-server/watcher/src/lib/watcher.ts
@@ -6,6 +6,23 @@ import { getNxVersion } from '@nx-console/language-server/workspace';
 import { gte } from 'semver';
 import type { WatchEvent } from 'nx/src/native';
 import { debounce } from '@nx-console/shared/utils';
+import { minimatch } from 'minimatch';
+
+const NX_PLUGIN_PATTERNS_TO_WATCH = [
+  '**/cypress.config.{js,ts,mjs,cjs}',
+  '**/{detox.config,.detoxrc}.{json,js}',
+  '**/app.{json,config.js}',
+  '**/jest.config.{cjs,mjs,js,cts,mts,ts}',
+  '**/next.config.{js,cjs,mjs}',
+  '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
+  '**/playwright.config.{js,ts,cjs,cts,mjs,mts}',
+  '**/remix.config.{js,cjs,mjs}',
+  '**/.storybook/main.{js,ts,mjs,mts,cjs,cts}',
+  '**/{vite,vitest}.config.{js,ts,mjs,mts,cjs,cts}',
+  '**/webpack.config.{js,ts,mjs,cjs}',
+  '**/jest.preset.js',
+  '**/tsconfig.*.json',
+];
 
 export async function languageServerWatcher(
   workspacePath: string,
@@ -26,7 +43,10 @@ export async function languageServerWatcher(
             e.path.endsWith('package.json') ||
             e.path.endsWith('nx.json') ||
             e.path.endsWith('workspace.json') ||
-            e.path.endsWith('tsconfig.base.json')
+            e.path.endsWith('tsconfig.base.json') ||
+            NX_PLUGIN_PATTERNS_TO_WATCH.some((pattern) =>
+              minimatch(e.path, pattern, { dot: true })
+            )
         )
       ) {
         lspLogger.log('Project configuration changed');

--- a/libs/language-server/watcher/src/lib/watcher.ts
+++ b/libs/language-server/watcher/src/lib/watcher.ts
@@ -31,10 +31,12 @@ export async function languageServerWatcher(
   callback: () => unknown
 ): Promise<() => void> {
   const version = await getNxVersion(workspacePath);
+  const debouncedCallback = debounce(callback, 500);
 
   if (gte(version.version, '16.4.0')) {
     const native = await import('nx/src/native');
     const watcher = new native.Watcher(workspacePath);
+
     watcher.watch((err: string | null, events: WatchEvent[]) => {
       if (err) {
         lspLogger.log('Error watching files: ' + err);
@@ -52,7 +54,7 @@ export async function languageServerWatcher(
         )
       ) {
         lspLogger.log('Project configuration changed');
-        debounce(callback, 500)();
+        debouncedCallback();
       }
     });
 
@@ -77,7 +79,7 @@ export async function languageServerWatcher(
           )
         ) {
           lspLogger.log('Project configuration changed');
-          debounce(callback, 500)();
+          debouncedCallback();
         }
       },
       watcherOptions(workspacePath)

--- a/libs/language-server/workspace/src/lib/workspace.ts
+++ b/libs/language-server/workspace/src/lib/workspace.ts
@@ -15,6 +15,7 @@ import {
 import { getNxWorkspaceConfig } from './get-nx-workspace-config';
 import { NxWorkspace } from '@nx-console/shared/types';
 import { getNxVersion } from './get-nx-version';
+import { lspLogger } from '@nx-console/language-server/utils';
 
 const enum Status {
   not_started,
@@ -83,6 +84,7 @@ async function _workspace(
         appsDir: config.workspaceConfiguration.workspaceLayout?.appsDir,
         libsDir: config.workspaceConfiguration.workspaceLayout?.libsDir,
       },
+      error: config.error,
       nxVersion: {
         major: version.major,
         minor: version.minor,

--- a/libs/shared/types/src/lib/nx-workspace.ts
+++ b/libs/shared/types/src/lib/nx-workspace.ts
@@ -31,6 +31,7 @@ export interface NxWorkspace {
   isLerna: boolean;
   nxVersion: NxVersion;
   isEncapsulatedNx: boolean;
+  error?: string;
   workspaceLayout: {
     appsDir?: string;
     libsDir?: string;

--- a/libs/vscode/lsp-client/src/lib/refresh-workspace.ts
+++ b/libs/vscode/lsp-client/src/lib/refresh-workspace.ts
@@ -1,5 +1,5 @@
 import { NxWorkspaceRefreshNotification } from '@nx-console/language-server/types';
-import { commands, EventEmitter, ExtensionContext } from 'vscode';
+import { commands, Disposable, EventEmitter, ExtensionContext } from 'vscode';
 import { sendNotification } from './configure-lsp-client';
 
 export const REFRESH_WORKSPACE = 'nxConsole.refreshWorkspace';
@@ -14,8 +14,8 @@ function handleVSCodeRefresh() {
   sendNotification(NxWorkspaceRefreshNotification);
 }
 
-export function onWorkspaceRefreshed(callback: () => void) {
-  refreshedEventEmitter.event(callback);
+export function onWorkspaceRefreshed(callback: () => void): Disposable {
+  return refreshedEventEmitter.event(callback);
 }
 
 /**

--- a/libs/vscode/project-details/src/lib/config-file-codelens-provider.ts
+++ b/libs/vscode/project-details/src/lib/config-file-codelens-provider.ts
@@ -6,6 +6,7 @@ import {
   getTargetsForConfigFile,
 } from '@nx-console/vscode/nx-workspace';
 import { CliTaskProvider } from '@nx-console/vscode/tasks';
+import { getTelemetry } from '@nx-console/vscode/utils';
 import { relative } from 'path';
 import {
   Node,
@@ -217,6 +218,7 @@ export class ConfigFileCodelensProvider implements CodeLensProvider {
       commands.registerCommand(
         CODELENS_RUN_TARGET_COMMAND,
         (project: string, target: string) => {
+          getTelemetry().featureUsed('nx.config-file-codelens.run-target');
           CliTaskProvider.instance.executeTask({
             command: 'run',
             positional: `${project}:${target}`,
@@ -233,6 +235,11 @@ export class ConfigFileCodelensProvider implements CodeLensProvider {
         projectName: string,
         fileName: string
       ) => {
+        getTelemetry().featureUsed(
+          'nx.config-file-codelens.run-target-quickpick',
+          { fileName }
+        );
+
         if (targets.length === 0) {
           window
             .showErrorMessage(

--- a/libs/vscode/project-details/src/lib/init-vscode-project-details.ts
+++ b/libs/vscode/project-details/src/lib/init-vscode-project-details.ts
@@ -5,7 +5,10 @@ import {
   getProjectByPath,
   getSourceMapFilesToProjectMap,
 } from '@nx-console/vscode/nx-workspace';
-import { showNoProjectAtPathMessage } from '@nx-console/vscode/utils';
+import {
+  getTelemetry,
+  showNoProjectAtPathMessage,
+} from '@nx-console/vscode/utils';
 import { dirname, join } from 'path';
 import { gte } from 'semver';
 import {
@@ -77,6 +80,8 @@ function getNxVersionAndRegisterCommand(context: ExtensionContext) {
           'showProjectDetailsView'
         );
         if (!isEnabled) return;
+
+        getTelemetry().featureUsed('nx.open-pdv');
         const uri = window.activeTextEditor?.document.uri;
         if (!uri) return;
         const project = await getProjectByPath(uri.path);

--- a/libs/vscode/project-details/src/lib/project-details-codelens-provider.ts
+++ b/libs/vscode/project-details/src/lib/project-details-codelens-provider.ts
@@ -8,6 +8,7 @@ import {
   getProjectByPath,
 } from '@nx-console/vscode/nx-workspace';
 import { CliTaskProvider } from '@nx-console/vscode/tasks';
+import { getTelemetry } from '@nx-console/vscode/utils';
 import { ProjectConfiguration } from 'nx/src/devkit-exports';
 import { JsonSourceFile, parseJsonText } from 'typescript';
 import {
@@ -68,7 +69,7 @@ export class ProjectDetailsCodelensProvider implements CodeLensProvider {
         return {
           ...codeLens,
           command: {
-            command: 'nxConsole.error',
+            command: 'nx.project-details.openToSide',
             title: `$(error) Project graph computation failed. Click to see Details.`,
           },
         };
@@ -141,6 +142,7 @@ export class ProjectDetailsCodelensProvider implements CodeLensProvider {
 }
 
 function showProjectDetailsQuickpick(project: ProjectConfiguration) {
+  getTelemetry().featureUsed('nx.open-project-details-codelens');
   const quickPick = window.createQuickPick();
   const targetItems: QuickPickItem[] = Object.entries(
     project.targets ?? {}

--- a/libs/vscode/project-details/src/lib/project-details-manager.ts
+++ b/libs/vscode/project-details/src/lib/project-details-manager.ts
@@ -12,28 +12,41 @@ export class ProjectDetailsManager {
     document: TextDocument,
     expandedTarget?: string
   ) {
-    const project = await getProjectByPath(document.uri.path);
-    if (!project) {
-      showNoProjectAtPathMessage(document.uri.path);
-      return;
-    }
+    const path = document.uri.path;
+    let preview = await this.findMatchingPreview(path);
 
-    let preview = this.previews.get(project.root);
     if (!preview) {
-      if (!project.name) {
-        return;
-      }
-      preview = new ProjectDetailsPreview(
-        project.name,
-        this.context,
-        expandedTarget
-      );
+      preview = new ProjectDetailsPreview(path, this.context, expandedTarget);
       preview.onDispose(() => {
-        this.previews.delete(project.root);
+        this.previews.delete(path);
       });
-      this.previews.set(project.root, preview);
+      this.previews.set(path, preview);
     }
 
     preview.reveal(ViewColumn.Beside);
+  }
+
+  private async findMatchingPreview(
+    path: string
+  ): Promise<ProjectDetailsPreview | undefined> {
+    console.log(
+      'getting preview for',
+      path,
+      Array.from(this.previews.entries()).map((p) => ({
+        path: p[0],
+        root: p[1].projectRoot,
+      }))
+    );
+    const directMatch = this.previews.get(path);
+    if (directMatch) return directMatch;
+
+    const projectRoot = (await getProjectByPath(path))?.root;
+    if (!projectRoot) return;
+
+    for (const [, preview] of this.previews) {
+      if (preview.projectRoot === projectRoot) return preview;
+    }
+
+    return;
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "graphql-request": "^5.0.0",
     "jsonc-parser": "^3.0.0",
     "lit": "^2.4.1",
+    "minimatch": "^9.0.3",
     "request-light": "^0.5.8",
     "rxjs": "7.5.6",
     "semver": "^7.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25184,6 +25184,7 @@ __metadata:
     jsonc-parser: ^3.0.0
     lit: ^2.4.1
     memfs: ^3.4.7
+    minimatch: ^9.0.3
     mocha: ^10.0.0
     nx: 17.1.0-beta.4
     ovsx: ^0.7.1


### PR DESCRIPTION
- propagate workspace error & reload codelenses
- better error handling
- don't fall back on deprecated readWorkspaceConfig from 17.3 onwards
- PDV preview can start without knowing the project by path
