### PR TITLE
fix(intellij): improve finding Nx configuration files

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/FindNxConfigurationFiles.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/FindNxConfigurationFiles.kt
@@ -15,11 +15,11 @@ suspend fun findNxConfigurationFiles(
     readAction {
         val startDirectory = LocalFileSystem.getInstance().findFileByPath(project.nxBasePath)
         if (startDirectory != null) {
-            ProjectFileIndex.getInstance(project).iterateContentUnderDirectory(startDirectory) { file ->
+            ProjectFileIndex.getInstance(project).iterateContentUnderDirectory(startDirectory) {
+                file ->
                 if (
                     !file.isDirectory &&
-                    (file.name == "project.json" ||
-                        (includeNxJson && file.name == "nx.json"))
+                        (file.name == "project.json" || (includeNxJson && file.name == "nx.json"))
                 ) {
                     paths.add(file)
                 }


### PR DESCRIPTION
Use `ProjectFileIndex.getInstance(project).iterateContentUnderDirectory` as it skips visiting excluded files, and there are many of them under `node_modules`.
Fixes #2347