### PR TITLE
fix(vscode): avoid returning undefined in runningTasksGuidelines

### DIFF
--- a/libs/shared/llm-context/src/lib/nx-console-rules.ts
+++ b/libs/shared/llm-context/src/lib/nx-console-rules.ts
@@ -61,11 +61,11 @@ If the user wants help with fixing an error in their CI pipeline, use the follow
 
 function runningTasksGuidelines(nxVersion: string | undefined) {
   if (!nxVersion) {
-    return undefined;
+    return '';
   }
 
   if (!gte(nxVersion, '21.1.0-beta.1')) {
-    return undefined;
+    return '';
   }
 
   return `


### PR DESCRIPTION
**fix(vscode): avoid returning undefined in runningTasksGuidelines**

### The issue:
`undefined` is printed out when runningTasksGuidelines returns early.

### Fix

This PR refactors the `runningTasksGuidelines` function to prevent it from implicitly returning `undefined` and to clarify its return logic.

The changes are as follows:
- If `noVersion` is true, the function now explicitly returns an empty string.
- If `gte(xVersion, '21.1.0-beta.1')` is true, the function now explicitly returns empty string.
