### PR TITLE
fix(intellij): fix generate ui

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateRunAnythingProvider.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateRunAnythingProvider.kt
@@ -127,7 +127,7 @@ class NxGenerateRunAnythingProvider : RunAnythingCommandLineProvider() {
                         NxGeneratorOptionsRequestOptions(
                             collection = generator.data.collection,
                             name = generator.data.name,
-                            path = generator.path
+                            path = generator.schemaPath
                         )
                     )
             }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
@@ -120,7 +120,7 @@ class NxGenerateService(val project: Project) {
                         NxGeneratorOptionsRequestOptions(
                             generator.data.collection,
                             generator.data.name,
-                            generator.path
+                            generator.schemaPath
                         )
                     )
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/models/NxGenerator.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/models/NxGenerator.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class NxGenerator(
     val name: String,
-    val path: String,
+    val schemaPath: String,
     val data: NxGeneratorData,
     val options: List<NxGeneratorOption>?,
     val contextValues: NxGeneratorContext?,
@@ -14,7 +14,7 @@ data class NxGenerator(
         generator: NxGenerator,
         options: List<NxGeneratorOption>? = generator.options,
         contextValues: NxGeneratorContext? = generator.contextValues
-    ) : this(generator.name, generator.path, generator.data, options, contextValues) {}
+    ) : this(generator.name, generator.schemaPath, generator.data, options, contextValues) {}
 }
 
 @Serializable


### PR DESCRIPTION
## Current behaviour
Trying to launch the generate ui fails to open. This is because the schema changed from the language server, which caused the `NxGenerator` data class in the kotlin side to serialize with missing data

## Expected behaviour
The `NxGenerator` data class now has the same property name as the nxls, which will allow proper serialization and open the generate ui window 