### PR TITLE
feat(nx-mcp): additional tools for Nx Cloud integration

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -5,11 +5,15 @@ import { Logger } from '@nx-console/shared-utils';
 import {
   getNxCloudTerminalOutput,
   getRecentCIPEData,
+  getPipelineExecutionsSearch,
+  getPipelineExecutionDetails,
 } from '@nx-console/shared-nx-cloud';
 import { z } from 'zod';
 import {
   NX_CLOUD_CIPE_DETAILS,
   NX_CLOUD_CIPE_FAILURE,
+  NX_CLOUD_PIPELINE_EXECUTIONS_SEARCH,
+  NX_CLOUD_PIPELINE_EXECUTIONS_DETAILS,
 } from '@nx-console/shared-llm-context/src/lib/tool-names';
 
 export function registerNxCloudTools(
@@ -48,6 +52,32 @@ export function registerNxCloudTools(
       telemetry,
       getGitDiffs ?? (async () => null),
     ),
+  );
+
+  // Pipeline Executions Search
+  server.tool(
+    NX_CLOUD_PIPELINE_EXECUTIONS_SEARCH,
+    'Search for pipeline executions in Nx Cloud. Returns a list of pipeline executions matching the search criteria.',
+    pipelineExecutionSearchSchema.shape,
+    {
+      destructiveHint: false,
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
+    nxCloudPipelineExecutionsSearch(workspacePath, logger, telemetry),
+  );
+
+  // Pipeline Execution Details
+  server.tool(
+    NX_CLOUD_PIPELINE_EXECUTIONS_DETAILS,
+    'Get detailed information about a specific pipeline execution in Nx Cloud.',
+    pipelineExecutionDetailsSchema.shape,
+    {
+      destructiveHint: false,
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
+    nxCloudPipelineExecutionDetails(workspacePath, logger, telemetry),
   );
 }
 
@@ -215,3 +245,535 @@ const nxCloudCipeAffectedFilesAndTerminalOutput =
 
     return { content };
   };
