### PR TITLE
fix(nxls): provide autocomplete only for plugins that contain nx

### DIFF
--- a/libs/language-server/capabilities/code-completion/src/lib/inference-plugins-completion.ts
+++ b/libs/language-server/capabilities/code-completion/src/lib/inference-plugins-completion.ts
@@ -33,9 +33,11 @@ export async function inferencePluginsCompletion(
         .split('node_modules/')
         .pop();
 
-      inferencePluginsCompletion.push({
-        label: `${dependencyPath}/plugin`,
-      });
+      if (dependencyPath?.includes('nx')) {
+        inferencePluginsCompletion.push({
+          label: `${dependencyPath}/plugin`,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Before, we would sometimes show unrelated plugins in our autocomplete.
![image](https://github.com/user-attachments/assets/7508185f-7ba6-4e59-b423-815b278cec78)

Once we have a better way of detecting whether a plugin provides an inference plugin, we can update this. But for now let's err on the side of caution - I'd rather miss certain third-party plugins than regularly show flat-out wrong things.