### PR TITLE
fix(nx-mcp): workspace tools shouldn't be available if cwd is not an nx workspace

### DIFF
--- a/apps/nx-mcp-e2e/src/workspace_detection.test.ts
+++ b/apps/nx-mcp-e2e/src/workspace_detection.test.ts
@@ -1,0 +1,110 @@
+import {
+  createInvokeMCPInspectorCLI,
+  e2eCwd,
+  newWorkspace,
+  simpleReactWorkspaceOptions,
+  uniq,
+} from '@nx-console/shared-e2e-utils';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('workspace detection', () => {
+  let invokeMCPInspectorCLI: Awaited<
+    ReturnType<typeof createInvokeMCPInspectorCLI>
+  >;
+
+  describe('with nx workspace', () => {
+    const workspaceName = uniq('nx-mcp-nx-workspace-test');
+    const testWorkspacePath = join(e2eCwd, workspaceName);
+
+    beforeAll(async () => {
+      newWorkspace({
+        name: workspaceName,
+        options: simpleReactWorkspaceOptions,
+      });
+      invokeMCPInspectorCLI = await createInvokeMCPInspectorCLI(
+        e2eCwd,
+        workspaceName,
+      );
+    });
+
+    afterAll(() => {
+      rmSync(testWorkspacePath, { recursive: true, force: true });
+    });
+
+    it('should have workspace-specific tools when cwd is nx workspace', () => {
+      const result = invokeMCPInspectorCLI('--method tools/list');
+      const toolNames = result.tools.map((tool: any) => tool.name);
+
+      expect(toolNames).toContain('nx_docs');
+      expect(toolNames).toContain('nx_available_plugins');
+      expect(toolNames).toContain('nx_workspace_path');
+      expect(toolNames).toContain('nx_workspace');
+      expect(toolNames).toContain('nx_project_details');
+    });
+  });
+
+  describe('with non-existent path', () => {
+    const workspaceName = uniq('nx-mcp-temp-workspace');
+
+    beforeAll(async () => {
+      mkdirSync(join(e2eCwd, workspaceName), { recursive: true });
+      invokeMCPInspectorCLI = await createInvokeMCPInspectorCLI(
+        e2eCwd,
+        workspaceName,
+      );
+    });
+
+    afterAll(() => {
+      rmSync(join(e2eCwd, workspaceName), { recursive: true, force: true });
+    });
+
+    it('should not have workspace tools when pointing to non-existent path', () => {
+      const nonExistentPath = '/this/path/does/not/exist';
+      const result = invokeMCPInspectorCLI(
+        nonExistentPath,
+        '--method tools/list',
+      );
+      const toolNames = result.tools.map((tool: any) => tool.name);
+
+      expect(toolNames).toContain('nx_docs');
+      expect(toolNames).toContain('nx_available_plugins');
+      expect(toolNames).not.toContain('nx_workspace_path');
+      expect(toolNames).not.toContain('nx_workspace');
+      expect(toolNames).not.toContain('nx_project_details');
+    });
+  });
+
+  describe('with empty directory', () => {
+    const workspaceName = uniq('nx-mcp-empty-dir');
+    const emptyDirPath = join(e2eCwd, workspaceName);
+
+    beforeAll(async () => {
+      mkdirSync(emptyDirPath, { recursive: true });
+      writeFileSync(
+        join(emptyDirPath, 'README.md'),
+        'This is not an nx workspace',
+      );
+
+      invokeMCPInspectorCLI = await createInvokeMCPInspectorCLI(
+        e2eCwd,
+        workspaceName,
+      );
+    });
+
+    afterAll(() => {
+      rmSync(emptyDirPath, { recursive: true, force: true });
+    });
+
+    it('should not have workspace tools when pointing to empty directory', () => {
+      const result = invokeMCPInspectorCLI(emptyDirPath, '--method tools/list');
+      const toolNames = result.tools.map((tool: any) => tool.name);
+
+      expect(toolNames).toContain('nx_docs');
+      expect(toolNames).toContain('nx_available_plugins');
+      expect(toolNames).not.toContain('nx_workspace_path');
+      expect(toolNames).not.toContain('nx_workspace');
+      expect(toolNames).not.toContain('nx_project_details');
+    });
+  });
+});

--- a/apps/nx-mcp-e2e/src/workspace_path.test.ts
+++ b/apps/nx-mcp-e2e/src/workspace_path.test.ts
@@ -40,19 +40,19 @@ describe('workspace path', () => {
 
   it('should return the workspace path when provided as a positional', () => {
     const result = invokeMCPInspectorCLI(
-      'my/workspace/path/positional',
+      testWorkspacePath,
       '--method tools/call',
       '--tool-name nx_workspace_path',
     );
-    expect(result.content[0].text).toBe('my/workspace/path/positional');
+    expect(result.content[0].text).toBe(testWorkspacePath);
   });
 
   it('should return the workspace path when provided as an option', () => {
     const result = invokeMCPInspectorCLI(
-      '--workspace-path my/workspace/path/named-arg',
+      `--workspace-path ${testWorkspacePath}`,
       '--method tools/call',
       '--tool-name nx_workspace_path',
     );
-    expect(result.content[0].text).toBe('my/workspace/path/named-arg');
+    expect(result.content[0].text).toBe(testWorkspacePath);
   });
 });

--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -17,6 +17,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import express from 'express';
 import { isNxCloudUsed } from '@nx-console/shared-nx-cloud';
+import { checkIsNxWorkspace } from '@nx-console/shared-npm';
 
 interface ArgvType {
   workspacePath?: string;
@@ -74,9 +75,13 @@ async function main() {
     .help()
     .parseSync() as ArgvType;
 
-  const nxWorkspacePath: string = (argv.workspacePath ||
+  const providedPath: string = (argv.workspacePath ||
     (argv._[0] as string) ||
     process.cwd()) as string;
+
+  // Check if the provided path is an Nx workspace
+  const isNxWorkspace = await checkIsNxWorkspace(providedPath);
+  const nxWorkspacePath = isNxWorkspace ? providedPath : undefined;
 
   let googleAnalytics: GoogleAnalytics | undefined;
 
@@ -105,7 +110,8 @@ async function main() {
       // todo(cammisuli): implement this using standard git commands
       return undefined;
     },
-    isNxCloudEnabled: async () => await isNxCloudUsed(nxWorkspacePath),
+    isNxCloudEnabled: async () =>
+      nxWorkspacePath ? await isNxCloudUsed(nxWorkspacePath) : false,
   };
 
   const server = await NxMcpServerWrapper.create(

--- a/apps/nx-mcp/tsconfig.app.json
+++ b/apps/nx-mcp/tsconfig.app.json
@@ -8,6 +8,9 @@
   "exclude": ["eslint.config.js", "eslint.config.cjs", "eslint.config.mjs"],
   "references": [
     {
+      "path": "../../libs/shared/npm/tsconfig.lib.json"
+    },
+    {
       "path": "../../libs/shared/nx-cloud/tsconfig.lib.json"
     },
     {

--- a/apps/nx-mcp/tsconfig.json
+++ b/apps/nx-mcp/tsconfig.json
@@ -4,6 +4,9 @@
   "include": [],
   "references": [
     {
+      "path": "../../libs/shared/npm"
+    },
+    {
       "path": "../../libs/shared/nx-cloud"
     },
     {


### PR DESCRIPTION
falling back to the cwd as the workspace path is great but it should check for an nx workspace. Otherwise we will have a lot of nonfunctional tools.