+
+// Schemas for the new tools
+const pipelineExecutionSearchSchema = z.object({
+  branches: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by specific branches'),
+  statuses: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by execution statuses'),
+  authors: z.array(z.string()).optional().describe('Filter by commit authors'),
+  repositoryUrl: z.string().optional().describe('Filter by repository URL'),
+  minCreatedAtMs: z
+    .number()
+    .optional()
+    .describe('Minimum creation timestamp in milliseconds'),
+  maxCreatedAtMs: z
+    .number()
+    .optional()
+    .describe('Maximum creation timestamp in milliseconds'),
+  vcsTitleContains: z
+    .string()
+    .optional()
+    .describe('Filter by VCS title containing this text'),
+  limit: z
+    .number()
+    .optional()
+    .default(50)
+    .describe('Maximum number of results to return'),
+  pageToken: z.string().optional().describe('Token for pagination'),
+});
+
+const pipelineExecutionDetailsSchema = z.object({
+  pipelineExecutionId: z
+    .string()
+    .describe('The ID of the pipeline execution to retrieve'),
+});
+
+const runSearchSchema = z.object({
+  pipelineExecutionId: z
+    .string()
+    .optional()
+    .describe('Filter by pipeline execution ID'),
+  branches: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by specific branches'),
+  runGroups: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by run group names'),
+  commitShas: z.array(z.string()).optional().describe('Filter by commit SHAs'),
+  statuses: z.array(z.string()).optional().describe('Filter by run statuses'),
+  minStartTimeMs: z
+    .number()
+    .optional()
+    .describe('Minimum start time in milliseconds'),
+  maxStartTimeMs: z
+    .number()
+    .optional()
+    .describe('Maximum start time in milliseconds'),
+  commandContains: z
+    .string()
+    .optional()
+    .describe('Filter by command containing this text'),
+  urlSlug: z.string().optional().describe('Filter by specific URL slug'),
+  limit: z
+    .number()
+    .optional()
+    .default(50)
+    .describe('Maximum number of results to return'),
+  pageToken: z.string().optional().describe('Token for pagination'),
+});
+
+const runDetailsSchema = z.object({
+  runId: z.string().describe('The ID of the run to retrieve'),
+});
+
+const taskSearchSchema = z.object({
+  runIds: z.array(z.string()).optional().describe('Filter by specific run IDs'),
+  pipelineExecutionIds: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by pipeline execution IDs'),
+  taskIds: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by specific task IDs'),
+  projectNames: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by project names'),
+  targets: z.array(z.string()).optional().describe('Filter by target names'),
+  configurations: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by configurations'),
+  hashes: z.array(z.string()).optional().describe('Filter by task hashes'),
+  statuses: z.array(z.string()).optional().describe('Filter by task statuses'),
+  cacheStatuses: z
+    .array(z.string())
+    .optional()
+    .describe('Filter by cache statuses'),
+  minStartTimeMs: z
+    .number()
+    .optional()
+    .describe('Minimum start time in milliseconds'),
+  maxStartTimeMs: z
+    .number()
+    .optional()
+    .describe('Maximum start time in milliseconds'),
+  limit: z
+    .number()
+    .optional()
+    .default(100)
+    .describe('Maximum number of results to return'),
+  pageToken: z.string().optional().describe('Token for pagination'),
+});
+
+const taskDetailsSchema = z.object({
+  runId: z.string().describe('The ID of the run containing the task'),
+  encodedTaskId: z.string().describe('The URL-encoded task ID to retrieve'),
+});
+
+// Implementation functions
+const nxCloudPipelineExecutionsSearch =
+  (
+    workspacePath: string,
+    logger: Logger,
+    telemetry: NxConsoleTelemetryLogger | undefined,
+  ) =>
+  async (
+    params: z.infer<typeof pipelineExecutionSearchSchema>,
+  ): Promise<CallToolResult> => {
+    telemetry?.logUsage('ai.tool-call', {
+      tool: NX_CLOUD_PIPELINE_EXECUTIONS_SEARCH,
+    });
+
+    const result = await getPipelineExecutionsSearch(
+      workspacePath,
+      logger,
+      params as any,
+    );
+
+    if (result.error) {
+      throw new Error(
+        `Error searching pipeline executions: ${result.error.message}`,
+      );
+    }
+
+    const content: CallToolResult['content'] = [];
+
+    if (result.data?.items && result.data.items.length > 0) {
+      content.push({
+        type: 'text',
+        text: `Found ${result.data.items.length} pipeline executions:`,
+      });
+
+      for (const execution of result.data.items) {
+        content.push({
+          type: 'text',
+          text: `- Pipeline Execution ID: ${execution.id}`,
+        });
+        content.push({
+          type: 'text',
+          text: `  Branch: ${execution.branch}, Status: ${execution.status}`,
+        });
+        content.push({
+          type: 'text',
+          text: `  Created: ${new Date(execution.createdAtMs).toISOString()}`,
+        });
+        if (execution.vcsTitle) {
+          content.push({
+            type: 'text',
+            text: `  Title: ${execution.vcsTitle}`,
+          });
+        }
+        if (execution.author) {
+          content.push({
+            type: 'text',
+            text: `  Author: ${execution.author}`,
+          });
+        }
+      }
+
+      if (result.data.nextPageToken) {
+        content.push({
+          type: 'text',
+          text: `Next page token: ${result.data.nextPageToken}`,
+        });
+      }
+    } else {
+      content.push({
+        type: 'text',
+        text: 'No pipeline executions found matching the criteria.',
+      });
+    }
+
+    return { content };
+  };
+
+const nxCloudPipelineExecutionDetails =
+  (
+    workspacePath: string,
+    logger: Logger,
+    telemetry: NxConsoleTelemetryLogger | undefined,
+  ) =>
+  async (
+    params: z.infer<typeof pipelineExecutionDetailsSchema>,
+  ): Promise<CallToolResult> => {
+    telemetry?.logUsage('ai.tool-call', {
+      tool: NX_CLOUD_PIPELINE_EXECUTIONS_DETAILS,
+    });
+
+    const result = await getPipelineExecutionDetails(
+      workspacePath,
+      logger,
+      params.pipelineExecutionId,
+    );
+
+    if (result.error) {
+      throw new Error(
+        `Error getting pipeline execution details: ${result.error.message}`,
+      );
+    }
+
+    const content: CallToolResult['content'] = [];
+    const execution = result.data!;
+
+    content.push({
+      type: 'text',
+      text: `Pipeline Execution Details for ID: ${execution.id}`,
+    });
+    content.push({
+      type: 'text',
+      text: `Branch: ${execution.branch}, Status: ${execution.status}`,
+    });
+    content.push({
+      type: 'text',
+      text: `Created: ${new Date(execution.createdAtMs).toISOString()}`,
+    });
+    if (execution.completedAtMs) {
+      content.push({
+        type: 'text',
+        text: `Completed: ${new Date(execution.completedAtMs).toISOString()}`,
+      });
+    }
+    if (execution.durationMs) {
+      content.push({
+        type: 'text',
+        text: `Duration: ${Math.round(execution.durationMs / 1000)}s`,
+      });
+    }
+
+    content.push({
+      type: 'text',
+      text: `Run Groups (${execution.runGroups.length}):`,
+    });
+    for (const runGroup of execution.runGroups) {
+      content.push({
+        type: 'text',
+        text: `- ${runGroup.runGroupName}: ${runGroup.status}`,
+      });
+    }
+
+    return { content };
+  };
+
+// In Progress
+// const nxCloudRunsSearch =
+//   (
+//     workspacePath: string,
+//     logger: Logger,
+//     telemetry: NxConsoleTelemetryLogger | undefined,
+//   ) =>
+//   async (params: z.infer<typeof runSearchSchema>): Promise<CallToolResult> => {
+//     telemetry?.logUsage('ai.tool-call', {
+//       tool: NX_CLOUD_RUNS_SEARCH,
+//     });
+//
+//     const result = await getRunsSearch(workspacePath, logger, params as any);
+//
+//     if (result.error) {
+//       throw new Error(`Error searching runs: ${result.error.message}`);
+//     }
+//
+//     const content: CallToolResult['content'] = [];
+//
+//     if (result.data?.items && result.data.items.length > 0) {
+//       content.push({
+//         type: 'text',
+//         text: `Found ${result.data.items.length} runs:`,
+//       });
+//
+//       for (const run of result.data.items) {
+//         content.push({
+//           type: 'text',
+//           text: `- Run ID: ${run.id}`,
+//         });
+//         content.push({
+//           type: 'text',
+//           text: `  Command: ${run.command}`,
+//         });
+//         content.push({
+//           type: 'text',
+//           text: `  Status: ${run.status}, Tasks: ${run.taskCount}`,
+//         });
+//         content.push({
+//           type: 'text',
+//           text: `  Duration: ${Math.round(run.durationMs / 1000)}s`,
+//         });
+//         if (run.branch) {
+//           content.push({
+//             type: 'text',
+//             text: `  Branch: ${run.branch}`,
+//           });
+//         }
+//       }
+//
+//       if (result.data.nextPageToken) {
+//         content.push({
+//           type: 'text',
+//           text: `Next page token: ${result.data.nextPageToken}`,
+//         });
+//       }
+//     } else {
+//       content.push({
+//         type: 'text',
+//         text: 'No runs found matching the criteria.',
+//       });
+//     }
+//
+//     return { content };
+//   };
+//
+// const nxCloudRunDetails =
+//   (
+//     workspacePath: string,
+//     logger: Logger,
+//     telemetry: NxConsoleTelemetryLogger | undefined,
+//   ) =>
+//   async (params: z.infer<typeof runDetailsSchema>): Promise<CallToolResult> => {
+//     telemetry?.logUsage('ai.tool-call', {
+//       tool: NX_CLOUD_RUNS_DETAILS,
+//     });
+//
+//     const result = await getRunDetails(workspacePath, logger, params.runId);
+//
+//     if (result.error) {
+//       throw new Error(`Error getting run details: ${result.error.message}`);
+//     }
+//
+//     const content: CallToolResult['content'] = [];
+//     const run = result.data!;
+//
+//     content.push({
+//       type: 'text',
+//       text: `Run Details for ID: ${run.id}`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Command: ${run.command}`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Status: ${run.status}, Task Count: ${run.taskCount}`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Duration: ${Math.round(run.durationMs / 1000)}s`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Started: ${new Date(run.startTimeMs).toISOString()}`,
+//     });
+//
+//     if (run.tasks && run.tasks.length > 0) {
+//       content.push({
+//         type: 'text',
+//         text: `Tasks (${run.tasks.length}):`,
+//       });
+//       for (const task of run.tasks.slice(0, 10)) {
+//         // Limit to first 10 tasks
+//         content.push({
+//           type: 'text',
+//           text: `- ${task.projectName}:${task.target} (${task.status}) - ${Math.round(task.durationMs / 1000)}s`,
+//         });
+//       }
+//       if (run.tasks.length > 10) {
+//         content.push({
+//           type: 'text',
+//           text: `... and ${run.tasks.length - 10} more tasks`,
+//         });
+//       }
+//     }
+//
+//     return { content };
+//   };
+//
+// const nxCloudTasksSearch =
+//   (
+//     workspacePath: string,
+//     logger: Logger,
+//     telemetry: NxConsoleTelemetryLogger | undefined,
+//   ) =>
+//   async (params: z.infer<typeof taskSearchSchema>): Promise<CallToolResult> => {
+//     telemetry?.logUsage('ai.tool-call', {
+//       tool: NX_CLOUD_TASKS_SEARCH,
+//     });
+//
+//     const result = await getTasksSearch(workspacePath, logger, params as any);
+//
+//     if (result.error) {
+//       throw new Error(`Error searching tasks: ${result.error.message}`);
+//     }
+//
+//     const content: CallToolResult['content'] = [];
+//
+//     if (result.data?.items && result.data.items.length > 0) {
+//       content.push({
+//         type: 'text',
+//         text: `Found ${result.data.items.length} tasks:`,
+//       });
+//
+//       for (const task of result.data.items) {
+//         content.push({
+//           type: 'text',
+//           text: `- Task ID: ${task.taskId}`,
+//         });
+//         content.push({
+//           type: 'text',
+//           text: `  Project: ${task.projectName}, Target: ${task.target}`,
+//         });
+//         content.push({
+//           type: 'text',
+//           text: `  Status: ${task.status}, Cache: ${task.cacheStatus}`,
+//         });
+//         content.push({
+//           type: 'text',
+//           text: `  Duration: ${Math.round(task.durationMs / 1000)}s`,
+//         });
+//         if (task.runId) {
+//           content.push({
+//             type: 'text',
+//             text: `  Run ID: ${task.runId}`,
+//           });
+//         }
+//       }
+//
+//       if (result.data.nextPageToken) {
+//         content.push({
+//           type: 'text',
+//           text: `Next page token: ${result.data.nextPageToken}`,
+//         });
+//       }
+//     } else {
+//       content.push({
+//         type: 'text',
+//         text: 'No tasks found matching the criteria.',
+//       });
+//     }
+//
+//     return { content };
+//   };
+//
+// const nxCloudTaskDetails =
+//   (
+//     workspacePath: string,
+//     logger: Logger,
+//     telemetry: NxConsoleTelemetryLogger | undefined,
+//   ) =>
+//   async (
+//     params: z.infer<typeof taskDetailsSchema>,
+//   ): Promise<CallToolResult> => {
+//     telemetry?.logUsage('ai.tool-call', {
+//       tool: NX_CLOUD_TASKS_DETAILS,
+//     });
+//
+//     const result = await getTaskDetails(
+//       workspacePath,
+//       logger,
+//       params.runId,
+//       params.encodedTaskId,
+//     );
+//
+//     if (result.error) {
+//       throw new Error(`Error getting task details: ${result.error.message}`);
+//     }
+//
+//     const content: CallToolResult['content'] = [];
+//     const task = result.data!;
+//
+//     content.push({
+//       type: 'text',
+//       text: `Task Details for ID: ${task.taskId}`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Project: ${task.projectName}, Target: ${task.target}`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Status: ${task.status}, Cache Status: ${task.cacheStatus}`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Duration: ${Math.round(task.durationMs / 1000)}s`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Hash: ${task.hash}`,
+//     });
+//     content.push({
+//       type: 'text',
+//       text: `Cacheable: ${task.isCacheable}`,
+//     });
+//     if (task.params) {
+//       content.push({
+//         type: 'text',
+//         text: `Parameters: ${task.params}`,
+//       });
+//     }
+//     if (task.priorAttempts && task.priorAttempts.length > 0) {
+//       content.push({
+//         type: 'text',
+//         text: `Prior Attempts: ${task.priorAttempts.length}`,
+//       });
+//     }
+//
+//     return { content };
+//   };

