### PR TITLE
fix(intellij): use refresh service directly and avoid going through actionPerformed

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowPanel.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolWindowPanel.kt
@@ -25,7 +25,6 @@ import com.intellij.util.messages.Topic
 import com.intellij.util.ui.JBUI
 import dev.nx.console.nx_toolwindow.tree.NxProjectsTree
 import dev.nx.console.nx_toolwindow.tree.NxTreeStructure
-import dev.nx.console.nxls.NxRefreshWorkspaceAction
 import dev.nx.console.nxls.NxRefreshWorkspaceService
 import dev.nx.console.nxls.NxWorkspaceRefreshListener
 import dev.nx.console.nxls.NxlsService
@@ -326,7 +325,12 @@ class NxToolWindowPanel(private val project: Project) : SimpleToolWindowPanel(tr
                     }
 
                     override fun actionPerformed(e: AnActionEvent) {
-                        NxRefreshWorkspaceAction().actionPerformed(e)
+                        TelemetryService.getInstance(project)
+                            .featureUsed(
+                                TelemetryEvent.MISC_REFRESH_WORKSPACE,
+                                mapOf("source" to TelemetryEventSource.PROJECTS_VIEW),
+                            )
+                        NxRefreshWorkspaceService.getInstance(project).refreshWorkspace()
                     }
                 }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/project_details/ProjectDetailsEditorWithPreview.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/project_details/ProjectDetailsEditorWithPreview.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import dev.nx.console.models.NxVersion
-import dev.nx.console.nxls.NxRefreshWorkspaceAction
+import dev.nx.console.nxls.NxRefreshWorkspaceService
 import dev.nx.console.telemetry.TelemetryEvent
 import dev.nx.console.telemetry.TelemetryEventSource
 import dev.nx.console.telemetry.TelemetryService
@@ -59,7 +59,7 @@ class ProjectDetailsEditorWithPreview(private val project: Project, file: Virtua
                             TelemetryEvent.MISC_REFRESH_WORKSPACE,
                             mapOf("source" to TelemetryEventSource.EDITOR_TOOLBAR),
                         )
-                    NxRefreshWorkspaceAction().actionPerformed(e)
+                    NxRefreshWorkspaceService.getInstance(project).refreshWorkspace()
                 }
             }
 


### PR DESCRIPTION
this fixes an `OverrideOnly` violation as well