### PR TITLE
feat(vscode): add undo-migration action when approving current migration

### DIFF
--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -52,6 +52,19 @@ export async function skipMigration(migration: MigrationDetailsWithId) {
   );
 }
 
+export async function undoMigration(migration: MigrationDetailsWithId) {
+  const workspacePath = getNxWorkspacePath();
+  const migrateUIApi = await importMigrateUIApi(workspacePath);
+  migrateUIApi.modifyMigrationsJsonMetadata(
+    workspacePath,
+    // TODO: Once Nx is updated with the `undoMigration` API we can remove the ts-ignore.
+    // This is safe to call, since this code path only happens if the bundled or local version of Nx exposes the "Undo" button.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    migrateUIApi.undoMigration(workspacePath, migration.id),
+  );
+}
+
 export async function confirmPackageChanges() {
   window.withProgress(
     {
@@ -93,10 +106,9 @@ export async function confirmPackageChanges() {
             );
           });
 
-        repository.add(filesToAdd);
+        await repository.add(filesToAdd);
 
-        repository.commit('chore: start nx migration', {
-          signCommit: true,
+        await repository.commit('chore: start nx migration', {
           noVerify: true,
         });
 

--- a/libs/vscode/migrate/src/lib/migrate-webview.ts
+++ b/libs/vscode/migrate/src/lib/migrate-webview.ts
@@ -3,7 +3,6 @@ import { directoryExists } from '@nx-console/shared-file-system';
 import { workspaceDependencyPath } from '@nx-console/shared-npm';
 import { getNxWorkspacePath } from '@nx-console/vscode-configuration';
 import { getNxVersion } from '@nx-console/vscode-nx-workspace';
-import { getOutputChannel } from '@nx-console/vscode-output-channels';
 import { readFileSync } from 'fs';
 import type { MigrationsJsonEntry } from 'nx/src/config/misc-interfaces';
 import { join } from 'path';
@@ -17,6 +16,7 @@ import {
 import {
   cancelMigration,
   skipMigration,
+  undoMigration,
   viewDocumentation,
   viewImplementation,
 } from './commands/migrate-commands';
@@ -26,7 +26,7 @@ import {
   runManyMigrations,
   runSingleMigration,
 } from './commands/run-migration';
-import { viewDiff, viewDiffForMigration } from './git-extension/view-diff';
+import { viewDiffForMigration } from './git-extension/view-diff';
 
 export class MigrateWebview {
   private _webviewPanel: WebviewPanel | undefined;
@@ -91,6 +91,9 @@ export class MigrateWebview {
           break;
         case 'skip-migration':
           skipMigration(message.payload.migration);
+          break;
+        case 'undo-migration':
+          undoMigration(message.payload.migration);
           break;
         case 'view-implementation':
           viewImplementation(message.payload.migration);


### PR DESCRIPTION
This PR adds a button for user to undo a migration that's already been applied and pending approval.

See: https://www.loom.com/share/97286bdc80ea4538af76a914ef8f0f8b

Also, fixes an existing issue where the `start migrations` commit was never actually done since we did not await the promises from `repository.add` and `repository.commit`.


## Current Behavior
When a migration is pending approval, the only option is to accept it.

## Expected Behavior
Allow user to undo a migration if they don't want the changes.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
