### PR TITLE
fix(nx-mcp): make sure relative path is resolved when passing it to nx-mcp

### DIFF
--- a/apps/nx-mcp-e2e/src/workspace_path.test.ts
+++ b/apps/nx-mcp-e2e/src/workspace_path.test.ts
@@ -55,4 +55,14 @@ describe('workspace path', () => {
     );
     expect(result.content[0].text).toBe(testWorkspacePath);
   });
+
+  it('should resolve "." to the current working directory when passed as workspace path', () => {
+    const result = invokeMCPInspectorCLI(
+      '.',
+      '--method tools/call',
+      '--tool-name nx_workspace_path',
+    );
+    // Since we're running from within the test workspace, "." should resolve to the test workspace path
+    expect(result.content[0].text).toBe(testWorkspacePath);
+  });
 });

--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -18,6 +18,7 @@ import { hideBin } from 'yargs/helpers';
 import express from 'express';
 import { isNxCloudUsed } from '@nx-console/shared-nx-cloud';
 import { checkIsNxWorkspace } from '@nx-console/shared-npm';
+import { resolve } from 'path';
 
 interface ArgvType {
   workspacePath?: string;
@@ -75,9 +76,9 @@ async function main() {
     .help()
     .parseSync() as ArgvType;
 
-  const providedPath: string = (argv.workspacePath ||
-    (argv._[0] as string) ||
-    process.cwd()) as string;
+  const providedPath: string = resolve(
+    argv.workspacePath || (argv._[0] as string) || process.cwd(),
+  ) as string;
 
   // Check if the provided path is an Nx workspace
   const isNxWorkspace = await checkIsNxWorkspace(providedPath);


### PR DESCRIPTION
before, we were just taking '.' as the path, now we resolve it to make sure subsequent steps work

proof of it working with a locally built version: 
<img width="940" alt="image" src="https://github.com/user-attachments/assets/afca4ac3-10ae-4a3a-bf3e-c2785476bc7e" />
