### PR TITLE
fix(vscode): catch more errors when checking yarn version

### DIFF
--- a/libs/vscode/typescript-plugin/src/lib/plugin-configuration.ts
+++ b/libs/vscode/typescript-plugin/src/lib/plugin-configuration.ts
@@ -87,15 +87,14 @@ export async function getPluginConfiguration(
   let packageManager: Configuration['packageManager'] =
     await detectPackageManager(workspaceRoot);
   if (packageManager === 'yarn') {
-    let yarnVersion;
     try {
-      yarnVersion =
+      const yarnVersion =
         (await getPackageManagerVersion(packageManager, workspaceRoot)) ??
         '1.0.0';
+      if (lt(yarnVersion, '2.0.0')) {
+        packageManager = 'yarn-classic';
+      }
     } catch {
-      yarnVersion = '1.0.0';
-    }
-    if (lt(yarnVersion, '2.0.0')) {
       packageManager = 'yarn-classic';
     }
   }


### PR DESCRIPTION
Catch a potential error when the collected yarn version is not something that can be processed with semver.