### PR TITLE
fix(intellij): make sure telemetry logs are set to trace

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryService.kt
@@ -35,7 +35,7 @@ class TelemetryService(private val cs: CoroutineScope) {
                         logger =
                             object : Logger {
                                 override fun log(message: String) {
-                                    this@TelemetryService.logger.info(message)
+                                    this@TelemetryService.logger.trace(message)
                                 }
                             }
                     }


### PR DESCRIPTION
this means the logs won't be polluted with these telemetry logs by default