### PR TITLE
fix: `npmDependencies` returns dependencies from `.nx/installation/node_modules` if `node_modules` is a file

### DIFF
--- a/libs/shared/file-system/src/index.ts
+++ b/libs/shared/file-system/src/index.ts
@@ -5,4 +5,5 @@ export { readAndCacheJsonFile } from './lib/cache-json';
 export { clearJsonCache } from './lib/cache-json';
 export { readAndParseJson } from './lib/cache-json';
 export { listFiles } from './lib/list-files';
+export { readDirectory } from './lib/read-directory';
 export { readFile } from './lib/read-file';

--- a/libs/shared/file-system/src/lib/read-directory.ts
+++ b/libs/shared/file-system/src/lib/read-directory.ts
@@ -1,0 +1,9 @@
+import { readdir } from 'fs/promises';
+
+export async function readDirectory(path: string): Promise<string[]> {
+  try {
+    return readdir(path);
+  } catch {
+    return [];
+  }
+}

--- a/libs/shared/npm/src/lib/npm-dependencies.spec.ts
+++ b/libs/shared/npm/src/lib/npm-dependencies.spec.ts
@@ -80,4 +80,26 @@ describe('npmDependencies', () => {
       'workspace/node_modules/package-bar',
     ]);
   });
+
+  it('should return scoped packages starting with @', async () => {
+    jest
+      .mocked(directoryExists)
+      .mockImplementation((filePath) =>
+        Promise.resolve(
+          [
+            'workspace/node_modules',
+            'workspace/node_modules/@scope',
+            'workspace/.nx/installation/node_modules',
+          ].includes(filePath)
+        )
+      );
+    jest
+      .mocked(readDirectory)
+      .mockResolvedValueOnce(['@scope'])
+      .mockResolvedValueOnce(['package-foo']);
+
+    expect(await npmDependencies('workspace')).toEqual([
+      'workspace/node_modules/@scope/package-foo',
+    ]);
+  });
 });

--- a/libs/shared/npm/src/lib/npm-dependencies.spec.ts
+++ b/libs/shared/npm/src/lib/npm-dependencies.spec.ts
@@ -1,0 +1,83 @@
+import { npmDependencies } from './npm-dependencies';
+import { directoryExists, readDirectory } from '@nx-console/shared/file-system';
+
+jest.mock('@nx-console/shared/file-system');
+
+describe('npmDependencies', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return no dependencies if `node_modules` and `.nx/installation/node_modules` do not exist', async () => {
+    jest.mocked(directoryExists).mockResolvedValue(false);
+
+    expect(await npmDependencies('workspace')).toEqual([]);
+  });
+
+  it('should return dependencies from `node_modules` if `node_modules` exists', async () => {
+    jest
+      .mocked(directoryExists)
+      .mockImplementation((filePath) =>
+        Promise.resolve(
+          [
+            'workspace/node_modules',
+            'workspace/node_modules/package-foo',
+            'workspace/node_modules/package-bar',
+          ].includes(filePath)
+        )
+      );
+    jest
+      .mocked(readDirectory)
+      .mockResolvedValue(['package-foo', 'package-bar']);
+
+    expect(await npmDependencies('workspace')).toEqual([
+      'workspace/node_modules/package-foo',
+      'workspace/node_modules/package-bar',
+    ]);
+  });
+
+  it('should return dependencies from `.nx/installation/node_modules` if only `.nx/installation/node_modules` exists', async () => {
+    jest
+      .mocked(directoryExists)
+      .mockImplementation((filePath) =>
+        Promise.resolve(
+          [
+            'workspace/.nx/installation/node_modules',
+            'workspace/.nx/installation/node_modules/package-foo',
+            'workspace/.nx/installation/node_modules/package-bar',
+          ].includes(filePath)
+        )
+      );
+    jest
+      .mocked(readDirectory)
+      .mockResolvedValue(['package-foo', 'package-bar']);
+
+    expect(await npmDependencies('workspace')).toEqual([
+      'workspace/.nx/installation/node_modules/package-foo',
+      'workspace/.nx/installation/node_modules/package-bar',
+    ]);
+  });
+
+  it('should return packages from `node_modules` if `node_modules` and `.nx/installation/node_modules` exist', async () => {
+    jest
+      .mocked(directoryExists)
+      .mockImplementation((filePath) =>
+        Promise.resolve(
+          [
+            'workspace/node_modules',
+            'workspace/node_modules/package-foo',
+            'workspace/node_modules/package-bar',
+            'workspace/.nx/installation/node_modules',
+          ].includes(filePath)
+        )
+      );
+    jest
+      .mocked(readDirectory)
+      .mockResolvedValue(['package-foo', 'package-bar']);
+
+    expect(await npmDependencies('workspace')).toEqual([
+      'workspace/node_modules/package-foo',
+      'workspace/node_modules/package-bar',
+    ]);
+  });
+});

