### PR TITLE
fix(vscode): fix wasi loading mock when requiring nx

### DIFF
--- a/apps/vscode/project.json
+++ b/apps/vscode/project.json
@@ -24,7 +24,8 @@
           "webpack",
           "@angular-devkit/*",
           "@nx/key",
-          "@nx/nx*"
+          "@nx/nx*",
+          "*/nx.wasi.cjs"
         ],
         "thirdParty": true,
         "minify": true,

--- a/tools/scripts/copy-to-vscode.js
+++ b/tools/scripts/copy-to-vscode.js
@@ -87,7 +87,7 @@ if (!fs.existsSync(nxGraphDestFolder)) {
   fs.mkdirSync(nxGraphDestFolder, { recursive: true });
 }
 fs.copySync(normalize('./node_modules/nx/src/core/graph'), nxGraphDestFolder);
-// this file is required at runtime in the bundle
+// // this file is required at runtime in the bundle
 fs.writeFileSync(
   './dist/apps/vscode/native-bindings.js',
   'module.exports = {};',
@@ -97,3 +97,5 @@ fs.writeFileSync(
   './dist/apps/vscode/default-tasks-runner.js',
   'module.exports = {};',
 );
+//
+fs.writeFileSync('./dist/apps/vscode/nx.wasi.cjs', 'module.exports = {};');


### PR DESCRIPTION
there were some errors with a packaged nx-console. We now mock one more file in order to get the migrate ui api to work without bundling all the native files.