### PR TITLE
fix: handle aliases and windows paths for getGeneratorSchema

### DIFF
--- a/libs/shared/llm-context/src/lib/generator-details.ts
+++ b/libs/shared/llm-context/src/lib/generator-details.ts
@@ -1,15 +1,32 @@
 import { GeneratorCollectionInfo } from '@nx-console/shared-schema';
 import { readFile } from 'fs/promises';
+import { normalize } from 'path';
 
 export async function getGeneratorSchema(
   generatorName: string,
   generators: GeneratorCollectionInfo[],
 ): Promise<any | undefined> {
-  const generator = generators.find((g) => g.name === generatorName);
+  const generator = generators.find((g) => {
+    if (g.name === generatorName) {
+      return true;
+    }
+
+    // check to see if the generator name has an alias
+    const [lib, gen] = generatorName.split(':');
+    if (g.collectionName === lib && g.data?.aliases.some((a) => a === gen)) {
+      return true;
+    }
+
+    return false;
+  });
   if (!generator) {
     return undefined;
   }
-  const schema = await readFile(generator.schemaPath, 'utf-8');
+
+  const schemaPath = normalize(
+    generator.schemaPath.replace(/^file:\/\/\//, ''),
+  );
+  const schema = await readFile(schemaPath, 'utf-8');
   const parsedSchema = JSON.parse(schema);
   delete parsedSchema['$schema'];
   delete parsedSchema['$id'];


### PR DESCRIPTION
This fixes the getGeneratorSchema for mcps. It handles two things:
* Ensures that we can find aliases like (`@nx/js:lib` instead of `@nx/js:library`)
* And fixes the paths for the schemas to work properly on Windows