### PR TITLE
fix(vscode): retry nxls request if connection is disposed during request

### DIFF
--- a/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
@@ -41,11 +41,8 @@ export async function getNxWorkspaceConfig(
   let errors: NxError[] | undefined;
 
   const start = performance.now();
-  logger.log('Retrieving workspace configuration');
+  logger.log(`Retrieving workspace configuration for nx ${nxVersion.full}`);
 
-  lspLogger.log(
-    `${JSON.stringify(nxVersion)}, gte: ${gte(nxVersion, '12.0.0')}`
-  );
   if (!gte(nxVersion, '12.0.0')) {
     lspLogger.log('Major version is less than 12');
     return readWorkspaceConfigs(workspacePath);


### PR DESCRIPTION
Right now, if a request takes longer and users try to refresh the language server while the request is in flight (actually passed along to the language client, not just in our wrapper), an error will be thrown.
This is potentially very ugly if run from a command and can be avoided. 
With our new state machine architecture, we can simply retry the request since it will automatically wait for the client to be running.