### PR TITLE
fix(intellij): set re/move dialog input field width to fill

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxReMoveProjectDialog.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxReMoveProjectDialog.kt
@@ -83,6 +83,7 @@ class NxReMoveProjectDialog(
                                                 model::project.toMutableProperty()
                                             )
                                             .comment(getShortcutHint())
+                                            .align(AlignX.FILL)
 
                                         addDocumentListener(
                                             object : BulkAwareDocumentListener.Simple {
@@ -146,6 +147,7 @@ class NxReMoveProjectDialog(
             callback()
         }
     }
+
     private fun getShortcutHint(): String {
         return "Use ${
           KeymapUtil.getFirstKeyboardShortcutText(


### PR DESCRIPTION
fixes https://github.com/nrwl/nx-console/issues/2104
before: 
<img width="420" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/65242b2f-4ce6-4031-801c-773666c04567">

after:
<img width="423" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/755b78fa-d089-4883-8715-6ecf3df1c19a">