--- a/libs/shared/llm-context/src/lib/tool-names.ts
+++ b/libs/shared/llm-context/src/lib/tool-names.ts
@@ -23,3 +23,13 @@ export const NX_RUN_GENERATOR = 'nx_run_generator';
 export const NX_CURRENT_RUNNING_TASKS_DETAILS =
   'nx_current_running_tasks_details';
 export const NX_CURRENT_RUNNING_TASK_OUTPUT = 'nx_current_running_task_output';
+
+export const NX_CLOUD_PIPELINE_EXECUTIONS_SEARCH =
+  'nx_cloud_pipeline_executions_search';
+export const NX_CLOUD_PIPELINE_EXECUTIONS_DETAILS =
+  'nx_cloud_pipeline_executions_details';
+// Coming soon
+export const NX_CLOUD_RUNS_SEARCH = 'nx_cloud_runs_search';
+export const NX_CLOUD_RUNS_DETAILS = 'nx_cloud_runs_details';
+export const NX_CLOUD_TASKS_SEARCH = 'nx_cloud_tasks_search';
+export const NX_CLOUD_TASKS_DETAILS = 'nx_cloud_tasks_details';

--- a/libs/shared/nx-cloud/src/index.ts
+++ b/libs/shared/nx-cloud/src/index.ts
@@ -3,3 +3,5 @@ export * from './lib/nx-cloud-config-ini';
 export * from './lib/cloud-ids';
 export * from './lib/get-nx-cloud-terminal-output';
 export * from './lib/get-recent-cipe-data';
