### PR TITLE
fix(vscode): parse jsonc mcp.json file

### DIFF
--- a/libs/vscode/utils/src/lib/mcp-json.ts
+++ b/libs/vscode/utils/src/lib/mcp-json.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import * as path from 'path';
 import { workspace, window } from 'vscode';
+import { parse } from 'jsonc-parser';
 import { isInCursor, isInWindsurf } from './editor-name-helpers';
 
 /**
@@ -61,7 +62,7 @@ export function hasNxMcpEntry(): boolean {
   }
 
   try {
-    const mcpJson = JSON.parse(readFileSync(mcpJsonPath, 'utf8'));
+    const mcpJson = parse(readFileSync(mcpJsonPath, 'utf8'));
     return !!(mcpJson.mcpServers?.['nx-mcp'] ?? mcpJson.servers?.['nx-mcp']);
   } catch (e) {
     return false;
@@ -84,7 +85,7 @@ export function readMcpJson(): any | null {
     if (fileContent.trim() === '') {
       return {};
     }
-    return JSON.parse(fileContent);
+    return parse(fileContent);
   } catch (error) {
     console.error('Error reading mcp.json:', error);
     return null;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "find-cache-dir": "^3.3.2",
     "ignore": "^7.0.4",
     "ini": "^4.1.3",
-    "jsonc-parser": "^3.0.0",
+    "jsonc-parser": "^3.3.1",
     "lit": "^2.4.1",
     "minimatch": "^9.0.3",
     "request-light": "^0.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12356,7 +12356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.0.0, jsonc-parser@npm:^3.2.0, jsonc-parser@npm:^3.3.1":
+"jsonc-parser@npm:^3.2.0, jsonc-parser@npm:^3.3.1":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 81ef19d98d9c6bd6e4a37a95e2753c51c21705cbeffd895e177f4b542cca9cda5fda12fb942a71a2e824a9132cf119dc2e642e9286386055e1365b5478f49a47
@@ -14497,7 +14497,7 @@ __metadata:
     jest-environment-jsdom: 29.7.0
     jest-environment-node: ^29.7.0
     jsonc-eslint-parser: ^2.1.0
-    jsonc-parser: ^3.0.0
+    jsonc-parser: ^3.3.1
     lit: ^2.4.1
     memfs: ^3.4.7
     minimatch: ^9.0.3


### PR DESCRIPTION
Closes #2504 

Use `jsonc-parser` to parse `mcp.json` which allows comments. This aligns with the VSCode configuration file format described here: https://code.visualstudio.com/docs/languages/json#_json-with-comments

Tested locally to confirm that I can start the nx mcp server with comments in `mcp.json`:

<img width="388" alt="Screenshot 2025-05-16 at 9 39 44 AM" src="https://github.com/user-attachments/assets/12b872f2-b886-459c-be28-039deea34d47" />
