### PR TITLE
fix(nxls): filter all paths that include a cache folder

### DIFF
--- a/libs/language-server/watcher/src/lib/daemon-watcher.ts
+++ b/libs/language-server/watcher/src/lib/daemon-watcher.ts
@@ -95,8 +95,8 @@ export class DaemonWatcher {
                 data?.changedFiles?.filter((f) => {
                   const normalized = normalize(f.path);
                   return !(
-                    normalized.startsWith(normalize('.yarn/cache')) ||
-                    normalized.startsWith(normalize('.nx/cache'))
+                    normalized.includes(normalize('.yarn/cache')) ||
+                    normalized.includes(normalize('.nx/cache'))
                   );
                 }) ?? [];
               if (filteredChangedFiles.length === 0) {


### PR DESCRIPTION
there are versions of nx which contain bugs where the daemon triggers a change even if the contents of `.nx/cache` are changes. This leads to infinite loops in Nx Console, which rebuild the project graph on change.
These are now filtered out - the daemon returns absolute paths here.