### PR TITLE
fix(vscode): support Angular migrations better in Migrate UI

### DIFF
--- a/libs/vscode/migrate/src/lib/commands/run-migration.ts
+++ b/libs/vscode/migrate/src/lib/commands/run-migration.ts
@@ -17,8 +17,22 @@ export async function runSingleMigration(
     async () => {
       commands.executeCommand('nxMigrate.refreshWebview');
 
-      const migrateUiApi = await importMigrateUIApi(workspacePath);
-      migrateUiApi.runSingleMigration(workspacePath, migration, configuration);
+      // Make sure we are in the workspace so module resolution works correctly.
+      // Angular 20 has a migration, for example, that won't work unless CWD is set to the workspace root.
+      const originalCwd = process.cwd();
+      process.chdir(workspacePath);
+
+      try {
+        const migrateUiApi = await importMigrateUIApi(workspacePath);
+        await migrateUiApi.runSingleMigration(
+          workspacePath,
+          migration,
+          configuration,
+        );
+      } finally {
+        // Ensure we switch back since the extension host can be shared.
+        process.chdir(originalCwd);
+      }
     },
   );
 }


### PR DESCRIPTION
This PR fixes Angular migrations when going through Migrate UI.

## Current Behavior

When running Angular migrations through VS Code's Migrate UI, two issues occur:
1. Module resolution fails with errors like Cannot find module '@angular/core' even though the modules exist in the workspace
2. Angular migrations (like control-flow-migration) fail with Could not find any files to migrate under the path undefined

This happens because migrations run without the proper working directory context, causing Node.js module resolution and file path resolution to fail.

## Expected Behavior

Migrations should run successfully with:
- Proper module resolution finding packages in the workspace's node_modules
- Correct file path resolution for Angular migrations to locate project files


## Implementation Details

The fix is simple: change the working directory to the workspace before running migrations. This single change resolves both issues because:
- Node.js resolves modules relative to the current working directory
- Angular migrations find files relative to the workspace root