### PR TITLE
feat(vscode): add status bar item whenever there is a fix available

### DIFF
--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -10,7 +10,7 @@ export function compareCIPEDataAndSendNotification(
   oldInfo: CIPEInfo[] | null,
   newInfo: CIPEInfo[],
 ) {
-  // Always update status bar regardless of notification settings
+  // Always update status bar
   updateAiFixStatusBar(newInfo);
 
   const nxCloudNotificationsSetting = GlobalConfigurationStore.instance.get(
@@ -187,28 +187,6 @@ function showAiFixNotification(cipe: CIPEInfo, runGroup: CIPERunGroup) {
   window
     .showInformationMessage(message, ...messageCommands)
     .then(handleResults);
-
-  // Update status bar
-  if (!aiFixStatusBarItem) {
-    aiFixStatusBarItem = window.createStatusBarItem(
-      StatusBarAlignment.Left,
-      100,
-    );
-  }
-
-  aiFixStatusBarItem.text = `$(wrench) Nx Cloud AI Fix: ${taskDisplay}`;
-  aiFixStatusBarItem.tooltip = message;
-  aiFixStatusBarItem.command = {
-    command: 'nxCloud.openFixDetails',
-    title: 'Show Error Details',
-    arguments: [
-      {
-        cipeId: cipe.ciPipelineExecutionId,
-        runGroupId: runGroup.runGroup,
-      },
-    ],
-  };
-  aiFixStatusBarItem.show();
 }
 
 export function disposeAiFixStatusBarItem() {

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -225,12 +225,14 @@ export function hideAiFixStatusBarItem() {
 }
 
 export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
-  // Find the first available AI fix
   let foundFix: { cipe: CIPEInfo; runGroup: CIPERunGroup } | null = null;
 
   for (const cipe of cipeData) {
     for (const runGroup of cipe.runGroups || []) {
-      if (runGroup.aiFix?.suggestedFix && runGroup.aiFix.userAction === 'NONE') {
+      if (
+        runGroup.aiFix?.suggestedFix &&
+        runGroup.aiFix.userAction === 'NONE'
+      ) {
         foundFix = { cipe, runGroup };
         break;
       }
@@ -239,7 +241,6 @@ export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
   }
 
   if (foundFix) {
-    // Show status bar with the first available fix
     if (!aiFixStatusBarItem) {
       aiFixStatusBarItem = window.createStatusBarItem(
         StatusBarAlignment.Left,
@@ -250,7 +251,7 @@ export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
     const taskDisplay = foundFix.runGroup.aiFix?.taskIds[0];
     const message = `Nx Cloud suggested a fix for ${taskDisplay} in #${foundFix.cipe.branch}`;
 
-    aiFixStatusBarItem.text = `$(wrench) Nx Cloud AI Fix: ${taskDisplay}`;
+    aiFixStatusBarItem.text = `$(wrench) Nx Cloud AI Fix`;
     aiFixStatusBarItem.tooltip = message;
     aiFixStatusBarItem.command = {
       command: 'nxCloud.openFixDetails',

--- a/libs/vscode/nx-cloud-view/src/init-nx-cloud-view.ts
+++ b/libs/vscode/nx-cloud-view/src/init-nx-cloud-view.ts
@@ -24,7 +24,10 @@ import {
   window,
 } from 'vscode';
 import { createActor } from 'xstate';
-import { compareCIPEDataAndSendNotification } from './cipe-notifications';
+import {
+  compareCIPEDataAndSendNotification,
+  disposeAiFixStatusBarItem,
+} from './cipe-notifications';
 import { CloudOnboardingViewProvider } from './cloud-onboarding-view';
 import { CloudRecentCIPEProvider } from './cloud-recent-cipe-view';
 import { machine } from './cloud-view-state-machine';
@@ -86,6 +89,7 @@ export function initNxCloudView(context: ExtensionContext) {
     showRefreshLoadingAtLocation({ viewId: 'nxCloudLoading' }),
     showRefreshLoadingAtLocation({ viewId: 'nxCloudRecentCIPE' }),
     showRefreshLoadingAtLocation({ viewId: 'nxCloudOnboarding' }),
+    { dispose: () => disposeAiFixStatusBarItem() },
   );
 
   // register commands

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -30,6 +30,7 @@ import {
 import { ActorRef, EventObject } from 'xstate';
 import { DiffContentProvider, parseGitDiff } from './diffs/diff-provider';
 import { createUnifiedDiffView } from './nx-cloud-fix-tree-item';
+import { hideAiFixStatusBarItem } from './cipe-notifications';
 
 export interface NxCloudFixDetails {
   cipe: CIPEInfo;
@@ -384,6 +385,7 @@ export class NxCloudFixWebview {
           if (success) {
             window.showInformationMessage('Nx Cloud fix applied successfully');
             commands.executeCommand('nxCloud.refresh');
+            hideAiFixStatusBarItem();
           }
         },
       ),
@@ -438,6 +440,7 @@ export class NxCloudFixWebview {
               data.runGroup.aiFix.aiFixId,
               'APPLIED_LOCALLY',
             );
+            hideAiFixStatusBarItem();
           } catch (error) {
             outputLogger.log(
               `Failed to apply Nx Cloud fix locally: ${error.stderr || error.message}`,
@@ -467,6 +470,7 @@ export class NxCloudFixWebview {
           if (success) {
             window.showInformationMessage('Nx Cloud fix ignored');
             commands.executeCommand('nxCloud.refresh');
+            hideAiFixStatusBarItem();
           }
         },
       ),
@@ -526,6 +530,7 @@ export class NxCloudFixWebview {
             runGroup: runGroup,
             terminalOutput,
           });
+          hideAiFixStatusBarItem();
         },
       ),
     );


### PR DESCRIPTION
This pull request introduces enhancements to the Nx Cloud extension for Visual Studio Code, focusing on AI fix notifications and tree view updates. The changes improve user experience by integrating a status bar indicator for AI fixes, adding badges to the tree view, and ensuring proper cleanup of UI elements when fixes are applied or dismissed.

### AI Fix Notifications and Status Bar Enhancements:
* Added a `StatusBarItem` to display AI fix suggestions in the status bar, including tooltip and command functionality. The status bar is updated dynamically based on available fixes. (`libs/vscode/nx-cloud-view/src/cipe-notifications.ts`, [[1]](diffhunk://#diff-6858641a2c7901fa6168d454f5672dd8b5f3487c346788ed7691a6f4e435395aL5-R15) [[2]](diffhunk://#diff-6858641a2c7901fa6168d454f5672dd8b5f3487c346788ed7691a6f4e435395aR184-R270)
* Implemented methods to dispose or hide the status bar item when no fixes are available or after user actions. (`libs/vscode/nx-cloud-view/src/cipe-notifications.ts`, [libs/vscode/nx-cloud-view/src/cipe-notifications.tsR184-R270](diffhunk://#diff-6858641a2c7901fa6168d454f5672dd8b5f3487c346788ed7691a6f4e435395aR184-R270))

### Tree View Updates:
* Introduced a badge system for the `CloudRecentCIPEProvider` tree view to display the count of unacted AI fixes. The badge updates dynamically based on pipeline data. (`libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts`, [[1]](diffhunk://#diff-bdb4a032e9fa6aa9a7262c46d61e6fbb1174fd5ca45e0b196f3c3bac3da35526R389) [[2]](diffhunk://#diff-bdb4a032e9fa6aa9a7262c46d61e6fbb1174fd5ca45e0b196f3c3bac3da35526R421-R452)
* Stored a reference to the tree view for badge updates and integrated it into the extension's lifecycle. (`libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts`, [libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.tsR463-R473](diffhunk://#diff-bdb4a032e9fa6aa9a7262c46d61e6fbb1174fd5ca45e0b196f3c3bac3da35526R463-R473))

### Cleanup and Integration:
* Ensured the status bar item is hidden or disposed of when fixes are applied, ignored, or dismissed through the `NxCloudFixWebview`. (`libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts`, [[1]](diffhunk://#diff-686a4822d329f79a54a07103f415254f2d51587e6c91d545e60eddee02af9a6dR388) [[2]](diffhunk://#diff-686a4822d329f79a54a07103f415254f2d51587e6c91d545e60eddee02af9a6dR443) [[3]](diffhunk://#diff-686a4822d329f79a54a07103f415254f2d51587e6c91d545e60eddee02af9a6dR473) [[4]](diffhunk://#diff-686a4822d329f79a54a07103f415254f2d51587e6c91d545e60eddee02af9a6dR533)
* Registered cleanup logic for the status bar item during extension disposal. (`libs/vscode/nx-cloud-view/src/init-nx-cloud-view.ts`, [libs/vscode/nx-cloud-view/src/init-nx-cloud-view.tsR92](diffhunk://#diff-5821585399696fa749957cc572cc6284c0bd5e31bd77e639c5f10ed7de98d014R92))