### PR TITLE
fix(intellij): fix freeze

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/ide/project_json_inspection/AnalyzeNxConfigurationFilesAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/ide/project_json_inspection/AnalyzeNxConfigurationFilesAction.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.CodeSmellDetector
+import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import dev.nx.console.utils.Notifier
 import dev.nx.console.utils.findNxConfigurationFiles
 
@@ -25,9 +26,13 @@ class AnalyzeNxConfigurationFilesNotificationAction :
     }
 }
 
+@Suppress("UnstableApiUsage")
 fun checkForCodeSmells(project: Project) {
+    val files = runWithModalProgressBlocking(project, "Find configuration files") {
+        findNxConfigurationFiles(project)
+    }
     val codeSmellDetector = CodeSmellDetector.getInstance(project)
-    val codeSmells = codeSmellDetector.findCodeSmells(findNxConfigurationFiles(project))
+    val codeSmells = codeSmellDetector.findCodeSmells(files)
     if (codeSmells.size == 0) {
         Notifier.notifyAnything(
             project,
@@ -37,3 +42,4 @@ fun checkForCodeSmells(project: Project) {
         codeSmellDetector.showCodeSmellErrors(codeSmells)
     }
 }
+

--- a/apps/intellij/src/main/kotlin/dev/nx/console/ide/project_json_inspection/AnalyzeNxConfigurationFilesAction.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/ide/project_json_inspection/AnalyzeNxConfigurationFilesAction.kt
@@ -28,9 +28,10 @@ class AnalyzeNxConfigurationFilesNotificationAction :
 
 @Suppress("UnstableApiUsage")
 fun checkForCodeSmells(project: Project) {
-    val files = runWithModalProgressBlocking(project, "Find configuration files") {
-        findNxConfigurationFiles(project)
-    }
+    val files =
+        runWithModalProgressBlocking(project, "Find configuration files") {
+            findNxConfigurationFiles(project)
+        }
     val codeSmellDetector = CodeSmellDetector.getInstance(project)
     val codeSmells = codeSmellDetector.findCodeSmells(files)
     if (codeSmells.size == 0) {
@@ -42,4 +43,3 @@ fun checkForCodeSmells(project: Project) {
         codeSmellDetector.showCodeSmellErrors(codeSmells)
     }
 }
-

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/FindNxConfigurationFiles.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/FindNxConfigurationFiles.kt
@@ -1,15 +1,19 @@
 package dev.nx.console.utils
 
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileVisitor
 
-fun findNxConfigurationFiles(project: Project, includeNxJson: Boolean = true): List<VirtualFile> {
+suspend fun findNxConfigurationFiles(
+    project: Project,
+    includeNxJson: Boolean = true
+): List<VirtualFile> {
     val paths: MutableList<VirtualFile> = ArrayList()
-    ReadAction.run<RuntimeException> {
+    readAction {
         val startDirectory = LocalFileSystem.getInstance().findFileByPath(project.nxBasePath)
         if (startDirectory != null) {
             VfsUtilCore.visitChildrenRecursively(
@@ -23,6 +27,7 @@ fun findNxConfigurationFiles(project: Project, includeNxJson: Boolean = true): L
                         ) {
                             paths.add(file)
                         }
+                        ProgressManager.checkCanceled()
                         return true
                     }
                 }


### PR DESCRIPTION
Fixes freeze with a following stack trace:
```
"DefaultDispatcher-worker-1" prio=0 tid=0x0 nid=0x0 runnable
     java.lang.Thread.State: RUNNABLE
 (in native)
	at java.base@17.0.10/sun.nio.fs.UnixNativeDispatcher.lstat0(Native Method)
	at java.base@17.0.10/sun.nio.fs.UnixNativeDispatcher.lstat(UnixNativeDispatcher.java:308)
	at java.base@17.0.10/sun.nio.fs.UnixFileAttributes.get(UnixFileAttributes.java:72)
	at java.base@17.0.10/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:52)
	at java.base@17.0.10/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:148)
	at java.base@17.0.10/java.nio.file.Files.readAttributes(Files.java:1851)
	at com.intellij.openapi.util.io.NioFiles.readAttributes(NioFiles.java:187)
	at com.intellij.util.io.PlatformNioHelper.visitDirectory(PlatformNioHelper.java:54)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemImpl.listWithAttributes(LocalFileSystemImpl.java:307)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemImpl.lambda$new$0(LocalFileSystemImpl.java:49)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemImpl$$Lambda$800/0x00000008008f3930.apply(Unknown Source)
	at com.intellij.openapi.vfs.DiskQueryRelay.accessDiskWithCheckCanceled(DiskQueryRelay.java:45)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemImpl.listWithCaching(LocalFileSystemImpl.java:274)
	at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.persistAllChildren(PersistentFSImpl.java:349)
	at com.intellij.openapi.vfs.newvfs.persistent.PersistentFSImpl.listAll(PersistentFSImpl.java:416)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.loadAllChildren(VirtualDirectoryImpl.java:411)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl.getChildren(VirtualDirectoryImpl.java:404)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:313)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at com.intellij.openapi.vfs.VfsUtilCore.visitChildrenRecursively(VfsUtilCore.java:334)
	at dev.nx.console.utils.FindNxConfigurationFilesKt.findNxConfigurationFiles$lambda$0(FindNxConfigurationFiles.kt:15)
	at dev.nx.console.utils.FindNxConfigurationFilesKt$$Lambda$2814/0x00000008018d8c58.run(Unknown Source)
	at com.intellij.openapi.application.ReadAction.lambda$run$1(ReadAction.java:53)
	at com.intellij.openapi.application.ReadAction$$Lambda$1809/0x0000000801309860.compute(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:909)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:65)
	at com.intellij.openapi.application.ReadAction.run(ReadAction.java:52)
	at dev.nx.console.utils.FindNxConfigurationFilesKt.findNxConfigurationFiles(FindNxConfigurationFiles.kt:12)
	at dev.nx.console.utils.NxProjectJsonToProjectMap.populateMap(NxProjectJsonToProjectMap.kt:43)
	at dev.nx.console.utils.NxProjectJsonToProjectMap.access$populateMap(NxProjectJsonToProjectMap.kt:14)
	at dev.nx.console.utils.NxProjectJsonToProjectMap$init$1.invokeSuspend(NxProjectJsonToProjectMap.kt:19)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
```