### PR TITLE
fix(vscode): show project details codelens above package.json#nx if it exists

### DIFF
--- a/libs/vscode/project-details/src/lib/project-details-codelens-provider.ts
+++ b/libs/vscode/project-details/src/lib/project-details-codelens-provider.ts
@@ -160,6 +160,12 @@ export class ProjectDetailsCodelensProvider implements NxCodeLensProvider {
       }
       return new Position(1, 1);
     } else {
+      const nxProperty = properties?.find(
+        (prop) => getPropertyName(prop) === 'nx'
+      );
+      if (nxProperty) {
+        return document.positionAt(nxProperty.getStart(jsonFile));
+      }
       const scriptsProperty = properties?.find(
         (prop) => getPropertyName(prop) === 'scripts'
       );


### PR DESCRIPTION
Now that `package.json` can contain an `nx` property with information about nx, let's default to that location for the codelens. First fallback is still the `scripts` property and finally the top of the file.