### PR TITLE
fix(nxls): use native watcher right away when daemon dies during watch process

### DIFF
--- a/libs/language-server/watcher/src/lib/daemon-watcher.ts
+++ b/libs/language-server/watcher/src/lib/daemon-watcher.ts
@@ -94,7 +94,7 @@ export class DaemonWatcher {
             if (error === 'closed') {
               if (!this.stopped) {
                 lspLogger.log('Daemon watcher connection closed, restarting');
-                this.tryRestartWatcher();
+                this.useNativeWatcher();
               }
             } else if (error) {
               lspLogger.log('Error watching files: ' + error);
@@ -142,24 +142,8 @@ export class DaemonWatcher {
       lspLogger.log(
         `Error initializing daemon watcher, check daemon logs. ${e}`
       );
-      this.tryRestartWatcher();
-    }
-  }
-
-  private async tryRestartWatcher() {
-    this.disposeEverything();
-    if (this.retryCount > 0) {
-      lspLogger.log('Daemon watcher failed to restart, using native watcher');
       this.useNativeWatcher();
-      return;
     }
-    this.retryCount++;
-    await new Promise((resolve) => {
-      const timeout = setTimeout(resolve, 100);
-      this.disposables.add(() => clearTimeout(timeout));
-    });
-
-    await this.initWatcher();
   }
 
   private useNativeWatcher() {


### PR DESCRIPTION
Before, the following happened:

- User runs `npx nx daemon --stop`
- Daemon stops
- user checks with `npx nx daemon`
- Daemon is running because nx console restarted it for the watcher in the background

Now we instantly transition to using the native watcher (which is what the daemon uses under the hood itself) if the daemon dies. After a change, the daemon is used again. We could think about changing this as well.