### PR TITLE
feat(migrate): add stop migration functionality and update commands

### DIFF
--- a/apps/vscode/project.json
+++ b/apps/vscode/project.json
@@ -25,6 +25,8 @@
           "@angular-devkit/*",
           "@nx/key",
           "@nx/nx*",
+          "nx",
+          "nx/*",
           "*/nx.wasi.cjs"
         ],
         "thirdParty": true,

--- a/apps/vscode/project.json
+++ b/apps/vscode/project.json
@@ -25,8 +25,6 @@
           "@angular-devkit/*",
           "@nx/key",
           "@nx/nx*",
-          "nx",
-          "nx/*",
           "*/nx.wasi.cjs"
         ],
         "thirdParty": true,

--- a/libs/vscode/migrate/src/lib/commands/finish-migration.ts
+++ b/libs/vscode/migrate/src/lib/commands/finish-migration.ts
@@ -1,7 +1,4 @@
 import { getNxWorkspacePath } from '@nx-console/vscode-configuration';
-import { execSync } from 'child_process';
-import { existsSync, readFileSync, rmSync } from 'fs';
-import { join } from 'path';
 import { window, commands } from 'vscode';
 import { importMigrateUIApi, readMigrationsJsonMetadata } from './utils';
 import { logAndShowError } from '@nx-console/vscode-output-channels';

--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -200,3 +200,27 @@ export async function viewDocumentation(migration: MigrationDetailsWithId) {
 
   commands.executeCommand('vscode.open', url);
 }
+
+export async function stopMigration(migration: MigrationDetailsWithId) {
+  try {
+    const workspacePath = getNxWorkspacePath();
+    const migrateUIApi = await importMigrateUIApi(workspacePath);
+
+    const isStopped = migrateUIApi.killMigrationProcess(
+      migration.id,
+      workspacePath,
+    );
+
+    if (isStopped) {
+      window.showInformationMessage(
+        `Migration "${migration.name}" has been stopped.`,
+      );
+    } else {
+      window.showWarningMessage(
+        `Migration "${migration.name}" was not running or could not be stopped.`,
+      );
+    }
+  } catch (error) {
+    window.showErrorMessage(`Failed to stop migration: ${error.message}`);
+  }
+}

--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -204,7 +204,8 @@ export async function viewDocumentation(migration: MigrationDetailsWithId) {
 export async function stopMigration(migration: MigrationDetailsWithId) {
   try {
     const workspacePath = getNxWorkspacePath();
-    const migrateUIApi = await importMigrateUIApi(workspacePath);
+    // TODO: Remove the `as any` cast once the repository is updated to use the latest Nx version that exports the `killMigrationProcess` function.
+    const migrateUIApi = (await importMigrateUIApi(workspacePath)) as any;
 
     const isStopped = migrateUIApi.killMigrationProcess(
       migration.id,

--- a/libs/vscode/migrate/src/lib/commands/run-migration.ts
+++ b/libs/vscode/migrate/src/lib/commands/run-migration.ts
@@ -15,10 +15,15 @@ export async function runSingleMigration(
       title: `Running ${migration.name}`,
     },
     async () => {
-      commands.executeCommand('nxMigrate.refreshWebview');
-
       const migrateUiApi = await importMigrateUIApi(workspacePath);
-      migrateUiApi.runSingleMigration(workspacePath, migration, configuration);
+      await migrateUiApi.runSingleMigration(
+        workspacePath,
+        migration,
+        configuration,
+      );
+
+      // Refresh after migration completes and writes to migrations.json
+      commands.executeCommand('nxMigrate.refreshWebview');
     },
   );
 }

--- a/libs/vscode/migrate/src/lib/migrate-webview.ts
+++ b/libs/vscode/migrate/src/lib/migrate-webview.ts
@@ -16,6 +16,7 @@ import {
 import {
   cancelMigration,
   skipMigration,
+  stopMigration,
   undoMigration,
   viewDocumentation,
   viewImplementation,
@@ -100,6 +101,9 @@ export class MigrateWebview {
           break;
         case 'view-documentation':
           viewDocumentation(message.payload.migration);
+          break;
+        case 'stop-migration':
+          stopMigration(message.payload.migration);
           break;
       }
     });


### PR DESCRIPTION
## Overview
This PR works in tandem with https://github.com/nrwl/nx/pull/31626 to enable the new Stop CTA inside of the Migrate UI.


### Key Features
- When we run a migration via the migrate UI it runs as a separate process.
- Ensure that the webview is updated after changes have been made via run migration.
- Add stop command to kill a currently running migration.

### MISC
- This change also fixes and issue with angular migration. The PR: https://github.com/nrwl/nx-console/pull/2565 was closed in favour of this one.