### PR TITLE
feat: Implemented VSCode lint problem matching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ Use the `F5` key or the debug menu option `Launch Client + Server` to start the 
 
 > :warning: Even though builds will be generated automatically, the Extension Development Host needs to be restarted in order to apply a new set of changes.
 
+> :warning: Set `window.openFilesInNewWindow` to "off" to prevent VSCode to reopen a new window
+
+> :warning: Make a copy of this project-folder and open the copy in VSCode when debugging locally. This as otherwise VSCode will switch to the original VSCode window.
+
 ### IntelliJ
 
 The `runIde` gradle task takes care of building Nx Console and starting a development instance of IntelliJ. Run the `nx-console [runIde]` gradle config in your IDE or use `nx run intellij:runIde` (which executes `./gradlew :apps:intellij:runIde` under the hood).

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-affected-flags.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-affected-flags.ts
@@ -17,11 +17,20 @@ export async function selectAffectedFlags(target: string): Promise<{
       };
     }
     default: {
+      let customOptions: string | undefined;
+      if (target === 'lint') {
+        customOptions = '--output-style=stream';
+      }
       return {
         command: 'affected',
-        flags: await selectFlags(`affected`, AFFECTED_OPTIONS, {
-          target,
-        }),
+        flags: await selectFlags(
+          `affected`,
+          AFFECTED_OPTIONS,
+          {
+            target,
+          },
+          customOptions
+        ),
       };
     }
   }

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-run-many-flags.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-run-many-flags.ts
@@ -21,7 +21,12 @@ export async function selectRunManyFlags(
     ];
   }
 
-  return await selectFlags('run-many', options, { target });
+  let customOptions: string | undefined;
+  if (target === 'lint') {
+    customOptions = '--output-style=stream';
+  }
+
+  return await selectFlags('run-many', options, { target }, customOptions);
 }
 
 const RUN_MANY_OPTIONS: Option[] = [

--- a/libs/vscode/tasks/src/lib/cli-task-definition.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-definition.ts
@@ -4,4 +4,5 @@ export interface CliTaskDefinition {
   flags: Array<string>;
   cwd?: string;
   env?: { [key: string]: string };
+  problemMatchers?: string | string[] | undefined;
 }

--- a/libs/vscode/tasks/src/lib/cli-task-provider.ts
+++ b/libs/vscode/tasks/src/lib/cli-task-provider.ts
@@ -95,6 +95,12 @@ export class CliTaskProvider implements TaskProvider {
           cwd: definition.cwd,
         });
       } else {
+        if (
+          definition.command === 'run' &&
+          definition.positional?.endsWith(':lint')
+        ) {
+          definition.problemMatchers = ['$eslint-stylish'];
+        }
         task = await CliTask.create(definition);
       }
     } catch (e) {

--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -46,7 +46,8 @@ export class CliTask extends Task {
           env: definition.env,
         },
         packageManagerCommands
-      )
+      ),
+      definition.problemMatchers
     );
 
     return task;

--- a/libs/vscode/tasks/src/lib/nx-task-commands.ts
+++ b/libs/vscode/tasks/src/lib/nx-task-commands.ts
@@ -94,11 +94,19 @@ async function promptForAffectedFlags(target: string) {
   const { positional, command, flags } = await selectAffectedFlags(target);
 
   if (flags !== undefined) {
+    let problemMatchers: string[] | undefined;
+    if (target === 'lint') {
+      problemMatchers = ['$eslint-stylish'];
+    }
+
     const task = await NxTask.create({
       command,
       flags,
       positional,
     });
+    if (task && problemMatchers) {
+      task.problemMatchers = problemMatchers;
+    }
     if (!task) {
       logAndShowError(
         'Error while creating task. Please see the logs for more information.'
@@ -118,10 +126,18 @@ async function promptForRunMany() {
   const flags = await selectRunManyFlags(target);
 
   if (flags !== undefined) {
+    let problemMatchers: string[] | undefined;
+    if (target === 'lint') {
+      problemMatchers = ['$eslint-stylish'];
+    }
+
     const task = await NxTask.create({
       command: 'run-many',
       flags,
     });
+    if (task && problemMatchers) {
+      task.problemMatchers = problemMatchers;
+    }
     if (!task) {
       logAndShowError(
         'Error while creating task. Please see the logs for more information.'


### PR DESCRIPTION
With this PR i propose to have VSCode automatically take the output of NX-linting tasks and present the issues as VSCode problems.
This PR implements the matching at:
* Running "affected" tasks
* Running "many" tasks
* Running an individual task
When running affected/many the output-style is automatically changed to display the found issues and allow for matching.

A known issue is that the default ESLint-formatter which is used by NX will report with absolute filepaths. The absolute filepaths might not align with the current environment as NX-caching does not take the root-folder in account.

In the future this feature might be extended to also work for Stylelint and others.

@MaxKless Would you like to check this PR?