### PR TITLE
fix(vscode): remove false dichotomy between vscode & cursor. make sure windsurf doesn't get notifications for now

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -114,7 +114,7 @@
         },
         {
           "command": "nx.configureMcpServer",
-          "when": "view == nxProjects && isInCursor && isNxWorkspace && !hasNxMcpConfigured",
+          "when": "view == nxProjects && (isInCursor || isInVSCode) && isNxWorkspace && !hasNxMcpConfigured",
           "group": "navigation@0",
           "title": "Add Nx to Cursor Agent"
         },
@@ -421,7 +421,7 @@
         },
         {
           "command": "nx.configureMcpServer",
-          "when": "isNxWorkspace && !hasNxMcpConfigured"
+          "when": "isNxWorkspace && !hasNxMcpConfigured && (isInCursor || isInVSCode)"
         }
       ]
     },

--- a/libs/shared/nx-cloud/tsconfig.lib.json
+++ b/libs/shared/nx-cloud/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "out-tsc/nx-cloud",
     "types": ["node"],
     "noImplicitReturns": false
   },

--- a/libs/vscode/mcp/src/lib/init-mcp.ts
+++ b/libs/vscode/mcp/src/lib/init-mcp.ts
@@ -8,6 +8,8 @@ import {
   getMcpJsonPath,
   getNxMcpPort,
   hasNxMcpEntry,
+  isInVSCode,
+  isInWindsurf,
   readMcpJson,
   writeMcpJson,
 } from '@nx-console/vscode-utils';
@@ -35,6 +37,8 @@ export async function initMcp(context: ExtensionContext) {
   }
 
   commands.executeCommand('setContext', 'isInCursor', isInCursor());
