### PR TITLE
fix(vscode): refactor ai fix webview & automatically update it

### DIFF
--- a/libs/vscode/nx-cloud-fix-webview/src/main.ts
+++ b/libs/vscode/nx-cloud-fix-webview/src/main.ts
@@ -35,8 +35,8 @@ export class Root extends LitElement {
     // Listen for messages from the extension
     window.addEventListener('message', (event) => {
       console.log('Received message from extension:', event);
-      if (event.type === 'update-details') {
-        globalThis.fixDetails = event.data as NxCloudFixData;
+      if (event.data.type === 'update-details') {
+        globalThis.fixDetails = event.data.details as NxCloudFixData;
         this.requestUpdate();
       }
     });

--- a/libs/vscode/nx-cloud-fix-webview/src/main.ts
+++ b/libs/vscode/nx-cloud-fix-webview/src/main.ts
@@ -12,9 +12,6 @@ export interface NxCloudFixWebviewMessage {
 
 @customElement('root-nx-cloud-fix-element')
 export class Root extends LitElement {
-  @property({ type: Object })
-  details: NxCloudFixData | undefined;
-
   static override styles = css`
     :host {
       display: block;
@@ -38,8 +35,8 @@ export class Root extends LitElement {
     // Listen for messages from the extension
     window.addEventListener('message', (event) => {
       if (event.type === 'update-details') {
-        const data = event.data as NxCloudFixData;
-        this.details = data;
+        globalThis.fixDetails = event.data as NxCloudFixData;
+        this.requestUpdate();
       }
     });
   }
@@ -47,7 +44,7 @@ export class Root extends LitElement {
   override render(): TemplateResult {
     return html`
       <nx-cloud-fix-component
-        .details=${this.details}
+        .details=${globalThis.fixDetails as NxCloudFixData}
         .onApply=${() => this.handleApply()}
         .onReject=${() => this.handleReject()}
         .onShowDiff=${() => this.handleShowDiff()}

--- a/libs/vscode/nx-cloud-fix-webview/src/main.ts
+++ b/libs/vscode/nx-cloud-fix-webview/src/main.ts
@@ -34,6 +34,7 @@ export class Root extends LitElement {
     super.connectedCallback();
     // Listen for messages from the extension
     window.addEventListener('message', (event) => {
+      console.log('Received message from extension:', event);
       if (event.type === 'update-details') {
         globalThis.fixDetails = event.data as NxCloudFixData;
         this.requestUpdate();

--- a/libs/vscode/nx-cloud-fix-webview/src/main.ts
+++ b/libs/vscode/nx-cloud-fix-webview/src/main.ts
@@ -35,8 +35,13 @@ export class Root extends LitElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    // Notify the extension that the webview is ready
-    this.vscodeApi.postMessage({ type: 'webview-ready' });
+    // Listen for messages from the extension
+    window.addEventListener('message', (event) => {
+      if (event.type === 'update-details') {
+        const data = event.data as NxCloudFixData;
+        this.details = data;
+      }
+    });
   }
 
   override render(): TemplateResult {

--- a/libs/vscode/nx-cloud-fix-webview/src/main.ts
+++ b/libs/vscode/nx-cloud-fix-webview/src/main.ts
@@ -12,6 +12,9 @@ export interface NxCloudFixWebviewMessage {
 
 @customElement('root-nx-cloud-fix-element')
 export class Root extends LitElement {
+  @property({ type: Object })
+  details: NxCloudFixData | undefined;
+
   static override styles = css`
     :host {
       display: block;
@@ -39,7 +42,7 @@ export class Root extends LitElement {
   override render(): TemplateResult {
     return html`
       <nx-cloud-fix-component
-        .details=${globalThis.fixDetails as NxCloudFixData}
+        .details=${this.details}
         .onApply=${() => this.handleApply()}
         .onReject=${() => this.handleReject()}
         .onShowDiff=${() => this.handleShowDiff()}

--- a/libs/vscode/nx-cloud-fix-webview/src/nx-cloud-fix-component.ts
+++ b/libs/vscode/nx-cloud-fix-webview/src/nx-cloud-fix-component.ts
@@ -689,7 +689,7 @@ export class NxCloudFixComponent extends LitElement {
       }
 
       .codicon-modifier-spin {
-        animation: spin 1s linear infinite;
+        animation: spin 2s linear infinite;
       }
 
       .task-id {

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -165,7 +165,7 @@ function showAiFixNotification(cipe: CIPEInfo, runGroup: CIPERunGroup) {
       });
       commands.executeCommand('nxCloud.openFixDetails', {
         cipeId: cipe.ciPipelineExecutionId,
-        runGroup,
+        runGroupId: runGroup.runGroup,
       });
     } else if (selection === 'Reject') {
       telemetry.logUsage('cloud.reject-ai-fix', {

--- a/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
@@ -37,11 +37,7 @@ import {
   RunTreeItem as RunTreeItemInterface,
   FailedTaskTreeItem as FailedTaskTreeItemInterface,
 } from './base-tree-item';
-import {
-  NxCloudFixTreeItem,
-  registerNxCloudFixCommands,
-} from './nx-cloud-fix-tree-item';
-import { NxCloudFixWebview } from './nx-cloud-fix-webview';
+import { NxCloudFixTreeItem } from './nx-cloud-fix-tree-item';
 
 export class CIPETreeItem
   extends BaseRecentCIPETreeItem
@@ -520,7 +516,6 @@ export class CloudRecentCIPEProvider extends AbstractTreeProvider<BaseRecentCIPE
           );
         },
       ),
-      ...registerNxCloudFixCommands(extensionContext, recentCIPEProvider),
       commands.registerCommand('nxCloud.helpMeFixCipeError', async () => {
         getTelemetry().logUsage('cloud.fix-cipe-error');
 

--- a/libs/vscode/nx-cloud-view/src/cloud-view-state-machine.spec.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-view-state-machine.spec.ts
@@ -23,7 +23,7 @@ const defaultImplementation = {
       params: {
         oldData: CIPEInfo[];
         newData: CIPEInfo[];
-      }
+      },
     ) => {
       compareCIPEDataAndSendNotificationMock(params.oldData, params.newData);
     },
@@ -79,6 +79,7 @@ describe('Cloud View State Machine', () => {
     actor.start();
 
     expect(actor.getSnapshot().matches('loading')).toBe(true);
+    expect(false).toBe(true);
   });
 
   it('should show onboarding view if there are no recent CIPEs and onboarding isnt complete', () => {

--- a/libs/vscode/nx-cloud-view/src/cloud-view-state-machine.spec.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-view-state-machine.spec.ts
@@ -79,7 +79,6 @@ describe('Cloud View State Machine', () => {
     actor.start();
 
     expect(actor.getSnapshot().matches('loading')).toBe(true);
-    expect(false).toBe(true);
   });
 
   it('should show onboarding view if there are no recent CIPEs and onboarding isnt complete', () => {

--- a/libs/vscode/nx-cloud-view/src/init-nx-cloud-view.ts
+++ b/libs/vscode/nx-cloud-view/src/init-nx-cloud-view.ts
@@ -29,6 +29,7 @@ import { CloudOnboardingViewProvider } from './cloud-onboarding-view';
 import { CloudRecentCIPEProvider } from './cloud-recent-cipe-view';
 import { machine } from './cloud-view-state-machine';
 import { TelemetryEventSource } from '@nx-console/shared-telemetry';
+import { NxCloudFixWebview } from './nx-cloud-fix-webview';
 
 export function initNxCloudView(context: ExtensionContext) {
   // set up state machine & listeners
@@ -59,6 +60,7 @@ export function initNxCloudView(context: ExtensionContext) {
   ).start();
   CloudOnboardingViewProvider.create(context, actor);
   CloudRecentCIPEProvider.create(context, actor);
+  NxCloudFixWebview.create(context, actor);
 
   async function updateOnboarding() {
     const onboardingInfo = await getCloudOnboardingInfo();

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-tree-item.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-tree-item.ts
@@ -61,7 +61,7 @@ export class NxCloudFixTreeItem
     this.command = {
       command: 'nxCloud.openFixDetails',
       title: 'Open Fix Details',
-      arguments: [{ cipeId: this.cipeId, runGroup: this.runGroup }],
+      arguments: [{ cipeId: this.cipeId, runGroupId: this.runGroup.runGroup }],
     };
 
     const aiFix = this.runGroup.aiFix;

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -163,10 +163,7 @@ export class NxCloudFixWebview {
       </head>
       <body>
         <script type="module" src="${webviewScriptUri}"></script>
-        <script>
-          globalThis.fixDetails = ${JSON.stringify(details)};
-        </script>
-        <root-nx-cloud-fix-element></root-nx-cloud-fix-element>
+        <root-nx-cloud-fix-element .details=${JSON.stringify(details)}></root-nx-cloud-fix-element>
       </body>
       </html>`;
   }

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -248,7 +248,7 @@ export class NxCloudFixWebview {
       this.currentFixDetails = undefined;
       this._onDispose.fire();
 
-      window.visibleTextEditors.forEach((editor) => {
+      window.visibleNotebookEditors.forEach((editor) => {
         console.log(editor);
       });
     });

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -204,11 +204,6 @@ export class NxCloudFixWebview {
   async updateFixDetailsFromRecentCIPEs(recentCIPEs: CIPEInfo[]) {
     if (!this.currentFixDetails) return;
 
-    console.log('updateFixDetailsFromRecentCIPEs called', {
-      currentCipeId: this.currentFixDetails.cipe.ciPipelineExecutionId,
-      currentRunGroup: this.currentFixDetails.runGroup.runGroup,
-    });
-
     const updatedDetails = recentCIPEs.find(
       (cipe) =>
         cipe.ciPipelineExecutionId ===
@@ -222,9 +217,6 @@ export class NxCloudFixWebview {
       );
 
       if (updatedRunGroup) {
-        console.log('Found updated runGroup', {
-          aiFix: updatedRunGroup.aiFix,
-        });
         this.currentFixDetails = {
           ...this.currentFixDetails,
           cipe: updatedDetails,
@@ -301,10 +293,6 @@ export class NxCloudFixWebview {
 
   private updateWebviewContent() {
     if (!this.webviewPanel || !this.currentFixDetails) return;
-
-    console.log('Sending update-details message to webview', {
-      aiFix: this.currentFixDetails.runGroup.aiFix,
-    });
 
     this.webviewPanel.webview.postMessage({
       type: 'update-details',
@@ -470,19 +458,11 @@ export class NxCloudFixWebview {
 
       // Show the unified diff in the beside column
       const title = `Nx Cloud Fix (${parsedDiff.length} file${parsedDiff.length === 1 ? '' : 's'})`;
-      const diffReturn = await commands.executeCommand(
-        'vscode.diff',
-        beforeUri,
-        afterUri,
-        title,
-        {
-          preview: false,
-          preserveFocus: false,
-          viewColumn: ViewColumn.Beside,
-        },
-      );
-
-      console.log(diffReturn);
+      await commands.executeCommand('vscode.diff', beforeUri, afterUri, title, {
+        preview: false,
+        preserveFocus: false,
+        viewColumn: ViewColumn.Beside,
+      });
     }
   }
 }

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -46,7 +46,6 @@ export class NxCloudFixWebview {
     if (!NxCloudFixWebview.INSTANCE) {
       const nxCloudFixWebview = new NxCloudFixWebview(extensionContext);
 
-      // Register content providers for virtual diff documents
       const diffContentProvider = new DiffContentProvider();
       extensionContext.subscriptions.push(
         workspace.registerTextDocumentContentProvider(

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -44,7 +44,7 @@ export class NxCloudFixWebview {
     actor: ActorRef<any, EventObject>,
   ): NxCloudFixWebview {
     if (!NxCloudFixWebview.INSTANCE) {
-      const nxCloudFixWebview = new NxCloudFixWebview(extensionContext, actor);
+      const nxCloudFixWebview = new NxCloudFixWebview(extensionContext);
 
       // Register content providers for virtual diff documents
       const diffContentProvider = new DiffContentProvider();
@@ -180,10 +180,7 @@ export class NxCloudFixWebview {
     return NxCloudFixWebview.INSTANCE;
   }
 
-  constructor(
-    private context: ExtensionContext,
-    private actor: ActorRef<any, EventObject>,
-  ) {}
+  constructor(private context: ExtensionContext) {}
 
   get onDispose() {
     return this._onDispose.event;
@@ -207,6 +204,7 @@ export class NxCloudFixWebview {
 
   async updateFixDetailsFromRecentCIPEs(recentCIPEs: CIPEInfo[]) {
     if (!this.currentFixDetails) return;
+    console.log('update triggered');
 
     const updatedDetails = recentCIPEs.find(
       (cipe) =>
@@ -214,6 +212,7 @@ export class NxCloudFixWebview {
         this.currentFixDetails.cipe.ciPipelineExecutionId,
     );
 
+    console.log('found update cipe details', updatedDetails);
     if (updatedDetails) {
       this.currentFixDetails = {
         ...this.currentFixDetails,
@@ -248,6 +247,10 @@ export class NxCloudFixWebview {
       this.webviewPanel = undefined;
       this.currentFixDetails = undefined;
       this._onDispose.fire();
+
+      window.visibleTextEditors.forEach((editor) => {
+        console.log(editor);
+      });
     });
 
     this.webviewPanel.webview.html = this.getWebviewHtml(


### PR DESCRIPTION
I refactored the AI fix webview. 
- It's now instantiated at the root of the library and takes care of registering its relevant commands itself.
- It consumes the state machine actor to listen for changes and trigger updates in the UI without destroying everything
- We only pass the cipeId and runGroupId and read from the current state when opening the UI from the notification to make sure that the UI is rendered with the most up-to-date state instead of what was true when the notification popped up. 
- the spinner is a bit slower