### PR TITLE
chore(repo): keep vscode & intellij telemetry in sync via target

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Check formatting of other files
         run: yarn nx format:check --verbose
 
+      - name: Check telemetry event synchronization
+        run: yarn nx run telemetry-check
+
       - name: Ensure the workspace configuration is in sync
         run: yarn nx-cloud record -- yarn nx sync:check
 

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -73,16 +73,13 @@ jobs:
       - name: Check formatting of other files
         run: yarn nx format:check --verbose
 
-      - name: Check telemetry event synchronization
-        run: yarn nx run telemetry-check
-
       - name: Ensure the workspace configuration is in sync
         run: yarn nx-cloud record -- yarn nx sync:check
 
       # - name: Run Nx Cloud conformance checks
       #   run: yarn nx-cloud record -- yarn nx-cloud conformance:check
 
-      - run: yarn nx affected --targets=lint,test,build,e2e-ci,typecheck,verifyPlugin --configuration=ci --exclude=nx-console --parallel=3
+      - run: yarn nx affected --targets=lint,test,build,e2e-ci,typecheck,verifyPlugin,telemetry-check --configuration=ci --exclude=nx-console --parallel=3
         timeout-minutes: 45
 
   main-windows:

--- a/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt
@@ -2,6 +2,9 @@ package dev.nx.console.telemetry
 
 import kotlin.reflect.full.companionObject
 
+// these are compared to libs/shared/telemetry/src/lib/telemetry-types.ts
+// through the @nx-console/workspace:telemetry-check target
+// keep them in sync with VSCode!
 enum class TelemetryEvent(val eventName: String) {
     // Activation
     EXTENSION_ACTIVATE("extension-activate"),

--- a/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt
@@ -15,6 +15,14 @@ enum class TelemetryEvent(val eventName: String) {
     MISC_OPEN_PROJECT_DETAILS_CODELENS("misc.open-project-details-codelens"),
     MISC_EXCEPTION("misc.exception"),
 
+    // AI
+    AI_ADD_MCP("ai.add-mcp"),
+    AI_CHAT_MESSAGE("ai.chat-message"),
+    AI_FEEDBACK_BAD("ai.feedback-bad"),
+    AI_FEEDBACK_GOOD("ai.feedback-good"),
+    AI_RESPONSE_INTERACTION("ai.response-interaction"),
+    AI_TOOL_CALL("ai.tool-call"),
+
     // Cloud
     CLOUD_CONNECT("cloud.connect"),
     CLOUD_OPEN_APP("cloud.open-app"),
@@ -25,6 +33,13 @@ enum class TelemetryEvent(val eventName: String) {
     CLOUD_VIEW_CIPE("cloud.view-cipe"),
     CLOUD_VIEW_CIPE_COMMIT("cloud.view-cipe-commit"),
     CLOUD_FIX_CIPE_ERROR("cloud.fix-cipe-error"),
+    CLOUD_APPLY_AI_FIX("cloud.apply-ai-fix"),
+    CLOUD_EXPLAIN_CIPE_ERROR("cloud.explain-cipe-error"),
+    CLOUD_OPEN_FIX_DETAILS("cloud.open-fix-details"),
+    CLOUD_REJECT_AI_FIX("cloud.reject-ai-fix"),
+    CLOUD_SHOW_AI_FIX("cloud.show-ai-fix"),
+    CLOUD_SHOW_AI_FIX_NOTIFICATION("cloud.show-ai-fix-notification"),
+    CLOUD_VIEW_RUN("cloud.view-run"),
 
     // Graph
     GRAPH_SHOW_ALL("graph.show-all"),

--- a/libs/shared/telemetry/src/lib/telemetry-types.ts
+++ b/libs/shared/telemetry/src/lib/telemetry-types.ts
@@ -2,6 +2,9 @@
  * Telemetry Events are defined here. They are
  * - grouped by namespace, separated with dots
  * - kebab-cased
+ * these are compared to apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt
+ * through the @nx-console/workspace:telemetry-check target
+ * keep them in sync with IntelliJ!
  */
 
 export type TelemetryEvents =

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "watch": "nx run vscode:watch:debug",
     "e2e": "nx e2e vscode-e2e",
     "update": "nx migrate latest",
-    "prepare": "husky",
-    "telemetry:check": "nx run telemetry-check"
+    "prepare": "husky"
   },
   "dependencies": {
     "@lit-labs/context": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "watch": "nx run vscode:watch:debug",
     "e2e": "nx e2e vscode-e2e",
     "update": "nx migrate latest",
-    "prepare": "husky"
+    "prepare": "husky",
+    "telemetry:check": "nx run telemetry-check"
   },
   "dependencies": {
     "@lit-labs/context": "^0.3.1",

--- a/project.json
+++ b/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "@nx-console/workspace",
+  "targets": {
+    "telemetry-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node tools/scripts/check-telemetry-sync.js"
+      }
+    }
+  }
+}

