### PR TITLE
fix(nxls): ignore .nx/workspace-data paths as a precaution

### DIFF
--- a/libs/language-server/watcher/src/lib/daemon-watcher.ts
+++ b/libs/language-server/watcher/src/lib/daemon-watcher.ts
@@ -96,7 +96,8 @@ export class DaemonWatcher {
                   const normalized = normalize(f.path);
                   return !(
                     normalized.includes(normalize('.yarn/cache')) ||
-                    normalized.includes(normalize('.nx/cache'))
+                    normalized.includes(normalize('.nx/cache')) ||
+                    normalized.includes(normalize('.nx/workspace-data'))
                   );
                 }) ?? [];
               if (filteredChangedFiles.length === 0) {

--- a/libs/language-server/watcher/src/lib/native-watcher.ts
+++ b/libs/language-server/watcher/src/lib/native-watcher.ts
@@ -62,7 +62,8 @@ export class NativeWatcher {
                 NativeWatcher.openDocuments.has(path)) &&
               !path.startsWith('node_modules') &&
               !path.startsWith(normalize('.nx/cache')) &&
-              !path.startsWith(normalize('.yarn/cache'))
+              !path.startsWith(normalize('.yarn/cache')) &&
+              !path.startsWith(normalize('.nx/workspace-data'))
           )
       ) {
         if (this.stopped) {


### PR DESCRIPTION
this doesn't fix any specific bug yet - but people have had issues in the past with watchers picking up changes in .nx/cache. So we're going to preemptively ignore the new .nx/workspace-data just to be safe.
