### PR TITLE
fix: use command cwd when running help command rather than project root

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowserBase.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowserBase.kt
@@ -287,9 +287,10 @@ abstract class NxGraphBrowserBase(protected val project: Project) : Disposable {
                 return true
             }
             "run-help" -> {
-                event.payload?.let { (projectName, _, _, _, _, helpCommand) ->
+                event.payload?.let { (projectName, _, _, _, _, helpCommand, helpCwd) ->
                     if (projectName != null && helpCommand != null) {
-                        NxHelpCommandService.getInstance(project).execute(projectName, helpCommand)
+                        NxHelpCommandService.getInstance(project)
+                            .execute(projectName, helpCommand, helpCwd)
                     }
                 }
                 return true
@@ -467,6 +468,7 @@ data class NxGraphInteractionPayload(
     val taskId: String? = null,
     val targetConfigString: String? = null,
     val helpCommand: String? = null,
+    val helpCwd: String? = null,
 )
 
 @Serializable

--- a/libs/vscode/graph-base/src/lib/handle-graph-interaction-event.ts
+++ b/libs/vscode/graph-base/src/lib/handle-graph-interaction-event.ts
@@ -46,6 +46,7 @@ export async function handleGraphInteractionEventBase(event: {
     const workspacePath = getNxWorkspacePath();
     const projectName = event.payload.projectName;
     const cmd = event.payload.helpCommand;
+    const cwd = event.payload.helpCwd;
 
     getNxWorkspaceProjects().then((projects) => {
       const project = projects[projectName];
@@ -63,7 +64,13 @@ export async function handleGraphInteractionEventBase(event: {
             TaskScope.Workspace,
             cmd,
             pkgManager,
-            new ShellExecution(cmd, { cwd: join(workspacePath, project.root) })
+            new ShellExecution(cmd, {
+              cwd: cwd
+                ? // CWD should be passed to match command CWD.
+                  join(workspacePath, cwd)
+                : // If CWD is not passed from Nx 19.4.0.
+                  join(workspacePath, project.root),
+            })
           )
         );
       });


### PR DESCRIPTION
This PR updates the handling of `run-help` for both vscode and intellij such that it supports reading `helpCwd` to run the help command. Currently, it is using the project root, which is not always correct, as is the case for `./gradlew`.

