### PR TITLE
fix(nxls): always provide at least empty project graph object

### DIFF
--- a/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
+++ b/libs/language-server/workspace/src/lib/get-nx-workspace-config.ts
@@ -27,7 +27,7 @@ export async function getNxWorkspaceConfig(
   nxVersion: NxVersion,
   logger: Logger
 ): Promise<{
-  projectGraph: ProjectGraph;
+  projectGraph: ProjectGraph | undefined;
   sourceMaps: ConfigurationSourceMaps | undefined;
   nxJson: NxJsonConfiguration;
   projectFileMap: ProjectFileMap | undefined;

--- a/libs/language-server/workspace/src/lib/workspace.ts
+++ b/libs/language-server/workspace/src/lib/workspace.ts
@@ -79,7 +79,10 @@ async function _workspace(
     const isLerna = await fileExists(join(workspacePath, 'lerna.json'));
 
     return {
-      projectGraph,
+      projectGraph: projectGraph ?? {
+        nodes: {},
+        dependencies: {},
+      },
       sourceMaps,
       nxJson,
       projectFileMap,


### PR DESCRIPTION
saw some error messages in rollbar that were triggered by an undefined `projectGraph` object