--- a/tools/scripts/check-telemetry-sync.js
+++ b/tools/scripts/check-telemetry-sync.js
@@ -2,24 +2,31 @@ const fs = require('fs');
 const path = require('path');
 
 function extractTypeScriptEvents() {
-  const filePath = path.join(__dirname, '../../libs/shared/telemetry/src/lib/telemetry-types.ts');
-  
+  const filePath = path.join(
+    __dirname,
+    '../../libs/shared/telemetry/src/lib/telemetry-types.ts',
+  );
+
   if (!fs.existsSync(filePath)) {
     console.error(`❌ TypeScript telemetry file not found: ${filePath}`);
     process.exit(1);
   }
 
   const content = fs.readFileSync(filePath, 'utf-8');
-  
+
   // Find the TelemetryEvents type definition
-  const typeMatch = content.match(/export type TelemetryEvents\s*=\s*([\s\S]*?);/);
+  const typeMatch = content.match(
+    /export type TelemetryEvents\s*=\s*([\s\S]*?);/,
+  );
   if (!typeMatch) {
-    console.error('❌ Could not find TelemetryEvents type definition in TypeScript file');
+    console.error(
+      '❌ Could not find TelemetryEvents type definition in TypeScript file',
+    );
     process.exit(1);
   }
 
   const typeDefinition = typeMatch[1];
-  
+
   // Extract all event strings from the union type
   const eventMatches = typeDefinition.match(/'\s*([^']+)\s*'/g);
   if (!eventMatches) {
@@ -29,23 +36,26 @@ function extractTypeScriptEvents() {
 
   // Clean up the events and filter out empty strings
   const events = eventMatches
-    .map(match => match.replace(/'/g, '').trim())
-    .filter(event => event.length > 0)
+    .map((match) => match.replace(/'/g, '').trim())
+    .filter((event) => event.length > 0)
     .sort();
 
   return events;
 }
 
 function extractKotlinEvents() {
-  const filePath = path.join(__dirname, '../../apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt');
-  
+  const filePath = path.join(
+    __dirname,
+    '../../apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt',
+  );
+
   if (!fs.existsSync(filePath)) {
     console.error(`❌ Kotlin telemetry file not found: ${filePath}`);
     process.exit(1);
   }
 
   const content = fs.readFileSync(filePath, 'utf-8');
-  
+
   // Extract all enum entries with their string values
   const enumMatches = content.match(/[A-Z_]+\("([^"]+)"\)/g);
   if (!enumMatches) {
@@ -55,46 +65,42 @@ function extractKotlinEvents() {
 
   // Extract the event strings from the enum values
   const events = enumMatches
-    .map(match => {
+    .map((match) => {
       const eventMatch = match.match(/\("([^"]+)"\)/);
       return eventMatch ? eventMatch[1] : '';
     })
-    .filter(event => event.length > 0)
+    .filter((event) => event.length > 0)
     .sort();
 
   return events;
 }
 
-function main() {
-  console.log('🔍 Checking telemetry event synchronization...\n');
+console.log('🔍 Checking telemetry event synchronization...\n');
 
-  const tsEvents = extractTypeScriptEvents();
-  const ktEvents = extractKotlinEvents();
+const tsEvents = extractTypeScriptEvents();
+const ktEvents = extractKotlinEvents();
 
-  console.log(`📊 Found ${tsEvents.length} events in TypeScript`);
-  console.log(`📊 Found ${ktEvents.length} events in Kotlin\n`);
+console.log(`📊 Found ${tsEvents.length} events in TypeScript`);
+console.log(`📊 Found ${ktEvents.length} events in Kotlin\n`);
 
-  const missingInKotlin = tsEvents.filter(e => !ktEvents.includes(e));
-  const missingInTypeScript = ktEvents.filter(e => !tsEvents.includes(e));
+const missingInKotlin = tsEvents.filter((e) => !ktEvents.includes(e));
+const missingInTypeScript = ktEvents.filter((e) => !tsEvents.includes(e));
 
-  if (missingInKotlin.length === 0 && missingInTypeScript.length === 0) {
-    console.log('✅ Telemetry events are synchronized!');
-    process.exit(0);
-  } else {
-    console.log('❌ Telemetry events are NOT synchronized!');
-    
-    if (missingInKotlin.length > 0) {
-      console.log('\n🔴 Missing in JetBrains:');
-      missingInKotlin.forEach(event => console.log(`  - ${event}`));
-    }
-    
-    if (missingInTypeScript.length > 0) {
-      console.log('\n🔴 Missing in VSCode:');
-      missingInTypeScript.forEach(event => console.log(`  - ${event}`));
-    }
-    
-    process.exit(1);
+if (missingInKotlin.length === 0 && missingInTypeScript.length === 0) {
+  console.log('✅ Telemetry events are synchronized!');
+  process.exit(0);
+} else {
+  console.log('❌ Telemetry events are NOT synchronized!');
+
+  if (missingInKotlin.length > 0) {
+    console.log('\n🔴 Missing in JetBrains:');
+    missingInKotlin.forEach((event) => console.log(`  - ${event}`));
   }
-}
 
-main();
+  if (missingInTypeScript.length > 0) {
+    console.log('\n🔴 Missing in VSCode:');
+    missingInTypeScript.forEach((event) => console.log(`  - ${event}`));
+  }
+
+  process.exit(1);
+}

--- a/tools/scripts/check-telemetry-sync.js
+++ b/tools/scripts/check-telemetry-sync.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+
+function extractTypeScriptEvents() {
+  const filePath = path.join(__dirname, '../../libs/shared/telemetry/src/lib/telemetry-types.ts');
+  
+  if (!fs.existsSync(filePath)) {
+    console.error(`❌ TypeScript telemetry file not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  
+  // Find the TelemetryEvents type definition
+  const typeMatch = content.match(/export type TelemetryEvents\s*=\s*([\s\S]*?);/);
+  if (!typeMatch) {
+    console.error('❌ Could not find TelemetryEvents type definition in TypeScript file');
+    process.exit(1);
+  }
+
+  const typeDefinition = typeMatch[1];
+  
+  // Extract all event strings from the union type
+  const eventMatches = typeDefinition.match(/'\s*([^']+)\s*'/g);
+  if (!eventMatches) {
+    console.error('❌ Could not extract events from TypeScript file');
+    process.exit(1);
+  }
+
+  // Clean up the events and filter out empty strings
+  const events = eventMatches
+    .map(match => match.replace(/'/g, '').trim())
+    .filter(event => event.length > 0)
+    .sort();
+
+  return events;
+}
+
+function extractKotlinEvents() {
+  const filePath = path.join(__dirname, '../../apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt');
+  
+  if (!fs.existsSync(filePath)) {
+    console.error(`❌ Kotlin telemetry file not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  
+  // Extract all enum entries with their string values
+  const enumMatches = content.match(/[A-Z_]+\("([^"]+)"\)/g);
+  if (!enumMatches) {
+    console.error('❌ Could not extract events from Kotlin file');
+    process.exit(1);
+  }
+
+  // Extract the event strings from the enum values
+  const events = enumMatches
+    .map(match => {
+      const eventMatch = match.match(/\("([^"]+)"\)/);
+      return eventMatch ? eventMatch[1] : '';
+    })
+    .filter(event => event.length > 0)
+    .sort();
+
+  return events;
+}
+
+function main() {
+  console.log('🔍 Checking telemetry event synchronization...\n');
+
+  const tsEvents = extractTypeScriptEvents();
+  const ktEvents = extractKotlinEvents();
+
+  console.log(`📊 Found ${tsEvents.length} events in TypeScript`);
+  console.log(`📊 Found ${ktEvents.length} events in Kotlin\n`);
+
+  const missingInKotlin = tsEvents.filter(e => !ktEvents.includes(e));
+  const missingInTypeScript = ktEvents.filter(e => !tsEvents.includes(e));
+
+  if (missingInKotlin.length === 0 && missingInTypeScript.length === 0) {
+    console.log('✅ Telemetry events are synchronized!');
+    process.exit(0);
+  } else {
+    console.log('❌ Telemetry events are NOT synchronized!');
+    
+    if (missingInKotlin.length > 0) {
+      console.log('\n🔴 Missing in JetBrains:');
+      missingInKotlin.forEach(event => console.log(`  - ${event}`));
+    }
+    
+    if (missingInTypeScript.length > 0) {
+      console.log('\n🔴 Missing in VSCode:');
+      missingInTypeScript.forEach(event => console.log(`  - ${event}`));
+    }
+    
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
A new telemetry event synchronization checker was implemented to ensure consistency between TypeScript and Kotlin implementations.

*   A new script, `tools/scripts/check-telemetry-sync.js`, was created.
    *   It reads `libs/shared/telemetry/src/lib/telemetry-types.ts` and `apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt`.
    *   It extracts and compares telemetry event strings using regex, reporting any discrepancies.
    *   The script exits with code 0 on synchronization and 1 otherwise, suitable for CI.
*   An Nx target, `telemetry-check`, was added to `project.json` to run the script via `node tools/scripts/check-telemetry-sync.js`.
*   A convenience script, `telemetry:check`, was added to `package.json` to execute the Nx target.
*   Thirteen missing telemetry events (e.g., `ai.chat-message`, `cloud.view-run`) were added to `apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt` to achieve synchronization.
*   The CI workflow `.github/workflows/ci_checks.yml` was updated to include a `Check telemetry event synchronization` step, running `yarn nx run telemetry-check` to enforce synchronization in the pipeline.

These changes ensure that telemetry events are consistently defined across both platforms and that any future desynchronization will be caught by CI.