### PR TITLE
feat: add generate-ui mcp tool & add more tools to copilot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,9 +106,9 @@
 
 /libs/vscode/utils/ @MaxKless
 
-/libs/vscode/mcp/ @MaxKless
-
 /libs/shared/npm/ @MaxKless
+
+/libs/vscode/mcp/ @MaxKless
 
 /apps/intellij/ @MaxKless
 

--- a/apps/generate-ui-v2-e2e/src/e2e/form-update.cy.ts
+++ b/apps/generate-ui-v2-e2e/src/e2e/form-update.cy.ts
@@ -1,0 +1,74 @@
+import { getFieldByName } from '../support/get-elements';
+import { visitGenerateUi } from '../support/visit-generate-ui';
+
+describe('Form Value Update', () => {
+  beforeEach(() => {
+    visitGenerateUi({
+      collectionName: '@nx/test',
+      generatorName: 'test',
+      description: 'description',
+      options: [
+        {
+          name: 'name',
+          type: 'string',
+          isRequired: false,
+          aliases: [],
+        },
+        {
+          name: 'directory',
+          type: 'string',
+          isRequired: false,
+          aliases: [],
+        },
+      ],
+    });
+
+    // Wait for the UI to be ready with generator schema
+    cy.get('[data-cy="title"]').should('be.visible');
+  });
+
+  it('should update field values when receiving form-value updates from IDE', () => {
+    getFieldByName('name').should('have.value', '');
+    getFieldByName('directory').should('have.value', '');
+
+    cy.window().then((win) => {
+      (win as any).intellijApi?.postToWebview({
+        payloadType: 'update-form-values',
+        payload: {
+          name: 'Updated Test Name',
+          directory: 'apps/updated-test-dir',
+        },
+      });
+    });
+
+    getFieldByName('name').should('have.value', 'Updated Test Name');
+
+    getFieldByName('directory').should('have.value', 'apps/updated-test-dir');
+  });
+
+  it('should update CWD breadcrumb when receiving form-value updates from IDE', () => {
+    cy.get('[data-cy="cwd-breadcrumb"]').should('be.visible');
+    cy.get('[data-cy="inline-edit-button"]').click();
+    cy.get('[data-cy="inline-edit-field"]').should('have.value', '');
+    cy.get("[data-cy='inline-edit-confirm']").click();
+
+    // Simulate IDE sending cwd update
+    cy.window().then((win) => {
+      (win as any).intellijApi?.postToWebview({
+        payloadType: 'update-form-values',
+        payload: {
+          cwd: 'apps/my-updated-app',
+        },
+      });
+    });
+
+    cy.get('[data-cy="cwd-breadcrumb"]').contains('my-updated-app');
+
+    // Click edit button and verify value is set in the input field
+    cy.get('[data-cy="inline-edit-button"]').click();
+    cy.get('[data-cy="inline-edit-field"]').should(
+      'have.value',
+      'apps/my-updated-app',
+    );
+  });
+});

--- a/apps/generate-ui-v2/src/components/fields/mixins/form-value-subscriber-mixin.ts
+++ b/apps/generate-ui-v2/src/components/fields/mixins/form-value-subscriber-mixin.ts
@@ -1,0 +1,52 @@
+import { ContextConsumer } from '@lit-labs/context';
+import { LitElement } from 'lit';
+import { formValuesServiceContext } from '../../../form-values.service';
+
+type Constructor<T> = new (...args: any[]) => T;
+
+export declare class FormValueSubscriberInterface {
+  getFieldNameForSubscription(): string | undefined;
+  setFieldValue(value: any): void;
+}
+
+/**
+ * Mixin that allows a component to subscribe to form value changes for a specific field
+ */
+export const FormValueSubscriber = <T extends Constructor<LitElement>>(
+  superClass: T,
+) => {
+  class FormValueSubscriberElement extends superClass {
+    // This method should be implemented by subclasses
+    getFieldNameForSubscription(): string | undefined {
+      return undefined;
+    }
+
+    connectedCallback() {
+      super.connectedCallback?.();
+
+      const fieldName = this.getFieldNameForSubscription();
+
+      // Only subscribe if we have a field name to identify the field
+      if (fieldName) {
+        new ContextConsumer(this, {
+          context: formValuesServiceContext,
+          callback: (service) => {
+            if (service) {
+              // Register for value changes from the form values service
+              service.registerValueChangeListener(fieldName, (newValue) => {
+                if (newValue !== undefined) {
+                  (this as any).setFieldValue(newValue);
+                  (this as any).dispatchValue();
+                }
+              });
+            }
+          },
+          subscribe: true,
+        });
+      }
+    }
+  }
+
+  return FormValueSubscriberElement as unknown as Constructor<FormValueSubscriberInterface> &
+    T;
+};

--- a/apps/generate-ui-v2/src/ide-communication.controller.ts
+++ b/apps/generate-ui-v2/src/ide-communication.controller.ts
@@ -79,12 +79,12 @@ export class IdeCommunicationController implements ReactiveController {
   }
 
   private pendingPluginValidationQueue: ((
-    results: ValidationResults
+    results: ValidationResults,
   ) => void)[] = [];
 
   async getValidationResults(
     formValues: FormValues,
-    schema: GeneratorSchema
+    schema: GeneratorSchema,
   ): Promise<ValidationResults> {
     // send request and wait until handleInputMessage resolves the promise
     const promise = new Promise<ValidationResults>((resolve) => {
@@ -92,7 +92,7 @@ export class IdeCommunicationController implements ReactiveController {
     });
 
     this.postMessageToIde(
-      new GenerateUiRequestValidationOutputMessage({ formValues, schema })
+      new GenerateUiRequestValidationOutputMessage({ formValues, schema }),
     );
 
     return await promise;
@@ -112,7 +112,7 @@ export class IdeCommunicationController implements ReactiveController {
         }
 
         this.handleInputMessage(data);
-      }
+      },
     );
 
     this.postToIde = (message) => vscode.postMessage(message);
@@ -127,7 +127,7 @@ export class IdeCommunicationController implements ReactiveController {
         }
 
         this.handleInputMessage(message);