--- a/libs/shared/npm/src/lib/npm-dependencies.ts
+++ b/libs/shared/npm/src/lib/npm-dependencies.ts
@@ -1,5 +1,5 @@
-import { stat, readdir } from 'fs/promises';
 import { join } from 'path';
+import { directoryExists, readDirectory } from '@nx-console/shared/file-system';
 
 /**
  * Get a flat list of all node_modules folders in the workspace.
@@ -20,47 +20,34 @@ export async function npmDependencies(workspacePath: string) {
   let nodeModulesDir = nodeModules;
 
   const res: string[] = [];
-  try {
-    if (!(await stat(nodeModules)).isDirectory()) {
+
+  if (!(await directoryExists(nodeModules))) {
+    if (!(await directoryExists(nodeModulesEncapsulated))) {
       return res;
-    }
-  } catch {
-    try {
-      if (!(await stat(nodeModulesEncapsulated)).isDirectory()) {
-        return res;
-      } else {
-        nodeModulesDir = nodeModulesEncapsulated;
-      }
-    } catch {
-      return res;
+    } else {
+      nodeModulesDir = nodeModulesEncapsulated;
     }
   }
 
-  const dirContents = await readdir(nodeModulesDir);
+  const dirContents = await readDirectory(nodeModulesDir);
 
   for (const npmPackageOrScope of dirContents) {
-    try {
-      if (npmPackageOrScope.startsWith('.')) {
-        continue;
-      }
-
-      const packageStats = await stat(join(nodeModulesDir, npmPackageOrScope));
-      if (!packageStats.isDirectory()) {
-        continue;
-      }
-
-      if (npmPackageOrScope.startsWith('@')) {
-        (await readdir(join(nodeModulesDir, npmPackageOrScope))).forEach(
-          (p) => {
-            res.push(`${nodeModulesDir}/${npmPackageOrScope}/${p}`);
-          }
-        );
-      } else {
-        res.push(`${nodeModulesDir}/${npmPackageOrScope}`);
-      }
-    } catch (e) {
-      // ignore packages where reading them causes an error
+    if (npmPackageOrScope.startsWith('.')) {
       continue;
+    }
+
+    if (!(await directoryExists(join(nodeModulesDir, npmPackageOrScope)))) {
+      continue;
+    }
+
+    if (npmPackageOrScope.startsWith('@')) {
+      (await readDirectory(join(nodeModulesDir, npmPackageOrScope))).forEach(
+        (p) => {
+          res.push(`${nodeModulesDir}/${npmPackageOrScope}/${p}`);
+        }
+      );
+    } else {
+      res.push(`${nodeModulesDir}/${npmPackageOrScope}`);
     }
   }
 


### PR DESCRIPTION
When writing unit tests for [`npmDependencies`](https://github.com/nrwl/nx-console/blob/bfd3c3d4ddb37c8a5fcb6c4b3a3445feb0b3fce5/libs/shared/npm/src/lib/npm-dependencies.ts), I decided to replace `await stat(x)).isDirectory()` with [`directoryExists(x)`](https://github.com/nrwl/nx-console/blob/bfd3c3d4ddb37c8a5fcb6c4b3a3445feb0b3fce5/libs/shared/file-system/src/lib/directory-exists.ts) from `@nx-console/shared/file-system` and added a `readDirectory` function to make it easier to mock those file system operations.

Since the `directoryExists` function already handles thrown exceptions inside, I could refactor the main code by getting rid of the nested try...catch blocks, but then I noticed a strange code path: Before, if `node_modules` was not a directory but an existing file, an empty array was returned regardless whether `.nx/installation/node_modules` directory existed. Now it goes on to check if `.nx/installation/node_modules` exists too. I think this is the correct behavior now, albeit quite an unlikely scenario.

You can check the new test cases to see if my understanding is correct.