+export * from './lib/get-pipeline-executions-search';
+export * from './lib/get-pipeline-execution-details';

--- a/libs/shared/nx-cloud/src/lib/get-pipeline-execution-details.ts
+++ b/libs/shared/nx-cloud/src/lib/get-pipeline-execution-details.ts
@@ -1,0 +1,163 @@
+import { Logger } from '@nx-console/shared-utils';
+import { xhr } from 'request-light';
+import { isNxCloudUsed } from './is-nx-cloud-used';
+import { getNxCloudUrl } from './cloud-ids';
+import { nxCloudAuthHeaders } from './nx-cloud-auth-headers';
+
+export interface AgentMetadataSummary {
+  launchTemplate?: string;
+  onlineAtMs?: number;
+  offlineAtMs?: number;
+  targetCount: number;
+}
+
+export interface LinkedWorkflowSummary {
+  id: string;
+  type: string;
+  workflowConfig: string;
+}
+
+export interface AssignmentRule {
+  // Define based on your actual AssignmentRule type
+  [key: string]: any;
+}
+
+export interface PipelineExecutionRunGroupDetails {
+  runGroupName: string;
+  status: string;
+  createdAtMs: number;
+  completedAtMs?: number;
+  durationMs?: number;
+  agentCount?: number;
+  commandCount?: number;
+  ciExecutionEnv: string;
+  hasCriticalError: boolean;
+  completedBy?: string;
+  stopAgentsOnFailure: boolean;
+  criticalErrorMessage?: string;
+  stopAgentsAfter?: string;
+  agentIds: string[];
+  closed: boolean;
+  requireExplicitCompletion: boolean;
+  linkedWorkflows: LinkedWorkflowSummary[];
+  activeAgentIds: string[];
+  assignmentRules?: AssignmentRule[];
+  agentsMetadataSummary: Record<string, AgentMetadataSummary>;
+  summaryMessage?: string;
+}
+
+export interface MCiVCSContext {
+  // Define based on your actual MCiVCSContext type
+  [key: string]: any;
+}
+
+export interface MWorkflowError {
+  // Define based on your actual MWorkflowError type
+  [key: string]: any;
+}
+
+export interface PipelineExecutionDetails {
+  id: string;
+  workspaceId: string;
+  ciExecutionId: string;
+  branch: string;
+  status: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+  completedAtMs?: number;
+  durationMs?: number;
+  runGroups: PipelineExecutionRunGroupDetails[];
+  vcsTitle?: string;
+  commitSha?: string;
+  author?: string;
+  repositoryUrl?: string;
+  affectedProjectRatio?: number;
+  touchedProjectCount: number;
+  affectedProjectCount?: number;
+  criticalWorkflowErrorCount: number;
+  cacheEnabled: boolean;
+  vcsContext?: MCiVCSContext;
+  cancellationRequested?: boolean;
+  touchedProjects?: string[];
+  affectedProjects?: string[];
+  criticalWorkflowErrors: MWorkflowError[];
+  projectGraphSha?: string;
+  fileMapSha?: string;
+  hashScope?: string;
+}
+
+export interface PipelineExecutionDetailsError {
+  type: 'authentication' | 'network' | 'not_found' | 'other';
+  message: string;
+}
+
+export async function getPipelineExecutionDetails(
+  workspacePath: string,
+  logger: Logger,
+  pipelineExecutionId: string,
+): Promise<{
+  data?: PipelineExecutionDetails;
+  error?: PipelineExecutionDetailsError;
+}> {
+  if (!(await isNxCloudUsed(workspacePath, logger))) {
+    return {
+      error: {
+        type: 'other',
+        message: 'Nx Cloud is not used in this workspace',
+      },
+    };
+  }
+
+  const nxCloudUrl = await getNxCloudUrl(workspacePath);
+  const url = `${nxCloudUrl}/nx-cloud/mcp-context/pipeline-executions/${pipelineExecutionId}`;
+
+  const headers: any = {
+    'Content-Type': 'application/json',
+    ...(await nxCloudAuthHeaders(workspacePath)),
+  };
+
+  logger.log(
+    `Making pipeline execution details request for ID: ${pipelineExecutionId}`,
+  );
+  try {
+    const response = await xhr({
+      type: 'GET',
+      url,
+      headers,
+      timeout: 10000,
+    });
+
+    const responseData = JSON.parse(
+      response.responseText,
+    ) as PipelineExecutionDetails;
+    return {
+      data: responseData,
+    };
+  } catch (e) {
+    if (e.status === 401) {
+      logger.log(`Authentication error: ${e.responseText}`);
+      return {
+        error: {
+          type: 'authentication',
+          message: e.responseText,
+        },
+      };
+    }
+    if (e.status === 404) {
+      logger.log(`Pipeline execution not found: ${e.responseText}`);
+      return {
+        error: {
+          type: 'not_found',
+          message: `Pipeline execution with ID ${pipelineExecutionId} not found`,
+        },
+      };
+    }
+    logger.log(`Error: ${JSON.stringify(e)}`);
+    return {
+      error: {
+        type: 'other',
+        message: e.responseText ?? e.message,
+      },
+    };
+  }
+}

