### PR TITLE
fix(vscode): catch yarn --version error in new typescript plugin

### DIFF
--- a/libs/vscode/typescript-plugin/src/lib/plugin-configuration.ts
+++ b/libs/vscode/typescript-plugin/src/lib/plugin-configuration.ts
@@ -84,10 +84,15 @@ export async function getPluginConfiguration(
   let packageManager: Configuration['packageManager'] =
     await detectPackageManager(workspaceRoot);
   if (packageManager === 'yarn') {
-    const yarnVersion = await getPackageManagerVersion(
-      packageManager,
-      workspaceRoot,
-    );
+    let yarnVersion;
+    try {
+      yarnVersion = await getPackageManagerVersion(
+        packageManager,
+        workspaceRoot,
+      );
+    } catch {
+      yarnVersion = '1.0.0';
+    }
     if (lt(yarnVersion, '2.0.0')) {
       packageManager = 'yarn-classic';
     }


### PR DESCRIPTION
we were seeing errors when people don't have `yarn` installed locally. The error was swallowed but we should still fix it.