### PR TITLE
fix(intellij): use bundled ktor & verify plugin in CI

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run Nx Cloud conformance checks
         run: yarn nx-cloud record -- yarn nx-cloud conformance:check
 
-      - run: yarn nx affected --targets=lint,test,build,e2e-ci,typecheck --configuration=ci --exclude=nx-console --parallel=3
+      - run: yarn nx affected --targets=lint,test,build,e2e-ci,typecheck,verifyPlugin --configuration=ci --exclude=nx-console --parallel=3
         timeout-minutes: 45
 
   main-windows:

--- a/apps/intellij/build.gradle.kts
+++ b/apps/intellij/build.gradle.kts
@@ -69,14 +69,6 @@ configurations.all {
 
 dependencies {
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1")
-
-    val ktorVersion = "2.3.12"
-    implementation("io.ktor:ktor-client-core:$ktorVersion")
-    implementation("io.ktor:ktor-client-cio:$ktorVersion")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
-    implementation("io.ktor:ktor-client-logging:$ktorVersion")
-
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.2")
 
     implementation("io.github.z4kn4fein:semver:2.0.0")

--- a/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryService.kt
@@ -5,8 +5,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import dev.nx.console.utils.isDevelopmentInstance
 import io.ktor.client.*
-import io.ktor.client.engine.cio.*
-import io.ktor.client.plugins.logging.*
+import io.ktor.client.engine.okhttp.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -28,19 +27,7 @@ class TelemetryService(private val cs: CoroutineScope) {
         if (isDevelopmentInstance) {
             LoggerTelemetryService()
         } else {
-            MeasurementProtocolService(
-                HttpClient(CIO) {
-                    install(Logging) {
-                        level = LogLevel.ALL
-                        logger =
-                            object : Logger {
-                                override fun log(message: String) {
-                                    this@TelemetryService.logger.trace(message)
-                                }
-                            }
-                    }
-                }
-            )
+            MeasurementProtocolService(HttpClient(OkHttp))
         }
 
     fun featureUsed(feature: TelemetryEvent, data: Map<String, Any>? = null) {


### PR DESCRIPTION
we don't have to bundle ktor, it's included in the intellij distribution. The version mismatch between what we had and what they had caused some issues. 

Turns out we don't need it anyways, the one `CIO` piece that we're using that they don't include is optional, we can use any other engine for sending basic http requests. 

Tested this out in the GA debug view so it works :) 