--- a/libs/shared/nx-cloud/src/lib/get-pipeline-executions-search.ts
+++ b/libs/shared/nx-cloud/src/lib/get-pipeline-executions-search.ts
@@ -1,0 +1,128 @@
+import { Logger } from '@nx-console/shared-utils';
+import { xhr } from 'request-light';
+import { isNxCloudUsed } from './is-nx-cloud-used';
+import { getNxCloudUrl } from './cloud-ids';
+import { nxCloudAuthHeaders } from './nx-cloud-auth-headers';
+
+export interface PipelineExecutionSearchRequest {
+  workspaceId: string;
+  branches?: string[];
+  statuses?: string[];
+  authors?: string[];
+  repositoryUrl?: string;
+  minCreatedAtMs?: number;
+  maxCreatedAtMs?: number;
+  vcsTitleContains?: string;
+  limit?: number;
+  pageToken?: string;
+}
+
+export interface RunGroupSummary {
+  runGroupName: string;
+  status: string;
+  createdAtMs: number;
+  completedAtMs?: number;
+  durationMs?: number;
+  agentCount?: number;
+  commandCount?: number;
+  ciExecutionEnv: string;
+  hasCriticalError: boolean;
+  completedBy?: string;
+}
+
+export interface PipelineExecutionSummary {
+  id: string;
+  workspaceId: string;
+  ciExecutionId: string;
+  branch: string;
+  status: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+  completedAtMs?: number;
+  durationMs?: number;
+  runGroupSummaries: RunGroupSummary[];
+  vcsTitle?: string;
+  commitSha?: string;
+  author?: string;
+  repositoryUrl?: string;
+  affectedProjectRatio?: number;
+  touchedProjectCount: number;
+  affectedProjectCount?: number;
+  criticalWorkflowErrorCount: number;
+  cacheEnabled: boolean;
+}
+
+export interface PipelineExecutionSearchResponse {
+  items: PipelineExecutionSummary[];
+  nextPageToken?: string;
+}
+
+export interface PipelineExecutionSearchError {
+  type: 'authentication' | 'network' | 'other';
+  message: string;
+}
+
+export async function getPipelineExecutionsSearch(
+  workspacePath: string,
+  logger: Logger,
+  request: PipelineExecutionSearchRequest,
+): Promise<{
+  data?: PipelineExecutionSearchResponse;
+  error?: PipelineExecutionSearchError;
+}> {
+  logger.log('workspacePath', workspacePath);
+
+  if (!(await isNxCloudUsed(workspacePath, logger))) {
+    return {
+      error: {
+        type: 'other',
+        message: `Nx Cloud is not used in this workspace (${workspacePath})`,
+      },
+    };
+  }
+
+  const nxCloudUrl = await getNxCloudUrl(workspacePath);
+  const url = `${nxCloudUrl}/nx-cloud/mcp-context/pipeline-executions/search`;
+
+  const headers: any = {
+    'Content-Type': 'application/json',
+    ...(await nxCloudAuthHeaders(workspacePath)),
+  };
+
+  const data = JSON.stringify(request);
+
+  logger.log(`Making pipeline executions search request`);
+  try {
+    const response = await xhr({
+      type: 'POST',
+      url,
+      headers,
+      data,
+      timeout: 10000,
+    });
+
+    const responseData = JSON.parse(
+      response.responseText,
+    ) as PipelineExecutionSearchResponse;
+    return {
+      data: responseData,
+    };
+  } catch (e) {
+    if (e.status === 401) {
+      logger.log(`Authentication error: ${e.responseText}`);
+      return {
+        error: {
+          type: 'authentication',
+          message: e.responseText,
+        },
+      };
+    }
+    logger.log(`Error: ${JSON.stringify(e)}`);
+    return {
+      error: {
+        type: 'other',
+        message: e.responseText ?? e.message,
+      },
+    };
+  }
+}

