### PR TITLE
refactor: common getPackageManagerCommand util with try/catch for older nx versions

### DIFF
--- a/libs/language-server/workspace/src/lib/nx-stop-daemon.ts
+++ b/libs/language-server/workspace/src/lib/nx-stop-daemon.ts
@@ -1,18 +1,13 @@
-import { importNxPackagePath } from '@nx-console/shared/npm';
 import { Logger } from '@nx-console/shared/schema';
+import { getPackageManagerCommand } from '@nx-console/shared/utils';
 import { execSync } from 'node:child_process';
 
 export async function nxStopDaemon(workspacePath: string, logger: Logger) {
   logger.log('stopping daemon with `nx daemon --stop`');
-  const { detectPackageManager, getPackageManagerCommand } =
-    await importNxPackagePath<typeof import('nx/src/utils/package-manager')>(
-      workspacePath,
-      'src/utils/package-manager',
-      logger
-    );
 
-  const packageManagerCommands = getPackageManagerCommand(
-    detectPackageManager(workspacePath)
+  const packageManagerCommands = await getPackageManagerCommand(
+    workspacePath,
+    logger
   );
   execSync(`${packageManagerCommands.exec} nx daemon --stop`, {
     cwd: workspacePath,

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -5,3 +5,4 @@ export { getNxExecutionCommand } from './lib/get-nx-execution-command';
 export * from './lib/utils';
 export * from './lib/kill-tree';
 export * from './lib/cipe';
+export * from './lib/package-manager-command';

--- a/libs/shared/utils/src/lib/get-nx-execution-command.ts
+++ b/libs/shared/utils/src/lib/get-nx-execution-command.ts
@@ -1,5 +1,6 @@
 import { importNxPackagePath } from '@nx-console/shared/npm';
 import { platform } from 'os';
+import { getPackageManagerCommand } from './package-manager-command';
 
 /**
  * see `getShellExecutionForConfig` for a vscode-specific implementation of this
@@ -17,13 +18,7 @@ export async function getNxExecutionCommand(config: {
       command = command.replace(/^nx/, './nx');
     }
   } else {
-    const { detectPackageManager, getPackageManagerCommand } =
-      await importNxPackagePath<typeof import('nx/src/devkit-exports')>(
-        config.cwd,
-        'src/devkit-exports'
-      );
-    const packageManager = detectPackageManager(config.cwd);
-    const packageManagerCommand = getPackageManagerCommand(packageManager);
+    const packageManagerCommand = await getPackageManagerCommand(config.cwd);
     command = `${packageManagerCommand.exec} ${command}`;
   }
 

--- a/libs/shared/utils/src/lib/package-manager-command.ts
+++ b/libs/shared/utils/src/lib/package-manager-command.ts
@@ -1,0 +1,37 @@
+import { importNxPackagePath } from '@nx-console/shared/npm';
+import { Logger } from '@nx-console/shared/schema';
+import type { PackageManagerCommands } from 'nx/src/utils/package-manager';
+
+export async function getPackageManagerCommand(
+  workspacePath: string,
+  logger?: Logger
+): Promise<PackageManagerCommands> {
+  try {
+    const { detectPackageManager, getPackageManagerCommand } =
+      await importNxPackagePath<typeof import('nx/src/utils/package-manager')>(
+        workspacePath,
+        'src/utils/package-manager',
+        logger
+      );
+
+    return getPackageManagerCommand(detectPackageManager(workspacePath));
+  } catch (e) {
+    logger?.log(`Error getting package manager command: ${JSON.stringify(e)}`);
+
+    // return npm by default
+    return {
+      install: 'npm install',
+      ciInstall: 'npm ci --legacy-peer-deps',
+      updateLockFile: 'npm install --package-lock-only',
+      add: 'npm install',
+      addDev: 'npm install -D',
+      rm: 'npm rm',
+      exec: 'npx',
+      dlx: 'npx',
+      run: (script: any, args: any) =>
+        `npm run ${script}${args ? ' -- ' + args : ''}`,
+      list: 'npm ls',
+      getRegistryUrl: 'npm config get registry',
+    };
+  }
+}

--- a/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
+++ b/libs/vscode/add-dependency/src/lib/vscode-add-dependency.ts
@@ -1,16 +1,25 @@
-import type { PackageManager } from 'nx/src/devkit-exports';
+import { importNxPackagePath } from '@nx-console/shared/npm';
+import { gte } from '@nx-console/shared/nx-version';
+import { getPackageManagerCommand } from '@nx-console/shared/utils';
+import { getNxWorkspacePath } from '@nx-console/vscode/configuration';
+import { selectFlags } from '@nx-console/vscode/nx-cli-quickpicks';
 import {
   getGeneratorOptions,
   getGenerators,
   getNxVersion,
 } from '@nx-console/vscode/nx-workspace';
+import { logAndShowTaskCreationError } from '@nx-console/vscode/output-channels';
+import { getTelemetry } from '@nx-console/vscode/telemetry';
 import {
   getShellExecutionForConfig,
   resolveDependencyVersioning,
 } from '@nx-console/vscode/utils';
+import { execSync } from 'child_process';
 import { existsSync } from 'fs';
+import type { PackageManager } from 'nx/src/devkit-exports';
 import { join } from 'path';
 import { xhr, XHRResponse } from 'request-light';
+import { major } from 'semver';
 import {
   commands,
   ExtensionContext,
@@ -21,14 +30,6 @@ import {
   TaskScope,
   window,
 } from 'vscode';
-import { selectFlags } from '@nx-console/vscode/nx-cli-quickpicks';
-import { execSync } from 'child_process';
-import { major } from 'semver';
-import { getNxWorkspacePath } from '@nx-console/vscode/configuration';
-import { importNxPackagePath } from '@nx-console/shared/npm';
-import { logAndShowTaskCreationError } from '@nx-console/vscode/output-channels';
-import { getTelemetry } from '@nx-console/vscode/telemetry';
-import { gte } from '@nx-console/shared/nx-version';
 
 export const ADD_DEPENDENCY_COMMAND = 'nxConsole.addDependency';
 export const ADD_DEV_DEPENDENCY_COMMAND = 'nxConsole.addDevDependency';
@@ -139,10 +140,7 @@ async function addDependency(
   workspacePath: string
 ) {
   try {
-    const { getPackageManagerCommand } = await importNxPackagePath<
-      typeof import('nx/src/devkit-exports')
-    >(workspacePath, 'src/devkit-exports');
-    const pkgManagerCommands = getPackageManagerCommand(pkgManager);
+    const pkgManagerCommands = await getPackageManagerCommand(workspacePath);
     const pkgManagerWorkspaceFlag = await getWorkspaceAddFlag(
       pkgManager,
       workspacePath

--- a/libs/vscode/graph-base/src/lib/nx-graph-server.ts
+++ b/libs/vscode/graph-base/src/lib/nx-graph-server.ts
@@ -1,4 +1,5 @@
 import { importNxPackagePath } from '@nx-console/shared/npm';
+import { getPackageManagerCommand } from '@nx-console/shared/utils';
 import { getNxWorkspacePath } from '@nx-console/vscode/configuration';
 import { ChildProcess, spawn } from 'child_process';
 import { createServer } from 'net';
@@ -144,13 +145,11 @@ export class NxGraphServer implements Disposable {
 
   private async spawnProcess(port: number): Promise<void> {
     const workspacePath = getNxWorkspacePath();
-    const { getPackageManagerCommand } = await importNxPackagePath<
-      typeof import('nx/src/devkit-exports')
-    >(workspacePath, 'src/devkit-exports');
+    const packageManagerCommand = await getPackageManagerCommand(workspacePath);
 
     return new Promise((resolve, reject) => {
       const nxGraphProcess = spawn(
-        getPackageManagerCommand().exec,
+        packageManagerCommand.exec,
         [
           'nx',
           'graph',

--- a/libs/vscode/nx-cloud-view/src/lib/init-nx-cloud-view.ts
+++ b/libs/vscode/nx-cloud-view/src/lib/init-nx-cloud-view.ts
@@ -34,6 +34,7 @@ import { compareCIPEDataAndSendNotification } from './cipe-notifications';
 import { CloudOnboardingViewProvider } from './cloud-onboarding-view';
 import { CloudRecentCIPEProvider } from './cloud-recent-cipe-view';
 import { machine } from './cloud-view-state-machine';
+import { getPackageManagerCommand } from '@nx-console/shared/utils';
 
 export function initNxCloudView(context: ExtensionContext) {
   // set up state machine & listeners
@@ -127,10 +128,8 @@ export function initNxCloudView(context: ExtensionContext) {
     }),
     commands.registerCommand('nxCloud.login', async () => {
       const workspacePath = getWorkspacePath();
-      const { getPackageManagerCommand } = await importNxPackagePath<
-        typeof import('nx/src/devkit-exports')
-      >(workspacePath, 'src/devkit-exports');
-      const pkgManagerCommands = getPackageManagerCommand();
+
+      const pkgManagerCommands = await getPackageManagerCommand(workspacePath);
 
       const command = 'nx-cloud login';
       const task = new Task(

--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -6,6 +6,7 @@ import { NxWorkspace } from '@nx-console/shared/types';
 import type { PackageManagerCommands } from 'nx/src/utils/package-manager';
 import { join } from 'path';
 import { importNxPackagePath } from '@nx-console/shared/npm';
+import { getPackageManagerCommand } from '@nx-console/shared/utils';
 
 export class CliTask extends Task {
   /**
@@ -62,15 +63,9 @@ export class CliTask extends Task {
       return [];
     }
 
-    const { detectPackageManager, getPackageManagerCommand } =
-      await importNxPackagePath<typeof import('nx/src/utils/package-manager')>(
-        w.workspacePath,
-        'src/utils/package-manager'
-      );
-    const packageManagerCommands = getPackageManagerCommand(
-      detectPackageManager(w?.workspacePath)
+    const packageManagerCommands = await getPackageManagerCommand(
+      w.workspacePath
     );
-
     const tasks = await Promise.all(
       definitions.map((definition) =>
         this.create(definition, w, packageManagerCommands)

--- a/libs/vscode/utils/src/lib/shell-execution.ts
+++ b/libs/vscode/utils/src/lib/shell-execution.ts
@@ -1,4 +1,5 @@
 import { importNxPackagePath } from '@nx-console/shared/npm';
+import { getPackageManagerCommand } from '@nx-console/shared/utils';
 import type { PackageManagerCommands } from 'nx/src/utils/package-manager';
 import { platform } from 'os';
 
@@ -28,11 +29,7 @@ export async function getShellExecutionForConfig(
     if (packageManagerCommands) {
       pmc = packageManagerCommands;
     } else {
-      const { detectPackageManager, getPackageManagerCommand } =
-        await importNxPackagePath<
-          typeof import('nx/src/utils/package-manager')
-        >(config.workspacePath, 'src/utils/package-manager');
-      pmc = getPackageManagerCommand(detectPackageManager(config.cwd));
+      pmc = await getPackageManagerCommand(config.cwd);
     }
 
     command = `${pmc.exec} ${command}`;


### PR DESCRIPTION
older versions of nx don't `try/catch` when invoking `yarn` or `pnpm`. This means that errors bubble up from nx into nx console. 
When detecting the package manager to run tasks or similar, we catch the error now and default to npm/npx.