### PR TITLE
fix(vscode): fix behaviour when only 1 generator is available & refactor old code

### DIFF
--- a/libs/vscode/generate-ui-webview/src/lib/generate-commands.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/generate-commands.ts
@@ -63,7 +63,6 @@ export async function registerGenerateCommands(context: ExtensionContext) {
         getTelemetry().logUsage('generate.ui', { source: 'projects-view' });
         openGenerateUi(
           undefined,
-          undefined,
           (treeItem.item as ProjectViewItem).nxProject.project
         );
       }

--- a/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
@@ -1,4 +1,4 @@
-import { getGenerator } from '@nx-console/vscode/nx-cli-quickpicks';
+import { getOrSelectGenerator } from '@nx-console/vscode/nx-cli-quickpicks';
 import { getGeneratorContextV2 } from '@nx-console/vscode/nx-workspace';
 import { ExtensionContext, Uri } from 'vscode';
 import { registerGenerateCommands } from './generate-commands';
@@ -12,12 +12,8 @@ export async function initGenerateUiWebview(context: ExtensionContext) {
   registerGenerateCommands(context);
 }
 
-export async function openGenerateUi(
-  contextUri?: Uri,
-  generatorName?: string,
-  projectName?: string
-) {
-  const generator = await getGenerator(generatorName);
+export async function openGenerateUi(contextUri?: Uri, projectName?: string) {
+  const generator = await getOrSelectGenerator();
   if (!generator) {
     return;
   }

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-re-move-generator.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-re-move-generator.ts
@@ -11,7 +11,7 @@ export async function selectReMoveGenerator(
 
   if (!generators || !generators.length) {
     window.showWarningMessage(
-      `No ${target} generator found. Did you run npm/pnpm/yarn install?`
+      `No generators found in your workspace. Did you run npm/pnpm/yarn install?`
     );
     return;
   }
@@ -19,6 +19,13 @@ export async function selectReMoveGenerator(
   const reMoveGenerators = generators.filter(
     (generator) => generator.data?.name === target
   );
+
+  if (!reMoveGenerators.length) {
+    window.showWarningMessage(
+      `No ${target} generator found. Did you run npm/pnpm/yarn install?`
+    );
+    return;
+  }
 
   if (reMoveGenerators.length === 1) {
     return reMoveGenerators[0].name;


### PR DESCRIPTION
- lets user select generator when there is only one generator instead of automatically selecting it (this won't affect the move/remove actions)
- fixes `generatorName` data that is used in generate ui header 
- show proper error when no move / remove generators are available
- simplifies & refactors old code (parts of this were still left over from when there was still a task & generate ui)