--- a/libs/shared/nx-cloud/src/lib/get-runs-search.ts
+++ b/libs/shared/nx-cloud/src/lib/get-runs-search.ts
@@ -1,0 +1,109 @@
+import { Logger } from '@nx-console/shared-utils';
+import { xhr } from 'request-light';
+import { isNxCloudUsed } from './is-nx-cloud-used';
+import { getNxCloudUrl } from './cloud-ids';
+import { nxCloudAuthHeaders } from './nx-cloud-auth-headers';
+
+export interface RunSearchRequest {
+  workspaceId: string;
+  pipelineExecutionId?: string;
+  branches?: string[];
+  runGroups?: string[];
+  commitShas?: string[];
+  statuses?: string[];
+  minStartTimeMs?: number;
+  maxStartTimeMs?: number;
+  commandContains?: string;
+  urlSlug?: string;
+  limit?: number;
+  pageToken?: string;
+}
+
+export interface RunSummary {
+  id: string;
+  workspaceId: string;
+  urlSlug: string;
+  command: string;
+  startTimeMs: number;
+  endTimeMs: number;
+  durationMs: number;
+  status: string;
+  taskCount: number;
+  branch?: string;
+  runGroup?: string;
+  commitSha?: string;
+  createdAtMs: number;
+  cacheEnabled: boolean;
+  nxVersion?: string;
+}
+
+export interface RunSearchResponse {
+  items: RunSummary[];
+  nextPageToken?: string;
+}
+
+export interface RunSearchError {
+  type: 'authentication' | 'network' | 'other';
+  message: string;
+}
+
+export async function getRunsSearch(
+  workspacePath: string,
+  logger: Logger,
+  request: RunSearchRequest,
+): Promise<{
+  data?: RunSearchResponse;
+  error?: RunSearchError;
+}> {
+  if (!(await isNxCloudUsed(workspacePath, logger))) {
+    return {
+      error: {
+        type: 'other',
+        message: 'Nx Cloud is not used in this workspace',
+      },
+    };
+  }
+
+  const nxCloudUrl = await getNxCloudUrl(workspacePath);
+  const url = `${nxCloudUrl}/nx-cloud/mcp-context/runs/search`;
+
+  const headers: any = {
+    'Content-Type': 'application/json',
+    ...(await nxCloudAuthHeaders(workspacePath)),
+  };
+
+  const data = JSON.stringify(request);
+
+  logger.log(`Making runs search request`);
+  try {
+    const response = await xhr({
+      type: 'POST',
+      url,
+      headers,
+      data,
+      timeout: 10000,
+    });
+
+    const responseData = JSON.parse(response.responseText) as RunSearchResponse;
+    return {
+      data: responseData,
+    };
+  } catch (e) {
+    if (e.status === 401) {
+      logger.log(`Authentication error: ${e.responseText}`);
+      return {
+        error: {
+          type: 'authentication',
+          message: e.responseText,
+        },
+      };
+    }
+    logger.log(`Error: ${JSON.stringify(e)}`);
+    return {
+      error: {
+        type: 'other',
+        message: e.responseText ?? e.message,
+      },
+    };
+  }
+}

