### PR TITLE
fix(vscode): update nxls workspacepath when changing it using the action

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -712,11 +712,7 @@
     "viewsWelcome": [
       {
         "view": "nxConsole.views.welcome",
-        "contents": "Nx Console - The UI for Nx"
-      },
-      {
-        "view": "nxConsole.views.welcome",
-        "contents": "[Getting Started](https://nx.dev/using-nx/console#nx-console-for-vscode)"
+        "contents": "It looks like you're not inside an Nx workspace. If your Nx workspace is in a different folder, you can manually select it below. \n[Change Workspace](command:nxConsole.selectWorkspaceManually)\nLearn more about Nx on [nx.dev](https://nx.dev) or check out the [Nx Console Documentation](https://nx.dev/getting-started/editor-setup)."
       },
       {
         "view": "nxConsole.views.angular-welcome",
@@ -780,9 +776,9 @@
       "nx-console": [
         {
           "id": "nxConsole.views.welcome",
-          "name": "Welcome",
+          "name": "Welcome to Nx Console",
           "when": "!isNxWorkspace && !isAngularWorkspace",
-          "contextualTitle": "Nx Console Getting Started",
+          "contextualTitle": "Nx Console - Getting Started",
           "icon": "tree-view-icon.svg",
           "visibility": "visible"
         },
@@ -801,7 +797,8 @@
         },
         {
           "id": "nxRunTarget",
-          "name": "Generate & Run Target"
+          "name": "Generate & Run Target",
+          "when": "isNxWorkspace"
         },
         {
           "id": "nxCommands",
@@ -811,7 +808,6 @@
         {
           "id": "nxHelpAndFeedback",
           "name": "Help and Feedback",
-          "when": "isNxWorkspace",
           "visibility": "collapsed"
         }
       ]

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -85,7 +85,6 @@ export async function activate(c: ExtensionContext) {
     WorkspaceConfigurationStore.fromContext(context);
 
     initTelemetry(context.extensionMode === ExtensionMode.Production);
-
     const manuallySelectWorkspaceDefinitionCommand = commands.registerCommand(
       LOCATE_YOUR_WORKSPACE.command?.command || '',
       async () => {

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -51,10 +51,7 @@ import {
 import { createNxlsClient, getNxlsClient } from '@nx-console/vscode/lsp-client';
 import { initNxConfigDecoration } from '@nx-console/vscode/nx-config-decoration';
 import { initNxConversion } from '@nx-console/vscode/nx-conversion';
-import {
-  NxHelpAndFeedbackProvider,
-  NxHelpAndFeedbackTreeItem,
-} from '@nx-console/vscode/nx-help-and-feedback-view';
+import { initHelpAndFeedbackView } from '@nx-console/vscode/nx-help-and-feedback-view';
 import { getNxWorkspace, stopDaemon } from '@nx-console/vscode/nx-workspace';
 import { initVscodeProjectGraph } from '@nx-console/vscode/project-graph';
 import { enableTypeScriptPlugin } from '@nx-console/vscode/typescript-plugin';
@@ -64,7 +61,6 @@ import { initVscodeProjectDetails } from '@nx-console/vscode/project-details';
 import { registerRefreshWorkspace } from './refresh-workspace';
 
 let runTargetTreeView: TreeView<RunTargetTreeItem>;
-let nxHelpAndFeedbackTreeView: TreeView<NxHelpAndFeedbackTreeItem | TreeItem>;
 
 let currentRunTargetTreeProvider: RunTargetTreeProvider;
 let nxProjectsTreeProvider: NxProjectTreeProvider;
@@ -85,6 +81,8 @@ export async function activate(c: ExtensionContext) {
     WorkspaceConfigurationStore.fromContext(context);
 
     initTelemetry(context.extensionMode === ExtensionMode.Production);
+
+    initHelpAndFeedbackView(context);
     const manuallySelectWorkspaceDefinitionCommand = commands.registerCommand(
       LOCATE_YOUR_WORKSPACE.command?.command || '',
       async () => {
@@ -243,18 +241,11 @@ async function setWorkspace(workspacePath: string) {
 
     nxProjectsTreeProvider = initNxProjectView(context);
 
-    nxHelpAndFeedbackTreeView = window.createTreeView('nxHelpAndFeedback', {
-      treeDataProvider: new NxHelpAndFeedbackProvider(context),
-    });
-
     initNxConfigDecoration(context);
 
     new AddDependencyCodelensProvider();
 
-    context.subscriptions.push(
-      nxHelpAndFeedbackTreeView,
-      revealWebViewPanelCommand
-    );
+    context.subscriptions.push(revealWebViewPanelCommand);
   } else {
     WorkspaceConfigurationStore.instance.set('nxWorkspacePath', workspacePath);
   }

--- a/libs/vscode/lsp-client/src/lib/nxls-client.ts
+++ b/libs/vscode/lsp-client/src/lib/nxls-client.ts
@@ -1,4 +1,7 @@
-import { NxWorkspaceRefreshNotification } from '@nx-console/language-server/types';
+import {
+  NxChangeWorkspace,
+  NxWorkspaceRefreshNotification,
+} from '@nx-console/language-server/types';
 import {
   getNxlsOutputChannel,
   getOutputChannel,
@@ -83,6 +86,10 @@ class NxlsClient {
 
   public async start(workspacePath: string) {
     if (this.state !== 'idle') {
+      if (this.workspacePath !== workspacePath) {
+        this.workspacePath = workspacePath;
+        this.sendNotification(NxChangeWorkspace, workspacePath);
+      }
       return;
     }
     this.workspacePath = workspacePath;

--- a/libs/vscode/nx-help-and-feedback-view/src/index.ts
+++ b/libs/vscode/nx-help-and-feedback-view/src/index.ts
@@ -1,2 +1,1 @@
-export * from './lib/nx-help-and-feedback-tree-item';
-export * from './lib/nx-help-and-feedback-provider';
+export * from './lib/init-help-and-feedback-view';

--- a/libs/vscode/nx-help-and-feedback-view/src/lib/init-help-and-feedback-view.ts
+++ b/libs/vscode/nx-help-and-feedback-view/src/lib/init-help-and-feedback-view.ts
@@ -1,0 +1,10 @@
+import { ExtensionContext, window } from 'vscode';
+import { NxHelpAndFeedbackProvider } from './nx-help-and-feedback-provider';
+
+export function initHelpAndFeedbackView(context: ExtensionContext) {
+  const nxHelpAndFeedbackTreeView = window.createTreeView('nxHelpAndFeedback', {
+    treeDataProvider: new NxHelpAndFeedbackProvider(context),
+  });
+
+  context.subscriptions.push(nxHelpAndFeedbackTreeView);
+}


### PR DESCRIPTION
Before, the new nxls client implementation did not always trigger updates when `Change Workspace` was executed.
Now, it does and the non-nx welcome view in Nx Console is improved:
- The welcome text is useful and actually has the primary action: changing your workspace
- There are links to learn more, following vscode guidelines for welcome views
- The 'generate & run more' view is not included anymore by default since we have the button now
- The 'Help & Feedback' view is included even in non-nx workspaces

Before: 
<img width="384" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/4021d3fc-81e9-4bc9-88cf-d0ad049e73a4">

After:
<img width="374" alt="image" src="https://github.com/nrwl/nx-console/assets/34165455/afb88f2a-43cb-4469-b686-abfbf7dd5742">