-      }
+      },
     );
 
     this.postToIde = (message) => {
@@ -141,7 +141,7 @@ export class IdeCommunicationController implements ReactiveController {
       case 'generator': {
         this.generatorSchema = message.payload;
         this.generatorContextContextProvider.setValue(
-          this.generatorSchema.context
+          this.generatorSchema.context,
         );
 
         this.host.requestUpdate();
@@ -171,6 +171,21 @@ export class IdeCommunicationController implements ReactiveController {
           resolve(message.payload);
         }
 
+        break;
+      }
+      case 'update-form-values': {
+        // Get the Root element cast to access its formValuesService
+        const root = this.host as unknown as {
+          formValuesService: {
+            updateFormValuesFromIde: (values: FormValues) => void;
+          };
+        };
+
+        if (root.formValuesService) {
+          root.formValuesService.updateFormValuesFromIde(message.payload);
+        }
+
+        this.host.requestUpdate();
         break;
       }
     }

--- a/apps/generate-ui-v2/src/main.ts
+++ b/apps/generate-ui-v2/src/main.ts
@@ -63,6 +63,16 @@ export class Root extends LitElement {
     document.body.removeChild(a);
   }
 
+  fillWithCopilot() {
+    this.icc.postMessageToIde({
+      payloadType: 'fill-with-copilot',
+      payload: {
+        generatorName: `${this.icc.generatorSchema?.collectionName}:${this.icc.generatorSchema?.generatorName}`,
+        formValues: this.formValuesService.getFormValues(),
+      },
+    });
+  }
+
   protected createRenderRoot() {
     return this;
   }
@@ -100,6 +110,20 @@ export class Root extends LitElement {
           </div>
 
           <div class="flex shrink-0">
+            ${when(
+              this.icc.editor === 'vscode' &&
+                this.icc.configuration?.hasCopilot,
+              () => html`
+                <button-element
+                  @click="${() => this.fillWithCopilot()}"
+                  title="Fill Generate UI with Copilot"
+                  appearance="icon"
+                  text="copilot"
+                  class="self-center py-2 pl-3"
+                >
+                </button-element>
+              `,
+            )}
             ${when(
               isNxGenerator && this.icc.editor === 'vscode',
               () => html`

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -440,6 +440,12 @@
           {
             "name": "explain-cipe",
             "description": "Explain the CI pipeline execution failure"
+          },
+          {
+            "name": "fill-generate-ui",
+            "description": "Fill the Nx generate UI with options",
+            "isSticky": false,
+            "when": "nxConsole.isFillingGenerateUi == true"
           }
         ],
         "disambiguation": [
@@ -506,13 +512,11 @@
       },
       {
         "name": "nx_generator-details",
+        "modelDescription": "View detailed information about an Nx generator",
+        "displayName": "Generator Details",
         "tags": [
           "nx"
         ],
-        "toolReferenceName": "nxGeneratorDetails",
-        "displayName": "Generator Details",
-        "modelDescription": "The detailed JSON schema for an nx generator",
-        "icon": "$(code-oss)",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -549,7 +553,7 @@
         }
       },
       {
-        "name": "nx_visualize_project_graph_project",
+        "name": "nx_visualize-project-graph-project",
         "tags": [
           "nx"
         ],
@@ -571,7 +575,7 @@
         }
       },
       {
-        "name": "nx_visualize_task_graph",
+        "name": "nx_visualize-task-graph",
         "tags": [
           "nx"
         ],
@@ -595,6 +599,67 @@
             "projectName",
             "taskName"
           ]
+        }
+      },
+      {
+        "name": "nx_available-plugins",
+        "modelDescription": "Lists available Nx plugins, including official and local workspace plugins. Use this to answer questions about nx plugins or integrations.",
+        "displayName": "Available Nx Plugins",
+        "icon": "$(plug)",
+        "toolReferenceName": "nxAvailablePlugins",
+        "tags": [
+          "nx"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "nx_open-generate-ui",
+        "modelDescription": "Opens the Nx generate UI with prefilled options",
+        "displayName": "Nx Generate UI",
+        "icon": "$(window)",
+        "tags": [
+          "nx"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "generatorName": {
+              "type": "string",
+              "description": "The name of the generator to open in the UI."
+            },
+            "options": {
+              "type": "object",
+              "description": "The options to prefill in the UI.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "cwd": {
+              "type": "string",
+              "description": "The current working directory to use for the generator. Relative to the nx workspace root. If not specified, will default to the nx workspace root."
+            }
+          },
+          "required": [
+            "generatorName",
+            "options"
+          ]
+        }
+      },
+      {
+        "name": "nx_visualize-full-project-graph",
+        "tags": [
+          "nx"
+        ],
+        "modelDescription": "Visualizes the entire Nx project graph for the workspace",
+        "icon": "$(source-control)",
+        "displayName": "Nx Full Project Graph",
+        "toolReferenceName": "nxVisualizeFullProjectGraph",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
         }
       }
     ],

--- a/apps/vscode/project.json
+++ b/apps/vscode/project.json
@@ -37,6 +37,11 @@
         "tsConfig": "apps/vscode/tsconfig.app.json",
         "assets": [
           {
+            "glob": "wrap-generator.js",
+            "input": "apps/vscode/src",
+            "output": "/"
+          },
+          {
             "glob": "nx-schema.json",
             "input": "apps/vscode/src",
             "output": "/"

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -31,7 +31,7 @@ import {
   watchFile,
 } from '@nx-console/vscode-utils';
 
-import { initMcp, updateMcpServerWorkspacePath } from '@nx-console/mcp';
+import { initMcp, updateMcpServerWorkspacePath } from '@nx-console/vscode-mcp';
 import { fileExists } from '@nx-console/shared-file-system';
 import {
   AddDependencyCodelensProvider,

--- a/apps/vscode/src/refresh-workspace.ts
+++ b/apps/vscode/src/refresh-workspace.ts
@@ -3,7 +3,7 @@ import { getNxlsClient } from '@nx-console/vscode-lsp-client';
 import { getOutputChannel } from '@nx-console/vscode-output-channels';
 import { getTelemetry } from '@nx-console/vscode-telemetry';
 import { commands, ExtensionContext } from 'vscode';
-import { refreshMcp } from '@nx-console/mcp';
+import { refreshMcp } from '@nx-console/vscode-mcp';
 
 const REFRESH_WORKSPACE = 'nxConsole.refreshWorkspace';
 

--- a/apps/vscode/src/wrap-generator.js
+++ b/apps/vscode/src/wrap-generator.js
@@ -1,0 +1,84 @@
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+
+const args = process.argv.slice(2);
+
+let generatorName = args[3] || 'unknown-generator';
+
+generatorName = generatorName.startsWith('@')
+  ? generatorName.substring(1).replace(/\//g, '-')
+  : generatorName.replace(/[@/]/g, '-');
+
+const cacheDirModule = require('nx/src/utils/cache-directory');
+const cacheDir = cacheDirModule.workspaceDataDirectory;
+
+const outputDir = path.join(cacheDir, 'console-generators');
+mkdirp.sync(outputDir);
+
+const findNextAvailableFileName = (baseName) => {
+  const baseFileName = path.join(outputDir, `${baseName}.log`);
+
+  if (!fs.existsSync(baseFileName)) {
+    return baseFileName;
+  }
+
+  let counter = 1;
+  let nextFileName;
+
+  do {
+    nextFileName = path.join(outputDir, `${baseName}-${counter}.log`);
+    counter++;
+  } while (fs.existsSync(nextFileName));
+
+  return nextFileName;
+};
+
+const outputFile = findNextAvailableFileName(generatorName);
+
+const outputLines = [];
+
+const command = args[0];
+const commandArgs = args.slice(1);
+
+const env = {
+  ...process.env,
+  FORCE_COLOR: 'true',
+  COLORTERM: 'truecolor',
+  TERM: process.env.TERM || 'xterm-256color',
+};
+
+const childProcess = spawn(command, commandArgs, {
+  stdio: ['inherit', 'pipe', 'pipe'],
+  shell: true,
+  env,
+  cwd: process.cwd(),
+});
+
+// Capture and forward stdout
+childProcess.stdout.on('data', (data) => {
+  const text = data.toString();
+  process.stdout.write(text);
+  outputLines.push(text);
+});
+
+// Capture and forward stderr
+childProcess.stderr.on('data', (data) => {
+  const text = data.toString();
+  process.stderr.write(text);
+  outputLines.push(text);
+});
+
+// Handle process completion
+childProcess.on('close', (code) => {
+  // Write captured output to file
+  fs.writeFileSync(outputFile, outputLines.join(''));
+  process.exit(code);
+});
+
+// Handle errors
+childProcess.on('error', (err) => {
+  console.error(`Failed to start command: ${err}`);
+  process.exit(1);
+});

--- a/apps/vscode/src/wrap-generator.js
+++ b/apps/vscode/src/wrap-generator.js
@@ -1,21 +1,30 @@
 const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const mkdirp = require('mkdirp');
 
 const args = process.argv.slice(2);
 
 let generatorName = args[3] || 'unknown-generator';
 
 generatorName = generatorName.startsWith('@')
-  ? generatorName.substring(1).replace(/\//g, '-')
-  : generatorName.replace(/[@/]/g, '-');
+  ? generatorName.substring(1).replace(/[/:]/g, '-')
+  : generatorName.replace(/[@/:]/g, '-');
 
-const cacheDirModule = require('nx/src/utils/cache-directory');
-const cacheDir = cacheDirModule.workspaceDataDirectory;
+let cacheDir = './.nx/workspace-data';
+try {
+  const cacheDirModulePath = require.resolve('nx/src/utils/cache-directory', {
+    paths: [process.cwd()],
+  });
+  if (cacheDirModulePath) {
+    const cacheDirModule = require(cacheDirModulePath);
+    cacheDir = cacheDirModule.workspaceDataDirectory;
+  }
+} catch (e) {
+  // do nothing
+}
 
 const outputDir = path.join(cacheDir, 'console-generators');
-mkdirp.sync(outputDir);
+fs.mkdirSync(outputDir, { recursive: true });
 
 const findNextAvailableFileName = (baseName) => {
   const baseFileName = path.join(outputDir, `${baseName}.log`);

--- a/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
@@ -398,7 +398,10 @@ export class NxMcpServerWrapper {
 Found generator schema for ${generatorName}: ${JSON.stringify(
                 generatorDetails,
               )}.
-**IMPORTANT FIRST STEP**: When generating libraries, apps, or components:
+              ${
+                this.ideProvider
+                  ? `Follow up by using the nx_run_generator tool. When generating libraries, apps or components, use the cwd option to specify the parent directory where you want to create the item.`
+                  : `**IMPORTANT FIRST STEP**: When generating libraries, apps, or components:
 
 1. FIRST navigate to the parent directory where you want to create the item:
 - Example: 'cd libs/shared' to create a library in libs/shared
@@ -410,7 +413,9 @@ Found generator schema for ${generatorName}: ${JSON.stringify(
 - Use 'cd' to change directories and specify the positional arg instead
 
 This approach provides better clarity about where new code will be generated
-and follows the Nx workspace convention for project organization.
+and follows the Nx workspace convention for project organization.`
+              }
+
             `,
             },
             {
@@ -520,8 +525,8 @@ and follows the Nx workspace convention for project organization.
     );
 
     this.server.tool(
-      'nx_open_generate_ui',
-      'Opens the generate ui WITH WHATEVER OPTIONS YOU PROVIDE PREFILLED. This allows the user to tweak the generator options before running it. ALWAYS use this instead of running a generator directly via the CLI. You can also call this tool to overwrite the options for an existing generator invocation.',
+      'nx_run_generator',
+      'Opens the generate ui with whatever options you provide prefilled. ALWAYS USE THIS to run nx generators. Use the nx_generators and nx_generator_schema tools to learn about the available options BEFORE using this tool. ALWAYS use this when the user wants to generate something and ALWAYS use this instead of running a generator directly via the CLI. You can also call this tool to overwrite the options for an existing generator invocation.',
       {
         generatorName: z.string().describe('The name of the generator to run'),
         options: z

--- a/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
@@ -1,38 +1,34 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
+  createGeneratorUiResponseMessage,
   getDocsContext,
   getDocsPrompt,
   getGeneratorNamesAndDescriptions,
   getGeneratorSchema,
   getGeneratorsPrompt,
   getNxJsonPrompt,
+  getPluginsInformation,
   getProjectGraphErrorsPrompt,
   getProjectGraphPrompt,
+  getProjectGraphVisualizationMessage,
+  getTaskGraphVisualizationMessage,
 } from '@nx-console/shared-llm-context';
 import {
   checkIsNxWorkspace,
   findMatchingProject,
-  getLocalWorkspacePlugins,
-  isDotNxInstallation,
 } from '@nx-console/shared-npm';
 import { NxConsoleTelemetryLogger } from '@nx-console/shared-telemetry';
-import { getAvailableNxPlugins, Logger } from '@nx-console/shared-utils';
+import { Logger } from '@nx-console/shared-utils';
 import { z } from 'zod';
 import { getMcpLogger } from './mcp-logger';
 
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { NxGeneratorsRequestOptions } from '@nx-console/language-server-types';
+import { NxVersion } from '@nx-console/nx-version';
 import { GeneratorCollectionInfo } from '@nx-console/shared-schema';
-import {
-  FocusProjectMessage,
-  FocusTaskMessage,
-  FullProjectGraphMessage,
-  IdeCallbackMessage,
-  NxWorkspace,
-} from '@nx-console/shared-types';
-import { gte, NxVersion } from '@nx-console/nx-version';
-import { join } from 'path';
+import { NxWorkspace } from '@nx-console/shared-types';
 import { readFile } from 'fs/promises';
+import path from 'path';
 import { registerNxCloudTools } from './tools/nx-cloud';
 
 export interface NxWorkspaceInfoProvider {
@@ -54,6 +50,17 @@ export interface NxWorkspaceInfoProvider {
   isNxCloudEnabled: boolean;
 }
 
+export interface NxIdeProvider {
+  focusProject: (projectName: string) => void;
+  focusTask: (projectName: string, taskName: string) => void;
+  showFullProjectGraph: () => void;
+  openGenerateUi: (
+    generatorName: string,
+    options: Record<string, unknown>,
+    cwd?: string,
+  ) => Promise<string>;
+}
+
 export class NxMcpServerWrapper {
   private server: McpServer;
   private logger: Logger;
@@ -62,7 +69,7 @@ export class NxMcpServerWrapper {
   constructor(
     initialWorkspacePath: string | undefined,
     private nxWorkspaceInfoProvider: NxWorkspaceInfoProvider,
-    private ideCallback?: (message: IdeCallbackMessage) => void,
+    private ideProvider?: NxIdeProvider,
     private telemetry?: NxConsoleTelemetryLogger,
     logger?: Logger,
   ) {
@@ -115,8 +122,13 @@ export class NxMcpServerWrapper {
       'nx_available_plugins',
       'Returns a list of available Nx plugins from the core team as well as local workspace Nx plugins.',
       async () => {
+        this.telemetry?.logUsage('ai.tool-call', {
+          tool: 'nx_available_plugins',
+        });
+
         let nxVersion: NxVersion | undefined = undefined;
         let nxWorkspace: NxWorkspace | undefined = undefined;
+        const workspacePath: string | undefined = this._nxWorkspacePath;
 
         if (this._nxWorkspacePath) {
           nxWorkspace = await this.nxWorkspaceInfoProvider.nxWorkspace(
@@ -126,117 +138,18 @@ export class NxMcpServerWrapper {
           nxVersion = nxWorkspace?.nxVersion;
         }
 
-        const availablePlugins = await getAvailableNxPlugins(nxVersion);
-
-        const availablePluginNames = new Set([
-          ...availablePlugins.official.map((plugin) => plugin.name),
-          ...availablePlugins.community.map((plugin) => plugin.name),
-        ]);
-
-        const localWorkspacePlugins: string[] = [];
-        let installedPlugins: string[] = [];
-
-        if (this._nxWorkspacePath && nxWorkspace) {
-          try {
-            const isDotNx = await isDotNxInstallation(this._nxWorkspacePath);
-
-            const packageJsonPath = isDotNx
-              ? join(
-                  this._nxWorkspacePath,
-                  '.nx',
-                  'installation',
-                  'package.json',
-                )
-              : join(this._nxWorkspacePath, 'package.json');
-
-            const packageJsonContent = await readFile(packageJsonPath, 'utf-8');
-            const packageJson = JSON.parse(packageJsonContent);
-
-            const allDependencies = {
-              ...(packageJson.dependencies || {}),
-              ...(packageJson.devDependencies || {}),
-            };
-
-            installedPlugins = Object.keys(allDependencies).filter((depName) =>
-              availablePluginNames.has(depName),
-            );
-          } catch (error) {
-            this.logger.log(
-              `Error determining installed plugins: ${error instanceof Error ? error.message : String(error)}`,
-            );
-            installedPlugins = [];
-          }
-          try {
-            const localPluginsMap = await getLocalWorkspacePlugins(
-              this._nxWorkspacePath,
-              nxWorkspace,
-            );
-            localPluginsMap.forEach((plugin) => {
-              localWorkspacePlugins.push(plugin.name);
-            });
-          } catch (error) {
-            this.logger.log(
-              `Error determining local plugins: ${error instanceof Error ? error.message : String(error)}`,
-            );
-          }
-        }
-
-        let formattedText = '';
-
-        if (localWorkspacePlugins.length > 0) {
-          formattedText += `=== LOCAL NX PLUGINS ===\n`;
-          formattedText += `(Note: These plugins are local to your workspace)\n\n`;
-          localWorkspacePlugins.forEach((pluginName) => {
-            formattedText += `[${pluginName}]\n`;
-          });
-          formattedText += `\n`;
-        }
-
-        if (installedPlugins.length > 0) {
-          formattedText += `=== INSTALLED NX PLUGINS ===\n`;
-          formattedText += `(Note: Installed plugins are not repeated in other categories)\n\n`;
-          installedPlugins.forEach((pluginName) => {
-            formattedText += `[${pluginName}]\n`;
-          });
-          formattedText += `\n`;
-        }
-
-        formattedText += `=== OFFICIAL NX PLUGINS ===\n`;
-
-        availablePlugins.official
-          .filter((plugin) => !installedPlugins.includes(plugin.name))
-          .forEach((plugin) => {
-            const cleanDescription = plugin.description
-              .replace(/\n/g, ' ')
-              .replace(/\s+/g, ' ')
-              .trim();
-
-            formattedText += `[${plugin.name}]\n${cleanDescription}\n`;
-          });
-
-        // We are going to disable community plugins for now as we work on cleaning up the registry
-
-        // formattedText += `=== COMMUNITY NX PLUGINS ===\n`;
-        // availablePlugins.community
-        //   .filter((plugin) => !localPlugins.includes(plugin.name))
-        //   .forEach((plugin) => {
-        //     const cleanDescription = plugin.description
-        //       .replace(/\n/g, ' ')
-        //       .replace(/\s+/g, ' ')
-        //       .trim();
-
-        //     formattedText += `[${plugin.name}]\n${cleanDescription}\n`;
-
-        //     if (plugin.url) {
-        //       formattedText += `URL: ${plugin.url}\n`;
-        //     }
-        //   });
+        const pluginsInfo = await getPluginsInformation(
+          nxVersion,
+          workspacePath,
+          nxWorkspace,
+          this.logger,
+        );
 
         return {
           content: [
             {
               type: 'text',
-              text: formattedText,
+              text: pluginsInfo.formattedText,
             },
           ],
         };
@@ -257,8 +170,8 @@ export class NxMcpServerWrapper {
       }
     }
 
-    if (this.ideCallback) {
-      this.registerIdeCallbackTools();
+    if (this.ideProvider) {
+      this.registerIdeTools();
     }
   }
 
@@ -465,6 +378,18 @@ export class NxMcpServerWrapper {
           generators,
         );
 
+        let examples = '';
+        try {
+          const examplesPath = path.join(
+            generators.find((g) => g.name === generatorName)?.schemaPath ?? '',
+            '..',
+            'examples.md',
+          );
+          examples = await readFile(examplesPath, 'utf-8');
+        } catch (e) {
+          examples = 'No examples available';
+        }
+
         return {
           content: [
             {
@@ -488,13 +413,17 @@ This approach provides better clarity about where new code will be generated
 and follows the Nx workspace convention for project organization.
             `,
             },
+            {
+              type: 'text',
+              text: 'Examples: \n' + examples,
+            },
           ],
         };
       },
     );
   }
 
-  private registerIdeCallbackTools(): void {
+  private registerIdeTools(): void {
     this.server.tool(
       'nx_visualize_graph',
       'Visualize the Nx graph. This can show either a project graph or a task graph depending on the parameters. Use this to help users understand project dependencies or task dependencies. There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.',
@@ -522,7 +451,8 @@ and follows the Nx workspace convention for project organization.
           tool: 'nx_visualize_graph',
           kind: visualizationType,
         });
-        if (this.ideCallback) {
+
+        if (this.ideProvider) {
           switch (visualizationType) {
             case 'project':
               if (!projectName) {
@@ -531,17 +461,12 @@ and follows the Nx workspace convention for project organization.
                   content: [{ type: 'text', text: 'Project name is required' }],
                 };
               }
-              this.ideCallback({
-                type: 'focus-project',
-                payload: {
-                  projectName,
-                },
-              } satisfies FocusProjectMessage);
+              this.ideProvider.focusProject(projectName);
               return {
                 content: [
                   {
                     type: 'text',
-                    text: `Opening project graph for ${projectName}. There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.`,
+                    text: getProjectGraphVisualizationMessage(projectName),
                   },
                 ],
               };
@@ -563,30 +488,25 @@ and follows the Nx workspace convention for project organization.
                   content: [{ type: 'text', text: 'Project name is required' }],
                 };
               }
-              this.ideCallback({
-                type: 'focus-task',
-                payload: {
-                  projectName,
-                  taskName,
-                },
-              } satisfies FocusTaskMessage);
+              this.ideProvider.focusTask(projectName, taskName);
               return {
                 content: [
                   {
                     type: 'text',
-                    text: `Opening graph focused on task ${taskName} for project ${projectName}. There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.`,
+                    text: getTaskGraphVisualizationMessage(
+                      projectName,
+                      taskName,
+                    ),
                   },
                 ],
               };
             case 'full-project-graph':
-              this.ideCallback({
-                type: 'full-project-graph',
-              } satisfies FullProjectGraphMessage);
+              this.ideProvider.showFullProjectGraph();
               return {
                 content: [
                   {
                     type: 'text',
-                    text: 'Opening full project graph. There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.',
+                    text: getProjectGraphVisualizationMessage(),
                   },
                 ],
               };
@@ -594,8 +514,67 @@ and follows the Nx workspace convention for project organization.
         }
         return {
           isError: true,
-          content: [{ type: 'text', text: 'No IDE available' }],
+          content: [{ type: 'text', text: 'No IDE provider available' }],
         };
+      },
+    );
+
+    this.server.tool(
+      'nx_open_generate_ui',
+      'Opens the generate ui WITH WHATEVER OPTIONS YOU PROVIDE PREFILLED. This allows the user to tweak the generator options before running it. ALWAYS use this instead of running a generator directly via the CLI. You can also call this tool to overwrite the options for an existing generator invocation.',
+      {
+        generatorName: z.string().describe('The name of the generator to run'),
+        options: z
+          .record(z.string(), z.unknown())
+          .describe('The options to pass to the generator'),
+        cwd: z
+          .string()
+          .optional()
+          .describe(
+            'The current working directory to run the generator from. This is always relative to the workspace root. If not specified, the workspace root will be used.',
+          ),
+      },
+      async ({ generatorName, options, cwd }) => {
+        this.telemetry?.logUsage('ai.tool-call', {
+          tool: 'nx_open_generate_ui',
+        });
+        if (!this._nxWorkspacePath) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'Error: Workspace path not set' }],
+          };
+        }
+
+        if (!this.ideProvider) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'No IDE provider available' }],
+          };
+        }
+        try {
+          const logFileName = await this.ideProvider.openGenerateUi(
+            generatorName,
+            options ?? {},
+            cwd,
+          );
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: createGeneratorUiResponseMessage(
+                  generatorName,
+                  logFileName,
+                ),
+              },
+            ],
+          };
+        } catch (e) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: String(e) }],
+          };
+        }
       },
     );
   }

--- a/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
@@ -541,7 +541,7 @@ and follows the Nx workspace convention for project organization.`
       },
       async ({ generatorName, options, cwd }) => {
         this.telemetry?.logUsage('ai.tool-call', {
-          tool: 'nx_open_generate_ui',
+          tool: 'nx_run_generator',
         });
         if (!this._nxWorkspacePath) {
           return {

--- a/libs/shared/generate-ui-types/src/lib/messages.ts
+++ b/libs/shared/generate-ui-types/src/lib/messages.ts
@@ -14,7 +14,8 @@ export type GenerateUiOutputMessage =
   | GenerateUiFormInitOutputMessage
   | GenerateUiRunGeneratorOutputMessage
   | GenerateUiRequestValidationOutputMessage
-  | GenerateUiCopyToClipboardOutputMessage;
+  | GenerateUiCopyToClipboardOutputMessage
+  | GenerateUiFillWithCopilotOutputMessage;
 
 export class GenerateUiFormInitOutputMessage {
   readonly payloadType = 'output-init';
@@ -36,7 +37,10 @@ export class GenerateUiRequestValidationOutputMessage {
   readonly payloadType = 'request-validation';
 
   constructor(
-    public readonly payload: { formValues: FormValues; schema: GeneratorSchema }
+    public readonly payload: {
+      formValues: FormValues;
+      schema: GeneratorSchema;
+    },
   ) {}
 }
 
@@ -44,6 +48,16 @@ export class GenerateUiCopyToClipboardOutputMessage {
   readonly payloadType = 'copy-to-clipboard';
 
   constructor(public readonly payload: string) {}
+}
+
+export class GenerateUiFillWithCopilotOutputMessage {
+  readonly payloadType = 'fill-with-copilot';
+  constructor(
+    public readonly payload: {
+      generatorName: string;
+      formValues: FormValues;
+    },
+  ) {}
 }
 
 /**
@@ -55,8 +69,8 @@ export type GenerateUiInputMessage =
   | GenerateUiConfigurationInputMessage
   | GenerateUiStylesInputMessage
   | GenerateUiBannerInputMessage
-  | GenerateUiValidationResultsInputMessage;
-
+  | GenerateUiValidationResultsInputMessage
+  | GenerateUiUpdateFormValuesInputMessage;
 export class GenerateUiGeneratorSchemaInputMessage {
   readonly payloadType = 'generator';
 
@@ -71,6 +85,7 @@ export class GenerateUiConfigurationInputMessage {
 
 export type GenerateUiConfiguration = {
   enableTaskExecutionDryRunOnChange: boolean;
+  hasCopilot: boolean;
 };
 
 export class GenerateUiStylesInputMessage {
@@ -107,7 +122,7 @@ export class GenerateUiBannerInputMessage {
     public readonly payload: {
       message: string;
       type: 'warning' | 'error';
-    }
+    },
   ) {}
 }
 
@@ -115,4 +130,10 @@ export class GenerateUiValidationResultsInputMessage {
   readonly payloadType = 'validation-results';
 
   constructor(public readonly payload: ValidationResults) {}
+}
+
+export class GenerateUiUpdateFormValuesInputMessage {
+  readonly payloadType = 'update-form-values';
+
+  constructor(public readonly payload: FormValues) {}
 }

--- a/libs/shared/llm-context/src/index.ts
+++ b/libs/shared/llm-context/src/index.ts
@@ -3,3 +3,6 @@ export * from './lib/nx-json';
 export * from './lib/docs';
 export * from './lib/generators';
 export * from './lib/generator-details';
+export * from './lib/plugins';
+export * from './lib/generate-ui';
+export * from './lib/graph-visualization';

--- a/libs/shared/llm-context/src/lib/generate-ui.ts
+++ b/libs/shared/llm-context/src/lib/generate-ui.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { getWorkspaceDataDirectory } from '@nx-console/shared-npm';
 
 /**
@@ -31,7 +31,9 @@ export async function createGeneratorLogFileName(
     } while (existsSync(finalFileName));
   }
 
-  return finalFileName;
+  const relativeFileName = relative(workspacePath, finalFileName);
+
+  return relativeFileName;
 }
 
 /**

--- a/libs/shared/llm-context/src/lib/generate-ui.ts
+++ b/libs/shared/llm-context/src/lib/generate-ui.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getWorkspaceDataDirectory } from '@nx-console/shared-npm';
+
+/**
+ * Creates a standardized log file name for generator execution
+ */
+export async function createGeneratorLogFileName(
+  workspacePath: string,
+  generatorName: string,
+): Promise<string> {
+  const sanitizedGeneratorName = generatorName.startsWith('@')
+    ? generatorName.substring(1).replace(/\//g, '-')
+    : generatorName.replace(/[@/]/g, '-');
+
+  const outputDir = join(
+    await getWorkspaceDataDirectory(workspacePath),
+    'console-generators',
+  );
+  const baseFileName = join(outputDir, `${sanitizedGeneratorName}.log`);
+
+  let finalFileName = baseFileName;
+  if (existsSync(baseFileName)) {
+    let counter = 1;
+    do {
+      finalFileName = join(
+        outputDir,
+        `${sanitizedGeneratorName}-${counter}.log`,
+      );
+      counter++;
+    } while (existsSync(finalFileName));
+  }
+
+  return finalFileName;
+}
+
+/**
+ * Creates the response message for when a generator UI is opened
+ */
+export function createGeneratorUiResponseMessage(
+  generatorName: string,
+  logFileName: string,
+): string {
+  return `Opening generate UI for ${generatorName} - THE USER IS MAKING CHANGES. PAUSE YOUR ANSWER. WAIT FOR THEM TO ASK YOU TO FINISH. THE GENERATOR RESULTS WILL BE WRITTEN TO ${logFileName} IF THE USER FINISHES THE GENERATOR. THIS FILE SHOULD NOT BE MENTIONED TO THE USER BUT YOU CAN READ THIS FILE TO UNDERSTAND WHAT HAPPENED DURING THE GENERATOR INVOCATION. IF MULTIPLE GENERATORS ARE INVOKED, THERE WILL BE MULTIPLE FILES.`;
+}

--- a/libs/shared/llm-context/src/lib/generate-ui.ts
+++ b/libs/shared/llm-context/src/lib/generate-ui.ts
@@ -10,8 +10,8 @@ export async function createGeneratorLogFileName(
   generatorName: string,
 ): Promise<string> {
   const sanitizedGeneratorName = generatorName.startsWith('@')
-    ? generatorName.substring(1).replace(/\//g, '-')
-    : generatorName.replace(/[@/]/g, '-');
+    ? generatorName.substring(1).replace(/[/:]/g, '-')
+    : generatorName.replace(/[@/:]/g, '-');
 
   const outputDir = join(
     await getWorkspaceDataDirectory(workspacePath),

--- a/libs/shared/llm-context/src/lib/graph-visualization.ts
+++ b/libs/shared/llm-context/src/lib/graph-visualization.ts
@@ -1,0 +1,21 @@
+/**
+ * Creates a standard response message for project graph visualization
+ */
+export function getProjectGraphVisualizationMessage(
+  projectName?: string,
+): string {
+  if (projectName) {
+    return `Opening project graph for ${projectName}. There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.`;
+  }
+  return 'Opening full project graph. There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.';
+}
+
+/**
+ * Creates a standard response message for task graph visualization
+ */
+export function getTaskGraphVisualizationMessage(
+  projectName: string,
+  taskName: string,
+): string {
+  return `Opening graph focused on task ${taskName} for project ${projectName}. There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.`;
+}

--- a/libs/shared/llm-context/src/lib/nx-console-rules.ts
+++ b/libs/shared/llm-context/src/lib/nx-console-rules.ts
@@ -1,0 +1,14 @@
+export const nxConsoleRules = `
+You have access to the Nx MCP server and the tools it provides. Use them.
+
+If the user wants to generate a file, use the following flow: 
+- learn about the nx workspace and any specifics the user needs
+- get the available generators using the 'nx_generators' tool
+- decide which generator to use
+- get generator details using the 'nx_generator_details' tool
+- decide which options to provide in order to best complete the user's request. Don't make any assumptions and keep the options minimalistic
+- open the generator UI using the 'nx_open_generate_ui' tool
+- wait for the user to finish the generator
+- read the generator log file using the 'nx_read_generator_log' tool
+- use the information provided in the log file to answer the user's question
+`;

--- a/libs/shared/llm-context/src/lib/plugins.ts
+++ b/libs/shared/llm-context/src/lib/plugins.ts
@@ -1,0 +1,152 @@
+import {
+  getLocalWorkspacePlugins,
+  isDotNxInstallation,
+} from '@nx-console/shared-npm';
+import {
+  AvailableNxPlugin,
+  getAvailableNxPlugins,
+} from '@nx-console/shared-utils';
+import { NxVersion } from '@nx-console/nx-version';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+import { NxWorkspace } from '@nx-console/shared-types';
+
+export interface LoggerInterface {
+  log: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+/**
+ * Gets the formatted plugins information
+ */
+export async function getPluginsInformation(
+  nxVersion: NxVersion | undefined,
+  workspacePath: string | undefined,
+  nxWorkspace: NxWorkspace | undefined,
+  logger?: LoggerInterface,
+): Promise<{
+  formattedText: string;
+  official: AvailableNxPlugin[];
+  community: AvailableNxPlugin[];
+  installed: string[];
+  local: string[];
+}> {
+  const availablePlugins = await getAvailableNxPlugins(nxVersion);
+
+  const availablePluginNames = new Set([
+    ...availablePlugins.official.map((plugin) => plugin.name),
+    ...availablePlugins.community.map((plugin) => plugin.name),
+  ]);
+
+  const localWorkspacePlugins: string[] = [];
+  let installedPlugins: string[] = [];
+
+  if (workspacePath && nxWorkspace) {
+    try {
+      const isDotNx = await isDotNxInstallation(workspacePath);
+
+      const packageJsonPath = isDotNx
+        ? join(workspacePath, '.nx', 'installation', 'package.json')
+        : join(workspacePath, 'package.json');
+
+      const packageJsonContent = await readFile(packageJsonPath, 'utf-8');
+      const packageJson = JSON.parse(packageJsonContent);
+
+      const allDependencies = {
+        ...(packageJson.dependencies || {}),
+        ...(packageJson.devDependencies || {}),
+      };
+
+      installedPlugins = Object.keys(allDependencies).filter((depName) =>
+        availablePluginNames.has(depName),
+      );
+    } catch (error) {
+      const errorMessage = `Error determining installed plugins: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+      if (logger) {
+        logger.log(errorMessage);
+      } else if (console) {
+        console.error(errorMessage);
+      }
+      installedPlugins = [];
+    }
+
+    try {
+      const localPluginsMap = await getLocalWorkspacePlugins(
+        workspacePath,
+        nxWorkspace,
+      );
+      localPluginsMap.forEach((plugin) => {
+        localWorkspacePlugins.push(plugin.name);
+      });
+    } catch (error) {
+      const errorMessage = `Error determining local plugins: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+      if (logger) {
+        logger.log(errorMessage);
+      } else if (console) {
+        console.error(errorMessage);
+      }
+    }
+  }
+
+  const formattedText = formatAvailablePluginsPrompt(
+    availablePlugins.official,
+    installedPlugins,
+    localWorkspacePlugins,
+  );
+
+  return {
+    formattedText,
+    official: availablePlugins.official,
+    community: availablePlugins.community,
+    installed: installedPlugins,
+    local: localWorkspacePlugins,
+  };
+}
+
+/**
+ * Formats the available plugins information into a human-readable text format
+ */
+export function formatAvailablePluginsPrompt(
+  officialPlugins: AvailableNxPlugin[],
+  installedPlugins: string[] = [],
+  localWorkspacePlugins: string[] = [],
+): string {
+  let formattedText = '';
+
+  if (localWorkspacePlugins.length > 0) {
+    formattedText += `=== LOCAL NX PLUGINS ===\n`;
+    formattedText += `(Note: These plugins are local to your workspace)\n\n`;
+    localWorkspacePlugins.forEach((pluginName) => {
+      formattedText += `[${pluginName}]\n`;
+    });
+    formattedText += `\n`;
+  }
+
+  if (installedPlugins.length > 0) {
+    formattedText += `=== INSTALLED NX PLUGINS ===\n`;
+    formattedText += `(Note: Installed plugins are not repeated in other categories)\n\n`;
+    installedPlugins.forEach((pluginName) => {
+      formattedText += `[${pluginName}]\n`;
+    });
+    formattedText += `\n`;
+  }
+
+  formattedText += `=== OFFICIAL NX PLUGINS ===\n`;
+  formattedText += `(Note: These plugins are not installed to your workspace, DO NOT TRY TO USE THEM. You can add them by running 'nx add {PLUGIN-NAME})' \n\n`;
+
+  officialPlugins
+    .filter((plugin) => !installedPlugins.includes(plugin.name))
+    .forEach((plugin) => {
+      const cleanDescription = plugin.description
+        ? plugin.description.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim()
+        : '';
+
+      formattedText += `[${plugin.name}]\n${cleanDescription}\n`;
+    });
+
+  return formattedText;
+}

--- a/libs/shared/llm-context/tsconfig.json
+++ b/libs/shared/llm-context/tsconfig.json
@@ -4,13 +4,19 @@
   "include": [],
   "references": [
     {
-      "path": "../utils"
-    },
-    {
       "path": "../types"
     },
     {
+      "path": "../nx-version"
+    },
+    {
+      "path": "../utils"
+    },
+    {
       "path": "../schema"
+    },
+    {
+      "path": "../npm"
     },
     {
       "path": "./tsconfig.lib.json"

--- a/libs/shared/llm-context/tsconfig.lib.json
+++ b/libs/shared/llm-context/tsconfig.lib.json
@@ -10,13 +10,19 @@
   "exclude": ["out-tsc", "**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
   "references": [
     {
-      "path": "../utils/tsconfig.lib.json"
-    },
-    {
       "path": "../types/tsconfig.lib.json"
     },
     {
+      "path": "../nx-version/tsconfig.lib.json"
+    },
+    {
+      "path": "../utils/tsconfig.lib.json"
+    },
+    {
       "path": "../schema/tsconfig.lib.json"
+    },
+    {
+      "path": "../npm/tsconfig.lib.json"
     }
   ]
 }

--- a/libs/shared/npm/src/index.ts
+++ b/libs/shared/npm/src/index.ts
@@ -15,3 +15,4 @@ export * from './lib/local-nx-utils/parse-target-string';
 export * from './lib/local-nx-utils/find-matching-projects';
 export * from './lib/local-nx-utils/get-local-workspace-plugins';
 export * from './lib/nx-json';
+export * from './lib/local-nx-utils/cache-dir';

--- a/libs/shared/npm/src/lib/local-nx-utils/cache-dir.ts
+++ b/libs/shared/npm/src/lib/local-nx-utils/cache-dir.ts
@@ -1,0 +1,33 @@
+import { join } from 'path';
+import {
+  importWorkspaceDependency,
+  workspaceDependencyPath,
+} from '../workspace-dependencies';
+
+export async function getCacheDir(workspacePath: string): Promise<string> {
+  const nxPath = await workspaceDependencyPath(workspacePath, 'nx');
+  if (!nxPath) {
+    throw 'local nx dependency not found';
+  }
+  const importPath = join(nxPath, 'src/utils/cache-directory');
+  const { cacheDir } =
+    await importWorkspaceDependency<
+      typeof import('nx/src/utils/cache-directory')
+    >(importPath);
+  return cacheDir;
+}
+
+export async function getWorkspaceDataDirectory(
+  workspacePath: string,
+): Promise<string> {
+  const nxPath = await workspaceDependencyPath(workspacePath, 'nx');
+  if (!nxPath) {
+    throw 'local nx dependency not found';
+  }
+  const importPath = join(nxPath, 'src/utils/cache-directory');
+  const { workspaceDataDirectory } =
+    await importWorkspaceDependency<
+      typeof import('nx/src/utils/cache-directory')
+    >(importPath);
+  return workspaceDataDirectory;
+}

--- a/libs/shared/utils/src/lib/get-available-nx-plugins.ts
+++ b/libs/shared/utils/src/lib/get-available-nx-plugins.ts
@@ -1,7 +1,7 @@
 import { gte, NxVersion } from '@nx-console/nx-version';
 import { xhr, XHRResponse } from 'request-light';
 
-type AvailableNxPlugin = {
+export type AvailableNxPlugin = {
   name: string;
   description: string;
   url?: string;

--- a/libs/vscode/copilot/src/index.ts
+++ b/libs/vscode/copilot/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/init-copilot.js';
+export * from './lib/init-copilot';

--- a/libs/vscode/copilot/src/lib/init-copilot.ts
+++ b/libs/vscode/copilot/src/lib/init-copilot.ts
@@ -73,7 +73,7 @@ export function initCopilot(context: ExtensionContext) {
       context: ChatContext,
       token: CancellationToken,
     ) {
-      if (result.metadata.command === 'explain-cipe') {
+      if (result.metadata?.command === 'explain-cipe') {
         return [
           {
             prompt: 'Can you fix the error?',

--- a/libs/vscode/copilot/src/lib/prompts/fill-generate-ui-prompt.tsx
+++ b/libs/vscode/copilot/src/lib/prompts/fill-generate-ui-prompt.tsx
@@ -1,0 +1,80 @@
+import { FormValues } from '@nx-console/shared-generate-ui-types';
+import {
+  BasePromptElementProps,
+  PromptElement,
+  PromptPiece,
+  PromptSizing,
+  UserMessage,
+} from '@vscode/prompt-tsx';
+import { ChatResponsePart } from '@vscode/prompt-tsx/dist/base/vscodeTypes';
+import { Progress, CancellationToken } from 'vscode';
+import { NxCopilotPromptProps } from './prompt';
+import { DocsPagesPrompt } from './docs-pages-prompt';
+import { NxProjectGraphPrompt } from './project-graph-prompt';
+import { NxJsonPrompt } from './nx-json-prompt';
+export interface FillGenerateUIPromptProps extends NxCopilotPromptProps {
+  formValues: FormValues;
+  generatorName: string;
+  generatorSchema: any;
+}
+
+export class FillGenerateUIPrompt extends PromptElement<FillGenerateUIPromptProps> {
+  override render(
+    state: void,
+    sizing: PromptSizing,
+    progress?: Progress<ChatResponsePart>,
+    token?: CancellationToken,
+  ): Promise<PromptPiece | undefined> | PromptPiece | undefined {
+    return (
+      <>
+        <UserMessage priority={100}>
+          You are an AI assistant specialized in Nx workspaces and monorepo
+          development. You provide precise, technical guidance for developers
+          working with Nx tools, patterns, and best practices. Use the provided
+          tools available to you to answer the users query.
+          <br /> YOU HAVE ONE JOB AND ONE JOB ONLY: PROVIDE A JSON OBJECT OF
+          FORM VALUES THAT WILL BE USED TO FILL THE GENERATE UI IN THE EDITOR.
+          The generate UI is a form that allows users to select options for a
+          generator. Output nothing but the changes in a JSON code block. <br />
+          Read the metadata about the nx workspace and docs to inform your
+          choices. The things you generate should fit in with similar projects
+          <br />
+          The user is trying to use the {this.props.generatorName} generator.
+          <br />
+          The current form values are: {JSON.stringify(this.props.formValues)}
+          <br />
+          You can make changes to them or overwrite them but leave those that
+          aren't relevant to the query the same. ONLY USE VALUES THAT CONFORM TO
+          THE SCHEMA BELOW.
+          <></>
+          If you're generating a library, app or component, you can specify the
+          parent directory via the cwd option. Don't use the directory option to
+          specify this, ALWAYS specify the cwd with a cwd option even if it's
+          not in the schema. If there is a name and a directory option, use the
+          directory option to specify what the library should be called / what
+          directory it should be placed in. This is not the parent directory but
+          the library itself.
+          <></>
+        </UserMessage>
+        <UserMessage priority={80}>
+          This is the schema for the generator:{' '}
+          {JSON.stringify(this.props.generatorSchema)}
+        </UserMessage>
+        <DocsPagesPrompt
+          docsPages={this.props.docsPages}
+          flexGrow={5}
+          passPriority
+        />
+        <NxProjectGraphPrompt
+          projectGraph={this.props.projectGraph}
+          priority={60}
+          flexGrow={2}
+          flexReserve="/4"
+          passPriority
+        />
+        <NxJsonPrompt nxJson={this.props.nxJson} flexGrow={3} passPriority />
+        <UserMessage priority={90}>{this.props.userQuery}</UserMessage>
+      </>
+    );
+  }
+}

--- a/libs/vscode/copilot/src/lib/tools/available-plugins-tool.ts
+++ b/libs/vscode/copilot/src/lib/tools/available-plugins-tool.ts
@@ -1,0 +1,54 @@
+import { getPluginsInformation } from '@nx-console/shared-llm-context';
+import { getNxWorkspace } from '@nx-console/vscode-nx-workspace';
+import { getTelemetry } from '@nx-console/vscode-telemetry';
+import { vscodeLogger } from '@nx-console/vscode-utils';
+import {
+  CancellationToken,
+  LanguageModelTextPart,
+  LanguageModelTool,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolInvocationPrepareOptions,
+  LanguageModelToolResult,
+  PreparedToolInvocation,
+} from 'vscode';
+
+export class AvailablePluginsTool implements LanguageModelTool<unknown> {
+  async invoke(
+    options: LanguageModelToolInvocationOptions<unknown>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult> {
+    getTelemetry().logUsage('ai.tool-call', {
+      tool: 'nx_available_plugins',
+    });
+
+    try {
+      const nxWorkspace = await getNxWorkspace();
+      const nxVersion = nxWorkspace?.nxVersion;
+      const workspacePath = nxWorkspace?.workspacePath;
+
+      const pluginsInfo = await getPluginsInformation(
+        nxVersion,
+        workspacePath,
+        nxWorkspace,
+        vscodeLogger,
+      );
+
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(pluginsInfo.formattedText),
+      ]);
+    } catch (error) {
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(`Error retrieving Nx plugins: ${error}`),
+      ]);
+    }
+  }
+
+  prepareInvocation(
+    options: LanguageModelToolInvocationPrepareOptions<unknown>,
+    token: CancellationToken,
+  ): PreparedToolInvocation {
+    return {
+      invocationMessage: 'Fetching available Nx plugins',
+    };
+  }
+}

--- a/libs/vscode/copilot/src/lib/tools/generator-details-tool.ts
+++ b/libs/vscode/copilot/src/lib/tools/generator-details-tool.ts
@@ -54,7 +54,7 @@ export class GeneratorDetailsTool
     token: CancellationToken,
   ): PreparedToolInvocation {
     return {
-      invocationMessage: 'Reading generator schema...',
+      invocationMessage: 'Reading generator schema',
     };
   }
 }

--- a/libs/vscode/copilot/src/lib/tools/open-generate-ui-tool.ts
+++ b/libs/vscode/copilot/src/lib/tools/open-generate-ui-tool.ts
@@ -1,0 +1,77 @@
+import { openGenerateUIPrefilled } from '@nx-console/vscode-generate-ui-webview';
+import { getTelemetry } from '@nx-console/vscode-telemetry';
+import { getNxWorkspacePath } from '@nx-console/vscode-configuration';
+import {
+  createGeneratorLogFileName,
+  createGeneratorUiResponseMessage,
+} from '@nx-console/shared-llm-context';
+import {
+  CancellationToken,
+  LanguageModelTextPart,
+  LanguageModelTool,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolInvocationPrepareOptions,
+  LanguageModelToolResult,
+  PreparedToolInvocation,
+} from 'vscode';
+
+export interface OpenGenerateUiToolInput {
+  generatorName: string;
+  options: Record<string, unknown>;
+  cwd?: string;
+}
+
+export class OpenGenerateUiTool
+  implements LanguageModelTool<OpenGenerateUiToolInput>
+{
+  async invoke(
+    options: LanguageModelToolInvocationOptions<OpenGenerateUiToolInput>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult> {
+    getTelemetry().logUsage('ai.tool-call', {
+      tool: 'nx_open_generate_ui',
+    });
+
+    const params = options.input;
+    const workspacePath = getNxWorkspacePath();
+
+    if (!workspacePath) {
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart('Error: Workspace path not set'),
+      ]);
+    }
+
+    try {
+      await openGenerateUIPrefilled({
+        _: ['generate', params.generatorName],
+        $0: 'nx',
+        ...(params.options || {}),
+        ...(params.cwd ? { cwd: params.cwd } : {}),
+      });
+
+      const finalFileName = await createGeneratorLogFileName(
+        workspacePath,
+        params.generatorName,
+      );
+
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(
+          createGeneratorUiResponseMessage(params.generatorName, finalFileName),
+        ),
+      ]);
+    } catch (e) {
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(`Error opening generate UI: ${e}`),
+      ]);
+    }
+  }
+
+  prepareInvocation(
+    options: LanguageModelToolInvocationPrepareOptions<OpenGenerateUiToolInput>,
+    token: CancellationToken,
+  ): PreparedToolInvocation {
+    return {
+      invocationMessage: 'Opening Nx generator UI',
+    };
+  }
+}

--- a/libs/vscode/copilot/src/lib/tools/project-details-tool.ts
+++ b/libs/vscode/copilot/src/lib/tools/project-details-tool.ts
@@ -48,7 +48,7 @@ export class ProjectDetailsTool
     token: CancellationToken,
   ): PreparedToolInvocation {
     return {
-      invocationMessage: 'Reading project configuration...',
+      invocationMessage: 'Reading project configuration',
     };
   }
 }

--- a/libs/vscode/copilot/src/lib/tools/visualize-full-project-graph-tool.ts
+++ b/libs/vscode/copilot/src/lib/tools/visualize-full-project-graph-tool.ts
@@ -1,0 +1,47 @@
+import { getTelemetry } from '@nx-console/vscode-telemetry';
+import { getProjectGraphVisualizationMessage } from '@nx-console/shared-llm-context';
+import { commands } from 'vscode';
+import {
+  CancellationToken,
+  LanguageModelTextPart,
+  LanguageModelTool,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolInvocationPrepareOptions,
+  LanguageModelToolResult,
+  PreparedToolInvocation,
+} from 'vscode';
+
+export class VisualizeFullProjectGraphTool
+  implements LanguageModelTool<unknown>
+{
+  async invoke(
+    options: LanguageModelToolInvocationOptions<unknown>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult> {
+    getTelemetry().logUsage('ai.tool-call', {
+      tool: 'nx_visualize_full_project_graph',
+    });
+
+    try {
+      // Execute the VS Code command to show the full project graph
+      await commands.executeCommand('nx.graph.showAll');
+
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(getProjectGraphVisualizationMessage()),
+      ]);
+    } catch (e) {
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(`Error visualizing project graph: ${e}`),
+      ]);
+    }
+  }
+
+  prepareInvocation(
+    options: LanguageModelToolInvocationPrepareOptions<unknown>,
+    token: CancellationToken,
+  ): PreparedToolInvocation {
+    return {
+      invocationMessage: 'Opening full project graph',
+    };
+  }
+}

--- a/libs/vscode/copilot/src/lib/tools/visualize-project-graph-tool.ts
+++ b/libs/vscode/copilot/src/lib/tools/visualize-project-graph-tool.ts
@@ -1,5 +1,6 @@
 import { getNxWorkspaceProjects } from '@nx-console/vscode-nx-workspace';
 import { getTelemetry } from '@nx-console/vscode-telemetry';
+import { getProjectGraphVisualizationMessage } from '@nx-console/shared-llm-context';
 import {
   CancellationToken,
   commands,
@@ -37,7 +38,7 @@ export class VisualizeProjectGraphTool
 
     return new LanguageModelToolResult([
       new LanguageModelTextPart(
-        `Opening the Nx project graph focused on project "${projectName}". There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.`,
+        getProjectGraphVisualizationMessage(projectName),
       ),
     ]);
   }
@@ -47,7 +48,7 @@ export class VisualizeProjectGraphTool
     token: CancellationToken,
   ): PreparedToolInvocation {
     return {
-      invocationMessage: `Opening project graph visualization for "${options.input.projectName}"...`,
+      invocationMessage: `Opening project graph visualization for "${options.input.projectName}"`,
     };
   }
 }

--- a/libs/vscode/copilot/src/lib/tools/visualize-task-graph-tool.ts
+++ b/libs/vscode/copilot/src/lib/tools/visualize-task-graph-tool.ts
@@ -1,5 +1,6 @@
 import { getNxWorkspaceProjects } from '@nx-console/vscode-nx-workspace';
 import { getTelemetry } from '@nx-console/vscode-telemetry';
+import { getTaskGraphVisualizationMessage } from '@nx-console/shared-llm-context';
 import {
   CancellationToken,
   commands,
@@ -43,7 +44,7 @@ export class VisualizeTaskGraphTool
 
     return new LanguageModelToolResult([
       new LanguageModelTextPart(
-        `Opening the Nx task graph focused on task "${taskName}" for project "${projectName}". There can only be one graph visualization open at a time so avoid similar tool calls unless the user specifically requests it.`,
+        getTaskGraphVisualizationMessage(projectName, taskName),
       ),
     ]);
   }
@@ -53,7 +54,7 @@ export class VisualizeTaskGraphTool
     token: CancellationToken,
   ): PreparedToolInvocation {
     return {
-      invocationMessage: `Opening task graph visualization for "${options.input.taskName}" in project "${options.input.projectName}"...`,
+      invocationMessage: `Opening task graph visualization for "${options.input.taskName}" in project "${options.input.projectName}"`,
     };
   }
 }

--- a/libs/vscode/copilot/tsconfig.json
+++ b/libs/vscode/copilot/tsconfig.json
@@ -4,6 +4,12 @@
   "include": [],
   "references": [
     {
+      "path": "../utils"
+    },
+    {
+      "path": "../../shared/generate-ui-types"
+    },
+    {
       "path": "../../shared/schema"
     },
     {

--- a/libs/vscode/copilot/tsconfig.lib.json
+++ b/libs/vscode/copilot/tsconfig.lib.json
@@ -8,6 +8,12 @@
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {
+      "path": "../utils/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/generate-ui-types/tsconfig.lib.json"
+    },
+    {
       "path": "../../shared/schema/tsconfig.lib.json"
     },
     {

--- a/libs/vscode/generate-ui-webview/src/index.ts
+++ b/libs/vscode/generate-ui-webview/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/init-generate-ui-webview';
+export * from './lib/fill-with-generate-ui';

--- a/libs/vscode/generate-ui-webview/src/lib/fill-with-generate-ui.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/fill-with-generate-ui.ts
@@ -1,0 +1,63 @@
+import { FormValues } from '@nx-console/shared-generate-ui-types';
+import { commands } from 'vscode';
+
+import { window } from 'vscode';
+import { updateGenerateUIValues } from './init-generate-ui-webview';
+
+let fillWithGenerateUiService: FillWithGenerateUiService;
+
+export function getFillWithGenerateUiService() {
+  if (!fillWithGenerateUiService) {
+    fillWithGenerateUiService = new FillWithGenerateUiService();
+  }
+  return fillWithGenerateUiService;
+}
+
+export async function fillWithGenerateUi(
+  generatorName: string,
+  options: FormValues,
+) {
+  const prompt = await window.showInputBox({
+    title: `What would you like to do with the ${generatorName} generator?`,
+  });
+  if (!prompt) {
+    return;
+  }
+  getFillWithGenerateUiService().setFillInfo(generatorName, options);
+  commands.executeCommand(
+    'workbench.action.chat.open',
+    `@nx /fill-generate-ui ${prompt}`,
+  );
+}
+
+export class FillWithGenerateUiService {
+  private generatorName: string;
+  private formValues: FormValues;
+
+  setFillInfo(generatorName: string, formValues: FormValues) {
+    this.generatorName = generatorName;
+    this.formValues = formValues;
+    commands.executeCommand(
+      'setContext',
+      'nxConsole.isFillingGenerateUi',
+      true,
+    );
+  }
+
+  getFillInfo() {
+    return {
+      generatorName: this.generatorName,
+      formValues: this.formValues,
+    };
+  }
+
+  clearFillInfo() {
+    this.generatorName = '';
+    this.formValues = {} as FormValues;
+    commands.executeCommand(
+      'setContext',
+      'nxConsole.isFillingGenerateUi',
+      false,
+    );
+  }
+}

--- a/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
@@ -41,6 +41,7 @@ export async function openGenerateUi(contextUri?: Uri, projectName?: string) {
 
 export async function openGenerateUIPrefilled(
   parsedArgs: Awaited<ReturnType<typeof yargs.parse>>,
+  openedFromAI = false,
 ) {
   const generatorName = parsedArgs['_'][1];
   const generator = await getOrSelectGenerator(generatorName.toString());
@@ -52,20 +53,27 @@ export async function openGenerateUIPrefilled(
 
   const generatorContext = await getGeneratorContextV2(undefined);
 
-  generateUIWebview.openGenerateUi({
-    ...generator,
-    context: {
-      ...generatorContext,
-      prefillValues: {
-        ...generatorContext.prefillValues,
-        ...parseIntoPrefillValues(parsedArgs, generator.options),
+  generateUIWebview.openGenerateUi(
+    {
+      ...generator,
+      context: {
+        ...generatorContext,
+        prefillValues: {
+          ...generatorContext.prefillValues,
+          ...parseIntoPrefillValues(parsedArgs, generator.options),
+        },
       },
     },
-  });
+    openedFromAI,
+  );
 }
 
 export async function updateGenerateUIValues(formValues: FormValues) {
   generateUIWebview.updateFormValues(formValues);
+}
+
+export function onGeneratorUiDispose(callback: () => void) {
+  return generateUIWebview.onDispose(callback);
 }
 
 function parseIntoPrefillValues(

--- a/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
+++ b/libs/vscode/generate-ui-webview/src/lib/init-generate-ui-webview.ts
@@ -8,6 +8,7 @@ import { registerGenerateCommands } from './generate-commands';
 import { GenerateUiWebview } from './generate-ui-webview';
 import yargs = require('yargs');
 import { Option } from '@nx-console/shared-schema';
+import { FormValues } from '@nx-console/shared-generate-ui-types';
 
 let generateUIWebview: GenerateUiWebview;
 
@@ -39,7 +40,7 @@ export async function openGenerateUi(contextUri?: Uri, projectName?: string) {
 }
 
 export async function openGenerateUIPrefilled(
-  parsedArgs: Awaited<ReturnType<typeof yargs.parse>>
+  parsedArgs: Awaited<ReturnType<typeof yargs.parse>>,
 ) {
   const generatorName = parsedArgs['_'][1];
   const generator = await getOrSelectGenerator(generatorName.toString());
@@ -63,9 +64,13 @@ export async function openGenerateUIPrefilled(
   });
 }
 
+export async function updateGenerateUIValues(formValues: FormValues) {
+  generateUIWebview.updateFormValues(formValues);
+}
+
 function parseIntoPrefillValues(
   yargsParseResult: Awaited<ReturnType<typeof yargs.parse>>,
-  options: Option[]
+  options: Option[],
 ): Record<string, string> {
   const positionals = yargsParseResult['_'].slice(2);
 
@@ -85,7 +90,7 @@ function parseIntoPrefillValues(
   }
 
   for (const [key, value] of Object.entries(yargsParseResult)) {
-    if (key !== '_' && key !== '$0') {
+    if (key !== '_' && key !== '$0' && value !== undefined) {
       prefillValues[key] = value.toString();
     }
   }

--- a/libs/vscode/mcp/package.json
+++ b/libs/vscode/mcp/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@nx-console/mcp",
+  "name": "@nx-console/vscode-mcp",
   "version": "0.0.1",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "nx": {
-    "name": "mcp",
+    "name": "vscode-mcp",
     "sourceRoot": "libs/vscode/mcp/src",
     "projectType": "library",
     "tags": [

--- a/libs/vscode/mcp/tsconfig.json
+++ b/libs/vscode/mcp/tsconfig.json
@@ -4,16 +4,13 @@
   "include": [],
   "references": [
     {
-      "path": "../../shared/nx-cloud"
-    },
-    {
       "path": "../nx-workspace"
     },
     {
-      "path": "../nx-cli-quickpicks"
+      "path": "../generate-ui-webview"
     },
     {
-      "path": "../generate-ui-webview"
+      "path": "../../shared/nx-cloud"
     },
     {
       "path": "../../shared/llm-context"

--- a/libs/vscode/mcp/tsconfig.json
+++ b/libs/vscode/mcp/tsconfig.json
@@ -10,7 +10,13 @@
       "path": "../nx-workspace"
     },
     {
-      "path": "../../shared/types"
+      "path": "../nx-cli-quickpicks"
+    },
+    {
+      "path": "../generate-ui-webview"
+    },
+    {
+      "path": "../../shared/llm-context"
     },
     {
       "path": "../../nx-mcp/nx-mcp-server"

--- a/libs/vscode/mcp/tsconfig.lib.json
+++ b/libs/vscode/mcp/tsconfig.lib.json
@@ -15,7 +15,13 @@
       "path": "../nx-workspace/tsconfig.lib.json"
     },
     {
-      "path": "../../shared/types/tsconfig.lib.json"
+      "path": "../nx-cli-quickpicks/tsconfig.lib.json"
+    },
+    {
+      "path": "../generate-ui-webview/tsconfig.lib.json"
+    },
+    {
+      "path": "../../shared/llm-context/tsconfig.lib.json"
     },
     {
       "path": "../../nx-mcp/nx-mcp-server/tsconfig.lib.json"

--- a/libs/vscode/mcp/tsconfig.lib.json
+++ b/libs/vscode/mcp/tsconfig.lib.json
@@ -9,16 +9,13 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../../shared/nx-cloud/tsconfig.lib.json"
-    },
-    {
       "path": "../nx-workspace/tsconfig.lib.json"
     },
     {
-      "path": "../nx-cli-quickpicks/tsconfig.lib.json"
+      "path": "../generate-ui-webview/tsconfig.lib.json"
     },
     {
-      "path": "../generate-ui-webview/tsconfig.lib.json"
+      "path": "../../shared/nx-cloud/tsconfig.lib.json"
     },
     {
       "path": "../../shared/llm-context/tsconfig.lib.json"

--- a/libs/vscode/nx-cli-quickpicks/src/lib/select-generator.ts
+++ b/libs/vscode/nx-cli-quickpicks/src/lib/select-generator.ts
@@ -13,7 +13,7 @@ import { selectFlags } from './select-flags';
 
 export async function selectGeneratorAndPromptForFlags(
   preselectedGenerator?: string,
-  preselectedFlags?: Record<string, string>
+  preselectedFlags?: Record<string, string>,
 ): Promise<
   | {
       generator: GeneratorSchema;
@@ -27,9 +27,8 @@ export async function selectGeneratorAndPromptForFlags(
     return;
   }
 
-  const selection: GeneratorSchema | undefined = await getOrSelectGenerator(
-    preselectedGenerator
-  );
+  const selection: GeneratorSchema | undefined =
+    await getOrSelectGenerator(preselectedGenerator);
 
   if (!selection) {
     return;
@@ -38,7 +37,7 @@ export async function selectGeneratorAndPromptForFlags(
   const flags = await selectFlags(
     `generate ${selection.collectionName}:${selection.generatorName}`,
     selection.options,
-    preselectedFlags
+    preselectedFlags,
   );
 
   if (!flags) {
@@ -52,7 +51,7 @@ export async function selectGeneratorAndPromptForFlags(
 }
 
 export async function getOrSelectGenerator(
-  generatorName?: string
+  generatorName?: string,
 ): Promise<GeneratorSchema | undefined> {
   if (generatorName) {
     const generatorInfo = {
@@ -62,7 +61,8 @@ export async function getOrSelectGenerator(
     const foundGenerator = ((await getGenerators()) ?? []).find(
       (gen) =>
         generatorInfo.collection === gen.data?.collection &&
-        generatorInfo.name === gen.data?.name
+        (generatorInfo.name === gen.data?.name ||
+          gen.data?.aliases?.includes(generatorInfo.name)),
     );
     if (foundGenerator) {
       const options = await getGeneratorOptions({
@@ -111,9 +111,9 @@ async function selectGenerator(): Promise<GeneratorSchema | undefined> {
         allowlist.find((rule) =>
           matchWithWildcards(
             `${item.generator.data?.collection}:${item.generator.data?.name}`,
-            rule
-          )
-        )
+            rule,
+          ),
+        ),
       );
     }
 
@@ -123,9 +123,9 @@ async function selectGenerator(): Promise<GeneratorSchema | undefined> {
           !blocklist.find((rule) =>
             matchWithWildcards(
               `${item.generator.data?.collection}:${item.generator.data?.name}`,
-              rule
-            )
-          )
+              rule,
+            ),
+          ),
       );
     }
   }

--- a/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
@@ -1,6 +1,10 @@
 import { CIPEInfo, CIPERun, CIPERunGroup } from '@nx-console/shared-types';
 import { isCompleteStatus, isFailedStatus } from '@nx-console/shared-utils';
-import { AbstractTreeProvider, isInCursor } from '@nx-console/vscode-utils';
+import {
+  AbstractTreeProvider,
+  isInCursor,
+  sendMessageToAgent,
+} from '@nx-console/vscode-utils';
 import { isDeepStrictEqual } from 'util';
 import {
   commands,
@@ -453,21 +457,7 @@ export class CloudRecentCIPEProvider extends AbstractTreeProvider<BaseRecentCIPE
 
         const fixMePrompt = 'help me fix the latest ci pipeline error';
 
-        if (isInCursor()) {
-          commands.executeCommand('composer.newAgentChat');
-          await new Promise((resolve) => setTimeout(resolve, 150));
-          const originalClipboard = await env.clipboard.readText();
-          await env.clipboard.writeText(fixMePrompt);
-          await commands.executeCommand('editor.action.clipboardPasteAction');
-          await env.clipboard.writeText(originalClipboard);
-        } else {
-          commands.executeCommand('workbench.action.chat.open', {
-            mode: 'agent',
-            query: fixMePrompt,
-            isPartialQuery: true,
-          });
-          await commands.executeCommand('workbench.action.chat.sendToNewChat');
-        }
+        sendMessageToAgent(fixMePrompt);
       }),
     );
   }

--- a/libs/vscode/nx-cloud-view/tsconfig.json
+++ b/libs/vscode/nx-cloud-view/tsconfig.json
@@ -16,9 +16,6 @@
       "path": "../output-channels"
     },
     {
-      "path": "../utils"
-    },
-    {
       "path": "../../shared/nx-cloud"
     },
     {
@@ -26,6 +23,9 @@
     },
     {
       "path": "../../shared/npm"
+    },
+    {
+      "path": "../utils"
     },
     {
       "path": "../telemetry"

--- a/libs/vscode/nx-cloud-view/tsconfig.lib.json
+++ b/libs/vscode/nx-cloud-view/tsconfig.lib.json
@@ -25,9 +25,6 @@
       "path": "../output-channels/tsconfig.lib.json"
     },
     {
-      "path": "../utils/tsconfig.lib.json"
-    },
-    {
       "path": "../../shared/nx-cloud/tsconfig.lib.json"
     },
     {
@@ -35,6 +32,9 @@
     },
     {
       "path": "../../shared/npm/tsconfig.lib.json"
+    },
+    {
+      "path": "../utils/tsconfig.lib.json"
     },
     {
       "path": "../telemetry/tsconfig.lib.json"

--- a/libs/vscode/tasks/src/index.ts
+++ b/libs/vscode/tasks/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/cli-task-provider';
 export * from './lib/nx-task-commands';
 export * from './lib/cli-task-commands';
 export * from './lib/init-tasks';
+export * from './lib/node-task';

--- a/libs/vscode/tasks/src/lib/node-task.ts
+++ b/libs/vscode/tasks/src/lib/node-task.ts
@@ -1,0 +1,63 @@
+import { getNxWorkspace } from '@nx-console/vscode-nx-workspace';
+import { join } from 'path';
+import { ShellExecution, Task, TaskScope } from 'vscode';
+
+export interface NodeTaskDefinition {
+  script: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export class NodeTask extends Task {
+  /**
+   * Creates a task to run a Node script with the given arguments
+   */
+  static async create(
+    definition: NodeTaskDefinition,
+  ): Promise<NodeTask | undefined> {
+    const nxWorkspace = await getNxWorkspace();
+    if (!nxWorkspace) {
+      return;
+    }
+
+    const { workspacePath } = nxWorkspace;
+    const args = definition.args || [];
+
+    const displayCommand = `node ${definition.script} ${args.join(' ')}`.trim();
+
+    // Create a direct ShellExecution rather than using getShellExecutionForConfig
+    // since we're not running an Nx command
+    const shellExecution = new ShellExecution(
+      `node ${definition.script} ${args.join(' ')}`.trim(),
+      {
+        cwd: definition.cwd
+          ? join(workspacePath, definition.cwd)
+          : workspacePath,
+        env: {
+          ...(definition.env || {}),
+          NX_CONSOLE: 'true',
+        },
+      },
+    );
+
+    const task = new NodeTask(
+      { ...definition, type: 'nx' },
+      TaskScope.Workspace,
+      displayCommand,
+      'node',
+      shellExecution,
+    );
+
+    return task;
+  }
+
+  static async batchCreate(
+    definitions: NodeTaskDefinition[],
+  ): Promise<NodeTask[]> {
+    const tasks = await Promise.all(
+      definitions.map((definition) => this.create(definition)),
+    );
+    return tasks.filter((task) => task !== undefined) as NodeTask[];
+  }
+}

--- a/libs/vscode/utils/src/index.ts
+++ b/libs/vscode/utils/src/index.ts
@@ -11,3 +11,4 @@ export * from './lib/logger';
 export * from './lib/git';
 export type { GitExtension, API as GitAPI } from './lib/git-extension';
 export { isInCursor } from './lib/is-in-cursor';
+export { sendMessageToAgent } from './lib/send-message-to-agent';

--- a/libs/vscode/utils/src/lib/send-message-to-agent.ts
+++ b/libs/vscode/utils/src/lib/send-message-to-agent.ts
@@ -1,0 +1,27 @@
+import { commands, env } from 'vscode';
+import { isInCursor } from './is-in-cursor';
+
+export async function sendMessageToAgent(message: string, newChat = true) {
+  if (isInCursor()) {
+    if (newChat) {
+      commands.executeCommand('composer.newAgentChat');
+    } else {
+      commands.executeCommand('composerMode.agent');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const originalClipboard = await env.clipboard.readText();
+    await env.clipboard.writeText(message);
+    await commands.executeCommand('editor.action.clipboardPasteAction');
+    await env.clipboard.writeText(originalClipboard);
+  } else {
+    commands.executeCommand('workbench.action.chat.open', {
+      mode: 'agent',
+      query: message,
+      isPartialQuery: newChat ? true : false,
+    });
+    if (newChat) {
+      await commands.executeCommand('workbench.action.chat.sendToNewChat');
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/tar-stream": "^3.1.3",
     "@types/universal-analytics": "0.4.5",
     "@types/uuid": "^8.3.4",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.96.0",
     "@types/vscode-webview": "^1.57.0",
     "@typescript-eslint/eslint-plugin": "7.16.1",
     "@typescript-eslint/parser": "7.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,12 +2844,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nx-console/mcp@workspace:libs/vscode/mcp":
-  version: 0.0.0-use.local
-  resolution: "@nx-console/mcp@workspace:libs/vscode/mcp"
-  languageName: unknown
-  linkType: soft
-
 "@nx-console/nx-mcp-server@workspace:libs/nx-mcp/nx-mcp-server":
   version: 0.0.0-use.local
   resolution: "@nx-console/nx-mcp-server@workspace:libs/nx-mcp/nx-mcp-server"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2970,6 +2970,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@nx-console/vscode-mcp@workspace:libs/vscode/mcp":
+  version: 0.0.0-use.local
+  resolution: "@nx-console/vscode-mcp@workspace:libs/vscode/mcp"
+  languageName: unknown
+  linkType: soft
+
 "@nx-console/vscode-migrate-sidebar-webview@workspace:libs/vscode/migrate-sidebar-webview":
   version: 0.0.0-use.local
   resolution: "@nx-console/vscode-migrate-sidebar-webview@workspace:libs/vscode/migrate-sidebar-webview"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5001,10 +5001,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/vscode@npm:^1.85.0":
-  version: 1.96.0
-  resolution: "@types/vscode@npm:1.96.0"
-  checksum: c7d65dd681fcf933048cbbfe24705ba8c8d89e82f8a7c5e7077e198f52d6b5ae39592eb0f48f87e3f9ef4a7a64eaa51ccbdcba93ffb838be69a6003b42cec5db
+"@types/vscode@npm:^1.96.0":
+  version: 1.98.0
+  resolution: "@types/vscode@npm:1.98.0"
+  checksum: 32f25d6d14dbbe92aac8862a2e3ebdc18cc2457e65dbe65d14cfe6fb39149e31b24d24ee88ce19dd83f02512a8f47c313267c306295e05fd4481207ecf8b1c6d
   languageName: node
   linkType: hard
 
@@ -14128,7 +14128,7 @@ __metadata:
     "@types/tar-stream": ^3.1.3
     "@types/universal-analytics": 0.4.5
     "@types/uuid": ^8.3.4
-    "@types/vscode": ^1.85.0
+    "@types/vscode": ^1.96.0
     "@types/vscode-webview": ^1.57.0
     "@typescript-eslint/eslint-plugin": 7.16.1
     "@typescript-eslint/parser": 7.16.1


### PR DESCRIPTION
Opening the generate UI already works with a button in vscode but now it can be done with an mcp tool by an agent.

Also, some of the mcp tools were backported to vscode to provide value there as well.