--- a/libs/shared/nx-cloud/src/lib/get-task-details.ts
+++ b/libs/shared/nx-cloud/src/lib/get-task-details.ts
@@ -1,0 +1,120 @@
+import { Logger } from '@nx-console/shared-utils';
+import { xhr } from 'request-light';
+import { isNxCloudUsed } from './is-nx-cloud-used';
+import { getNxCloudUrl } from './cloud-ids';
+import { nxCloudAuthHeaders } from './nx-cloud-auth-headers';
+
+export interface FailedTaskAttemptSummary {
+  startTimeMs: number;
+  endTimeMs: number;
+  durationMs: number;
+  status: string;
+  runId: string;
+}
+
+export interface MTaskMeta {
+  // Define based on your actual MTaskMeta type
+  [key: string]: any;
+}
+
+export interface TaskDetails {
+  taskId: string;
+  runId?: string;
+  projectName: string;
+  target: string;
+  startTimeMs: number;
+  endTimeMs: number;
+  durationMs: number;
+  status: string;
+  cacheStatus: string;
+  isCacheable: boolean;
+  hash: string;
+  targetGroupName?: string;
+  params: string;
+  artifactId?: string;
+  priorAttempts: FailedTaskAttemptSummary[];
+  terminalOutputUploadedToFileStorage: boolean;
+  parallelism: boolean;
+  meta?: MTaskMeta;
+  continuous: boolean;
+  batchId?: string;
+  associatedBatches: string[];
+  uploadedToStorage?: boolean;
+  hashScope?: string;
+}
+
+export interface TaskDetailsError {
+  type: 'authentication' | 'network' | 'not_found' | 'other';
+  message: string;
+}
+
+export async function getTaskDetails(
+  workspacePath: string,
+  logger: Logger,
+  runId: string,
+  encodedTaskId: string,
+): Promise<{
+  data?: TaskDetails;
+  error?: TaskDetailsError;
+}> {
+  if (!(await isNxCloudUsed(workspacePath, logger))) {
+    return {
+      error: {
+        type: 'other',
+        message: 'Nx Cloud is not used in this workspace',
+      },
+    };
+  }
+
+  const nxCloudUrl = await getNxCloudUrl(workspacePath);
+  const url = `${nxCloudUrl}/nx-cloud/mcp-context/runs/${runId}/tasks/${encodedTaskId}`;
+
+  const headers: any = {
+    'Content-Type': 'application/json',
+    ...(await nxCloudAuthHeaders(workspacePath)),
+  };
+
+  logger.log(
+    `Making task details request for run ID: ${runId}, task ID: ${encodedTaskId}`,
+  );
+  try {
+    const response = await xhr({
+      type: 'GET',
+      url,
+      headers,
+      timeout: 10000,
+    });
+
+    const responseData = JSON.parse(response.responseText) as TaskDetails;
+    return {
+      data: responseData,
+    };
+  } catch (e) {
+    if (e.status === 401) {
+      logger.log(`Authentication error: ${e.responseText}`);
+      return {
+        error: {
+          type: 'authentication',
+          message: e.responseText,
+        },
+      };
+    }
+    if (e.status === 404) {
+      logger.log(`Task not found: ${e.responseText}`);
+      const decodedTaskId = decodeURIComponent(encodedTaskId);
+      return {
+        error: {
+          type: 'not_found',
+          message: `Task with ID ${decodedTaskId} not found in run ${runId}`,
+        },
+      };
+    }
+    logger.log(`Error: ${JSON.stringify(e)}`);
+    return {
+      error: {
+        type: 'other',
+        message: e.responseText ?? e.message,
+      },
+    };
+  }
+}

