### PR TITLE
feat(vscode): add nxWorkspacePath configuration option

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -709,7 +709,7 @@
         },
         "nxConsole.nxWorkspacePath": {
           "type": "string",
-          "description": "Specifies the relative path to the root directory of the Nx workspace."
+          "description": "Specifies the path to the root directory of the Nx workspace."
         }
       }
     },

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -706,6 +706,10 @@
           "scope": "application",
           "default": false,
           "description": "Show a notification with the current Node version on startup - useful for debugging nvm issues."
+        },
+        "nxConsole.nxWorkspacePath": {
+          "type": "string",
+          "description": "Specifies the relative path to the root directory of the Nx workspace."
         }
       }
     },

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -709,7 +709,7 @@
         },
         "nxConsole.nxWorkspacePath": {
           "type": "string",
-          "description": "Specifies the path to the root directory of the Nx workspace."
+          "description": "Specifies the relative path to the root directory of the Nx workspace. Can be configured on a user or workspace level."
         }
       }
     },

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { dirname, join, parse, resolve } from 'path';
+import { dirname, join, parse, relative, resolve } from 'path';
 import {
   Disposable,
   ExtensionContext,
@@ -94,6 +94,7 @@ export async function activate(c: ExtensionContext) {
     }
 
     context.subscriptions.push(manuallySelectWorkspaceDefinitionCommand);
+    await registerSettingsNxWorkspacePathWatcher();
 
     await enableTypeScriptPlugin(context);
     watchCodeLensConfigChange(context);
@@ -133,6 +134,16 @@ function manuallySelectWorkspaceDefinition() {
       .then((value) => {
         if (value && value[0]) {
           const selectedDirectory = value[0].fsPath;
+          const workspaceRoot =
+            workspace.workspaceFolders?.[0].uri.fsPath || '';
+          const selectedDirectoryRelativePath = relative(
+            workspaceRoot,
+            selectedDirectory
+          );
+          GlobalConfigurationStore.instance.set(
+            'nxWorkspacePath',
+            selectedDirectoryRelativePath
+          );
           setWorkspace(selectedDirectory);
         }
       });
@@ -312,4 +323,26 @@ async function registerWorkspaceFileWatcher(
       refreshWorkspaceWithBackoff(iteration + 1);
     }
   }
+}
+
+async function registerSettingsNxWorkspacePathWatcher() {
+  const settingsNxWorkspacePathWatcher = workspace.onDidChangeConfiguration(
+    async (event) => {
+      if (event.affectsConfiguration('nxConsole.nxWorkspacePath')) {
+        const newWorkspacePath =
+          GlobalConfigurationStore.instance.config.get<string>(
+            'nxWorkspacePath'
+          );
+        if (newWorkspacePath) {
+          const nxWorkspacePath = resolve(
+            workspace.workspaceFolders?.[0].uri.fsPath || '',
+            newWorkspacePath
+          );
+          await setWorkspace(nxWorkspacePath);
+        }
+      }
+    }
+  );
+
+  context.subscriptions.push(settingsNxWorkspacePathWatcher);
 }

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { dirname, join, parse } from 'path';
+import { dirname, join, parse, resolve } from 'path';
 import {
   Disposable,
   ExtensionContext,
@@ -148,13 +148,17 @@ async function scanForWorkspace(vscodeWorkspacePath: string) {
 
   const { root } = parse(vscodeWorkspacePath);
 
-  const workspacePath = WorkspaceConfigurationStore.instance.get(
-    'nxWorkspacePath',
-    ''
-  );
-
-  if (workspacePath) {
-    currentDirectory = workspacePath;
+  const workspacePathFromSettings = GlobalConfigurationStore.instance.config.get<string>('nxWorkspacePath');
+  if (workspacePathFromSettings) {
+    currentDirectory = resolve(workspace.workspaceFolders?.[0].uri.fsPath || '', workspacePathFromSettings);
+  } else {
+    const workspacePath = WorkspaceConfigurationStore.instance.get(
+      'nxWorkspacePath',
+      ''
+    );
+    if (workspacePath) {
+      currentDirectory = workspacePath;
+    }
   }
 
   while (currentDirectory !== root) {

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -148,9 +148,13 @@ async function scanForWorkspace(vscodeWorkspacePath: string) {
 
   const { root } = parse(vscodeWorkspacePath);
 
-  const workspacePathFromSettings = GlobalConfigurationStore.instance.config.get<string>('nxWorkspacePath');
+  const workspacePathFromSettings =
+    GlobalConfigurationStore.instance.config.get<string>('nxWorkspacePath');
   if (workspacePathFromSettings) {
-    currentDirectory = resolve(workspace.workspaceFolders?.[0].uri.fsPath || '', workspacePathFromSettings);
+    currentDirectory = resolve(
+      workspace.workspaceFolders?.[0].uri.fsPath || '',
+      workspacePathFromSettings
+    );
   } else {
     const workspacePath = WorkspaceConfigurationStore.instance.get(
       'nxWorkspacePath',

--- a/libs/vscode/configuration/src/lib/configuration-keys.ts
+++ b/libs/vscode/configuration/src/lib/configuration-keys.ts
@@ -12,6 +12,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'useNewGenerateUiPreview',
   'showProjectDetailsView',
   'showNodeVersionOnStartup',
+  'nxWorkspacePath'
 ] as const;
 
 export type GlobalConfig = {
@@ -28,6 +29,7 @@ export type GlobalConfig = {
   useNewGenerateUiPreview: boolean;
   showProjectDetailsView: boolean;
   showNodeVersionOnStartup: boolean;
+  nxWorkspacePath: string;
 };
 
 /**

--- a/libs/vscode/configuration/src/lib/configuration-keys.ts
+++ b/libs/vscode/configuration/src/lib/configuration-keys.ts
@@ -12,7 +12,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'useNewGenerateUiPreview',
   'showProjectDetailsView',
   'showNodeVersionOnStartup',
-  'nxWorkspacePath'
+  'nxWorkspacePath',
 ] as const;
 
 export type GlobalConfig = {


### PR DESCRIPTION
This pull request introduces a new configuration option for specifying the Nx workspace path in the VS Code extension. The changes include updates to the configuration schema, new imports and functions to handle the workspace path, and modifications to existing functions to integrate the new setting.

Closes #2268

### Configuration Enhancements:
* [`apps/vscode/package.json`](diffhunk://#diff-ffd752c4d60ebba40a59cc7f9b8cb7b3beeedb5c14a8a8245246bf73846bf247R709-R712): Added a new configuration option `nxConsole.nxWorkspacePath` to specify the relative path to the root directory of the Nx workspace.

### Codebase Updates:
* `apps/vscode/src/main.ts`: 
  - Added new imports `relative` and `resolve` from the `path` module.
  - Integrated `registerSettingsNxWorkspacePathWatcher` in the `activate` function to watch for changes in the new configuration setting.
  - Updated `manuallySelectWorkspaceDefinition` to store the relative path of the selected directory in the global configuration.
  - Modified `scanForWorkspace` to use the new configuration setting if available.
  - Introduced `registerSettingsNxWorkspacePathWatcher` to handle changes in the `nxWorkspacePath` configuration setting.

### Configuration Keys:
* `libs/vscode/configuration/src/lib/configuration-keys.ts`: 
  - Added `nxWorkspacePath` to the global configuration keys.
  - Updated the `GlobalConfig` type to include `nxWorkspacePath`.