### PR TITLE
feat(intellij): autofocus first empty text field in re/move dialog

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxReMoveProjectDialog.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxReMoveProjectDialog.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.TextFieldWithAutoCompletion
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.*
+import com.intellij.util.applyIf
 import dev.nx.console.models.NxGeneratorContext
 import dev.nx.console.models.WorkspaceLayout
 import java.awt.event.ActionEvent
@@ -84,7 +85,11 @@ class NxReMoveProjectDialog(
                                             )
                                             .comment(getShortcutHint())
                                             .align(AlignX.FILL)
-                                            .focused()
+                                            .applyIf(
+                                                reMoveGeneratorContext?.project.isNullOrEmpty()
+                                            ) {
+                                                focused()
+                                            }
 
                                         addDocumentListener(
                                             object : BulkAwareDocumentListener.Simple {
@@ -116,7 +121,13 @@ class NxReMoveProjectDialog(
                             updateDestinationDirHint(model.project)
 
                             destinationField =
-                                textField().bindText(model::directory).align(AlignX.FILL).component
+                                textField()
+                                    .bindText(model::directory)
+                                    .align(AlignX.FILL)
+                                    .applyIf(!reMoveGeneratorContext?.project.isNullOrEmpty()) {
+                                        focused()
+                                    }
+                                    .component
                         }
                         .visible(mode == "move")
                         .layout(RowLayout.PARENT_GRID)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxReMoveProjectDialog.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxReMoveProjectDialog.kt
@@ -84,6 +84,7 @@ class NxReMoveProjectDialog(
                                             )
                                             .comment(getShortcutHint())
                                             .align(AlignX.FILL)
+                                            .focused()
 
                                         addDocumentListener(
                                             object : BulkAwareDocumentListener.Simple {


### PR DESCRIPTION
The project text field is focused by default when the re/move project dialog is opened. This improves UX because the user doesn't have to move the focus to the project field manually.

Before:
<img width="450" alt="Screenshot 2024-05-09 at 20 35 03" src="https://github.com/nrwl/nx-console/assets/6420535/f03a5291-9e38-4176-b824-72447f8015d7">

After:
<img width="450" alt="Screenshot 2024-05-09 at 20 35 51" src="https://github.com/nrwl/nx-console/assets/6420535/556379eb-473c-4391-b7df-43ee16838006">

When the project is prefilled then the destination text box is focused instead:
<img width="450" alt="image" src="https://github.com/nrwl/nx-console/assets/6420535/e81d71d2-ee34-4db3-8f49-168019392fe0">