--- a/libs/shared/nx-cloud/src/lib/get-tasks-search.ts
+++ b/libs/shared/nx-cloud/src/lib/get-tasks-search.ts
@@ -1,0 +1,96 @@
+import { Logger } from '@nx-console/shared-utils';
+import { xhr } from 'request-light';
+import { isNxCloudUsed } from './is-nx-cloud-used';
+import { getNxCloudUrl } from './cloud-ids';
+import { nxCloudAuthHeaders } from './nx-cloud-auth-headers';
+import { TaskSummary } from './get-run-details';
+
+export interface TaskSearchRequest {
+  workspaceId: string;
+  runIds?: string[];
+  pipelineExecutionIds?: string[];
+  taskIds?: string[];
+  projectNames?: string[];
+  targets?: string[];
+  configurations?: string[];
+  hashes?: string[];
+  statuses?: string[];
+  cacheStatuses?: string[];
+  minStartTimeMs?: number;
+  maxStartTimeMs?: number;
+  limit?: number;
+  pageToken?: string;
+}
+
+export interface TaskSearchResponse {
+  items: TaskSummary[];
+  nextPageToken?: string;
+}
+
+export interface TaskSearchError {
+  type: 'authentication' | 'network' | 'other';
+  message: string;
+}
+
+export async function getTasksSearch(
+  workspacePath: string,
+  logger: Logger,
+  request: TaskSearchRequest,
+): Promise<{
+  data?: TaskSearchResponse;
+  error?: TaskSearchError;
+}> {
+  if (!(await isNxCloudUsed(workspacePath, logger))) {
+    return {
+      error: {
+        type: 'other',
+        message: 'Nx Cloud is not used in this workspace',
+      },
+    };
+  }
+
+  const nxCloudUrl = await getNxCloudUrl(workspacePath);
+  const url = `${nxCloudUrl}/nx-cloud/mcp-context/tasks/search`;
+
+  const headers: any = {
+    'Content-Type': 'application/json',
+    ...(await nxCloudAuthHeaders(workspacePath)),
+  };
+
+  const data = JSON.stringify(request);
+
+  logger.log(`Making tasks search request`);
+  try {
+    const response = await xhr({
+      type: 'POST',
+      url,
+      headers,
+      data,
+      timeout: 10000,
+    });
+
+    const responseData = JSON.parse(
+      response.responseText,
+    ) as TaskSearchResponse;
+    return {
+      data: responseData,
+    };
+  } catch (e) {
+    if (e.status === 401) {
+      logger.log(`Authentication error: ${e.responseText}`);
+      return {
+        error: {
+          type: 'authentication',
+          message: e.responseText,
+        },
+      };
+    }
+    logger.log(`Error: ${JSON.stringify(e)}`);
+    return {
+      error: {
+        type: 'other',
+        message: e.responseText ?? e.message,
+      },
+    };
+  }
+}


### PR DESCRIPTION
Sketches out tools for:
* Get CIPEs (search)
* Get CIPE details (single entity)
* Get runs (search)
* Get run details (single entity)
* Get tasks (search)
* Get task details (single entity)

Only CIPE tools are exposed at this stage so we can start dogfooding -- follow-ups are on the way for runs, tasks, and likely more.

Will also create a follow-up where we only expose the tools if the Cloud instance that we're trying to connect to can support it.