### PR TITLE
chore: set up @nx/cypress/plugin

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -40,7 +40,7 @@ jobs:
           npx nx-cloud record -- ./gradlew ktfmtCheck
         env:
           NX_CLOUD_DISTRIBUTED_EXECUTION: false
-      - run: yarn nx affected --t=lint,test,build,e2e --configuration=ci --exclude=nx-console --verbose
+      - run: yarn nx affected --t=lint,test,build,e2e,e2e-ci --configuration=ci --exclude=nx-console --verbose
   main-windows:
     name: Main Windows
     runs-on: windows-latest

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -79,5 +79,5 @@ jobs:
           java-version: 17
           cache: gradle
       # there's no need to check formatting & linting again on windows
-      - run: yarn nx affected --t=test,build,e2e --configuration=ci --exclude=nx-console --verbose
+      - run: yarn nx affected --t=test,build,e2e,e2e-ci --configuration=ci --exclude=nx-console --verbose
         timeout-minutes: 45

--- a/apps/generate-ui-v2-e2e/cypress.config.ts
+++ b/apps/generate-ui-v2-e2e/cypress.config.ts
@@ -2,7 +2,14 @@ import { defineConfig } from 'cypress';
 import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
 
 export default defineConfig({
-  e2e: nxE2EPreset(__dirname, {
-    bundler: 'vite',
-  }),
+  e2e: {
+    ...nxE2EPreset(__dirname, {
+      bundler: 'vite',
+      webServerCommands: {
+        default: 'nx run generate-ui-v2-e2e:serve',
+      },
+      ciWebServerCommand: 'nx run generate-ui-v2-e2e:serve',
+    }),
+    baseUrl: 'http://localhost:4200',
+  },
 });

--- a/apps/generate-ui-v2-e2e/project.json
+++ b/apps/generate-ui-v2-e2e/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "apps/generate-ui-v2-e2e/src",
   "projectType": "application",
   "targets": {
-    "e2e": {
+    "e2e-local": {
       "options": {
         "browser": "chrome"
       }

--- a/apps/generate-ui-v2-e2e/project.json
+++ b/apps/generate-ui-v2-e2e/project.json
@@ -5,19 +5,8 @@
   "projectType": "application",
   "targets": {
     "e2e": {
-      "executor": "@nx/cypress:cypress",
       "options": {
-        "cypressConfig": "apps/generate-ui-v2-e2e/cypress.config.ts",
-        "devServerTarget": "generate-ui-v2-e2e:serve",
-        "testingType": "e2e",
-        "baseUrl": "http://localhost:4200",
         "browser": "chrome"
-      },
-      "configurations": {
-        "watch": {
-          "watch": true,
-          "headed": true
-        }
       }
     },
     "serve": {

--- a/nx.json
+++ b/nx.json
@@ -114,6 +114,14 @@
       "options": {
         "targetName": "test"
       }
+    },
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "targetName": "e2e",
+        "openTargetName": "open-cypress",
+        "ciTargetName": "e2e-ci"
+      }
     }
   ],
   "defaultBase": "master"

--- a/nx.json
+++ b/nx.json
@@ -118,7 +118,7 @@
     {
       "plugin": "@nx/cypress/plugin",
       "options": {
-        "targetName": "e2e",
+        "targetName": "e2e-local",
         "openTargetName": "open-cypress",
         "ciTargetName": "e2e-ci"
       }


### PR DESCRIPTION
Sets up `@nx/cypress/plugin`:

- with task splitting
- keeping the exact same options for the `e2e` task
- the `watch` configuration becomes the `open-cypress` task