### PR TITLE
fix(vscode): remove legacy migrate command

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -368,10 +368,6 @@
           "when": "isNxWorkspace"
         },
         {
-          "command": "nx.migrate",
-          "when": "isNxWorkspace"
-        },
-        {
           "command": "nx.generate.ui",
           "when": "isNxWorkspace"
         },
@@ -813,11 +809,6 @@
       },
       {
         "category": "Nx",
-        "title": "migrate",
-        "command": "nx.migrate"
-      },
-      {
-        "category": "Nx",
         "title": "Generate (UI)",
         "command": "nx.generate.ui",
         "icon": "$(browser)"
@@ -961,8 +952,7 @@
             "run-many",
             "affected",
             "affected --graph",
-            "list",
-            "migrate"
+            "list"
           ],
           "markdownDescription": "Common Nx commands that will be available in the sidebar view. You can specify either \n - Arbitrary Nx commands, like `build:example-app` or `nx run my-lib:test` (note that you can omit the prefixed `nx`) or  \n - Nx commands that are available through Nx Console, like `run-many`. They will be executed using the Nx Console UI."
         },

--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -1,6 +1,9 @@
+import { getPackageManagerCommand } from '@nx-console/shared-npm';
 import { getNxWorkspacePath } from '@nx-console/vscode-configuration';
 import { logAndShowError } from '@nx-console/vscode-output-channels';
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
 import {
   commands,
   ExtensionContext,
@@ -9,19 +12,15 @@ import {
   window,
   workspace,
 } from 'vscode';
+import { GitExtension } from '../git-extension/git';
+import { viewPackageJsonDiff } from '../git-extension/view-diff';
+import { MigrateWebview } from '../migrate-webview';
 import { startMigration } from './start-migration';
 import {
   importMigrateUIApi,
   modifyMigrationsJsonMetadata,
   readMigrationsJsonMetadata,
 } from './utils';
-import { GitExtension } from '../git-extension/git';
-import { viewPackageJsonDiff } from '../git-extension/view-diff';
-import { MigrateWebview } from '../migrate-webview';
-import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
-import { join } from 'path';
-import { existsSync } from 'fs';
-import { getPackageManagerCommand } from '@nx-console/shared-npm';
 
 export function registerCommands(
   context: ExtensionContext,

--- a/libs/vscode/tasks/tsconfig.json
+++ b/libs/vscode/tasks/tsconfig.json
@@ -4,12 +4,6 @@
   "include": [],
   "references": [
     {
-      "path": "../configuration"
-    },
-    {
-      "path": "../../shared/file-system"
-    },
-    {
       "path": "../utils"
     },
     {

--- a/libs/vscode/tasks/tsconfig.lib.json
+++ b/libs/vscode/tasks/tsconfig.lib.json
@@ -9,12 +9,6 @@
   "include": ["**/*.ts"],
   "references": [
     {
-      "path": "../configuration/tsconfig.lib.json"
-    },
-    {
-      "path": "../../shared/file-system/tsconfig.lib.json"
-    },
-    {
       "path": "../utils/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
now that we have the migrate ui, the old command can go... it wasn't really super useful anyways