### PR TITLE
fix(vscode): fix destructuring from undefined again

### DIFF
--- a/libs/vscode/typescript-plugin/src/lib/typescript-plugin.ts
+++ b/libs/vscode/typescript-plugin/src/lib/typescript-plugin.ts
@@ -177,76 +177,75 @@ async function enableTypescriptServerPlugin(
   let projectGraph: ProjectGraph | undefined;
   if (isTsSolutionSetup) {
     const nxWorkspace = await getNxWorkspace();
-    if (nxWorkspace) {
-      ({ projectGraph } = nxWorkspace);
-
-      disposables.push(
-        onWorkspaceRefreshed(async () => {
-          ({ projectGraph } = await getNxWorkspace());
-          await configurePlugin(
-            workspaceRoot,
-            projectGraph,
-            api,
-            pluginConfigurationCache,
-          );
-        }),
-      );
-    }
+    projectGraph = nxWorkspace?.projectGraph;
 
     disposables.push(
-      vscode.workspace.onDidOpenTextDocument(
-        (document) => {
-          if (
-            document.uri.fsPath.endsWith('.ts') ||
-            document.uri.fsPath.endsWith('.tsx')
-          ) {
-            configurePlugin(
-              workspaceRoot,
-              projectGraph,
-              api,
-              pluginConfigurationCache,
-            );
-          }
-        },
-        undefined,
-        context.subscriptions,
-      ),
-      watchFile(
-        `${workspaceRoot}/tsconfig.base.json`,
-        () => {
-          clearJsonCache(TSCONFIG_BASE, workspaceRoot);
+      onWorkspaceRefreshed(async () => {
+        const nxWorkspace = await getNxWorkspace();
+        projectGraph = nxWorkspace?.projectGraph;
+        await configurePlugin(
+          workspaceRoot,
+          projectGraph,
+          api,
+          pluginConfigurationCache,
+        );
+      }),
+    );
+  }
+
+  disposables.push(
+    vscode.workspace.onDidOpenTextDocument(
+      (document) => {
+        if (
+          document.uri.fsPath.endsWith('.ts') ||
+          document.uri.fsPath.endsWith('.tsx')
+        ) {
           configurePlugin(
             workspaceRoot,
             projectGraph,
             api,
             pluginConfigurationCache,
           );
-        },
-        context.subscriptions,
-      ),
-      vscode.workspace.onDidChangeTextDocument(
-        ({ document }) => {
-          if (document.uri.fsPath.endsWith(TSCONFIG_BASE)) {
-            configurePlugin(
-              workspaceRoot,
-              projectGraph,
-              api,
-              pluginConfigurationCache,
-            );
-          }
-        },
-        undefined,
-        context.subscriptions,
-      ),
-    );
+        }
+      },
+      undefined,
+      context.subscriptions,
+    ),
+    watchFile(
+      `${workspaceRoot}/tsconfig.base.json`,
+      () => {
+        clearJsonCache(TSCONFIG_BASE, workspaceRoot);
+        configurePlugin(
+          workspaceRoot,
+          projectGraph,
+          api,
+          pluginConfigurationCache,
+        );
+      },
+      context.subscriptions,
+    ),
+    vscode.workspace.onDidChangeTextDocument(
+      ({ document }) => {
+        if (document.uri.fsPath.endsWith(TSCONFIG_BASE)) {
+          configurePlugin(
+            workspaceRoot,
+            projectGraph,
+            api,
+            pluginConfigurationCache,
+          );
+        }
+      },
+      undefined,
+      context.subscriptions,
+    ),
+  );
 
-    await configurePlugin(
-      workspaceRoot,
-      projectGraph,
-      api,
-      pluginConfigurationCache,
-    );
-  }
+  await configurePlugin(
+    workspaceRoot,
+    projectGraph,
+    api,
+    pluginConfigurationCache,
+  );
 }
 
 async function disableTypescriptServerPlugin() {


### PR DESCRIPTION
we're still seeing this error in rollbar which made me go back and double check. Looks like there was another place in that file where we missed a destructuring statement.