### PR TITLE
fix(vscode): update failed CI notification message

### DIFF
--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -74,7 +74,7 @@ export function compareCIPEDataAndSendNotification(
 
     if (newCIPEIsFailed && !hasAiFix) {
       showMessageWithResultAndCommit(
-        `CI Pipeline Execution for #${newCIPE.branch} has completed`,
+        `CI Pipeline Execution for #${newCIPE.branch} has failed`,
         newCIPE.cipeUrl,
         newCIPE.commitUrl,
         'error',


### PR DESCRIPTION
It bothers me that the CI notification says "CI Pipeline Execution has completed" when it actually failed :)