+  commands.executeCommand('setContext', 'isInWindsurf', isInWindsurf());
+  commands.executeCommand('setContext', 'isInVSCode', isInVSCode());
 
   if (!(await checkIsNxWorkspace(getNxWorkspacePath()))) {
     return;
@@ -111,9 +115,16 @@ async function showMCPNotification() {
     return;
   }
 
+  if (isInWindsurf()) {
+    // TODO: do once windsurf supports project-level mcp servers
+    return;
+  }
+
   const msg = isInCursor()
     ? 'Improve Cursor Agents with Nx-specific context?'
-    : 'Improve Copilot Agents with Nx-specific context?';
+    : isInWindsurf()
+      ? 'Improve Cascade with Nx-specific context?'
+      : 'Improve Copilot Agents with Nx-specific context?';
 
   window
     .showInformationMessage(msg, 'Yes', "Don't ask again")

--- a/libs/vscode/mcp/src/lib/mcp-server.ts
+++ b/libs/vscode/mcp/src/lib/mcp-server.ts
@@ -22,10 +22,10 @@ import { getTelemetry } from '@nx-console/vscode-telemetry';
 import {
   getGitDiffs,
   getNxMcpPort,
+  isInVSCode,
   sendMessageToAgent,
   vscodeLogger,
 } from '@nx-console/vscode-utils';
-import { isInVSCode } from '@nx-console/vscode-utils/src/lib/is-in-cursor';
 import express from 'express';
 import { commands, ProgressLocation, tasks, window } from 'vscode';
 

--- a/libs/vscode/mcp/src/lib/mcp-server.ts
+++ b/libs/vscode/mcp/src/lib/mcp-server.ts
@@ -22,13 +22,12 @@ import { getTelemetry } from '@nx-console/vscode-telemetry';
 import {
   getGitDiffs,
   getNxMcpPort,
-  isInCursor,
   sendMessageToAgent,
   vscodeLogger,
 } from '@nx-console/vscode-utils';
+import { isInVSCode } from '@nx-console/vscode-utils/src/lib/is-in-cursor';
 import express from 'express';
 import { commands, ProgressLocation, tasks, window } from 'vscode';
-import { Disposable } from 'vscode-languageserver';
 
 export interface McpServerReturn {
   server: NxMcpServerWrapper;
@@ -127,7 +126,7 @@ export async function tryStartMcpServer(workspacePath: string) {
         foundGenerator.name,
       );
 
-      if (!isInCursor()) {
+      if (isInVSCode()) {
         window.withProgress(
           {
             location: ProgressLocation.Notification,

--- a/libs/vscode/migrate-sidebar-webview/tsconfig.webview.json
+++ b/libs/vscode/migrate-sidebar-webview/tsconfig.webview.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "outDir": "out-tsc/migrate-sidebar-webview",
+
     "emitDeclarationOnly": false,
     "types": ["node"],
     "module": "ESNext",

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -2,8 +2,7 @@ import { CIPEInfo } from '@nx-console/shared-types';
 import { isFailedStatus } from '@nx-console/shared-utils';
 import { GlobalConfigurationStore } from '@nx-console/vscode-configuration';
 import { getTelemetry } from '@nx-console/vscode-telemetry';
-import { isInCursor } from '@nx-console/vscode-utils';
-import { commands, env, window } from 'vscode';
+import { commands, window } from 'vscode';
 
 export function compareCIPEDataAndSendNotification(
   oldInfo: CIPEInfo[] | null,

--- a/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
@@ -1,15 +1,16 @@
 import { CIPEInfo, CIPERun, CIPERunGroup } from '@nx-console/shared-types';
 import { isCompleteStatus, isFailedStatus } from '@nx-console/shared-utils';
+import { getNxCloudStatus } from '@nx-console/vscode-nx-workspace';
+import { showErrorMessageWithOpenLogs } from '@nx-console/vscode-output-channels';
+import { getTelemetry } from '@nx-console/vscode-telemetry';
 import {
   AbstractTreeProvider,
-  isInCursor,
   sendMessageToAgent,
 } from '@nx-console/vscode-utils';
 import { isDeepStrictEqual } from 'util';
 import {
   commands,
   Disposable,
-  env,
   ExtensionContext,
   FileDecoration,
   FileDecorationProvider,
@@ -23,9 +24,6 @@ import {
 } from 'vscode';
 import { ActorRef, EventObject } from 'xstate';
 import { formatMillis } from './format-time';
-import { getTelemetry } from '@nx-console/vscode-telemetry';
-import { showErrorMessageWithOpenLogs } from '@nx-console/vscode-output-channels';
-import { getNxCloudStatus } from '@nx-console/vscode-nx-workspace';
 
 abstract class BaseRecentCIPETreeItem extends TreeItem {
   abstract type: 'CIPE' | 'runGroup' | 'run' | 'label' | 'failedTask';

--- a/libs/vscode/utils/src/index.ts
+++ b/libs/vscode/utils/src/index.ts
@@ -1,14 +1,18 @@
 export * from './lib/abstract-tree-provider';
-export * from './lib/read-projects';
-export * from './lib/empty-state-messages';
-export { watchFile } from './lib/watch-file';
-export { getShellExecutionForConfig } from './lib/shell-execution';
-export { getWorkspacePath } from './lib/get-workspace-path';
 export * from './lib/dependency-versioning';
-export * from './lib/register-codelens';
-export * from './lib/mcp-json';
-export * from './lib/logger';
+export * from './lib/empty-state-messages';
+export { getWorkspacePath } from './lib/get-workspace-path';
 export * from './lib/git';
-export type { GitExtension, API as GitAPI } from './lib/git-extension';
-export { isInCursor } from './lib/is-in-cursor';
+export type { API as GitAPI, GitExtension } from './lib/git-extension';
+export {
+  isInCursor,
+  isInVSCode,
+  isInWindsurf,
+} from '@nx-console/vscode-utils/src/lib/editor-name-helpers';
+export * from './lib/logger';
+export * from './lib/mcp-json';
+export * from './lib/read-projects';
+export * from './lib/register-codelens';
 export { sendMessageToAgent } from './lib/send-message-to-agent';
+export { getShellExecutionForConfig } from './lib/shell-execution';
+export { watchFile } from './lib/watch-file';

--- a/libs/vscode/utils/src/lib/editor-name-helpers.ts
+++ b/libs/vscode/utils/src/lib/editor-name-helpers.ts
@@ -1,0 +1,13 @@
+import { env } from 'vscode';
+
+export function isInCursor() {
+  return env.appName.toLowerCase().includes('cursor');
+}
+
+export function isInWindsurf() {
+  return env.appName.toLowerCase().includes('windsurf');
+}
+
+export function isInVSCode() {
+  return env.appName.toLowerCase().includes('visual studio code');
+}

--- a/libs/vscode/utils/src/lib/is-in-cursor.ts
+++ b/libs/vscode/utils/src/lib/is-in-cursor.ts
@@ -1,5 +1,0 @@
-import { env } from 'vscode';
-
-export function isInCursor() {
-  return env.appName.toLowerCase().includes('cursor');
-}

--- a/libs/vscode/utils/src/lib/mcp-json.ts
+++ b/libs/vscode/utils/src/lib/mcp-json.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import * as path from 'path';
 import { workspace, window } from 'vscode';
-import { isInCursor } from './is-in-cursor';
+import { isInCursor, isInWindsurf } from './editor-name-helpers';
 
 /**
  * Gets the path to the mcp.json file.
@@ -18,7 +18,10 @@ export function getMcpJsonPath(): string | null {
   if (isInCursor()) {
     // If in cursor, use the .cursor directory
     return path.join(vscodeWorkspacePath, '.cursor', 'mcp.json');
-  } else {
+  } // else if (isInWindsurf()) {
+  //   TODO: do once windsurf supports project-level mcp servers
+  // }
+  else {
     // If not in cursor, use the workspace root
     return path.join(vscodeWorkspacePath, '.vscode', 'mcp.json');
   }

--- a/libs/vscode/utils/src/lib/send-message-to-agent.ts
+++ b/libs/vscode/utils/src/lib/send-message-to-agent.ts
@@ -1,5 +1,5 @@
 import { commands, env } from 'vscode';
-import { isInCursor } from './is-in-cursor';
+import { isInCursor } from './editor-name-helpers';
 
 export async function sendMessageToAgent(message: string, newChat = true) {
   if (isInCursor()) {


### PR DESCRIPTION
sadly, windsurf doesn't seem to have support for project-level mcp servers right now. This means that we can't reliably register a server for the user as there would be different, competing nx-mcp servers for each workspace and it would be a real mess. 

Right now we'll have to let the users themselves take care of it, hopefully it changes in the future.