### PR TITLE
fix(vscode): rename ai notifications to be stronger & other small fixes

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/cloud/CIPENotificationService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/cloud/CIPENotificationService.kt
@@ -4,12 +4,13 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.notification.*
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.EDT
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import dev.nx.console.mcp.McpServerService
 import dev.nx.console.mcp.hasAIAssistantInstalled
+import dev.nx.console.models.AITaskFixUserAction
 import dev.nx.console.models.CIPEInfo
 import dev.nx.console.models.CIPERun
 import dev.nx.console.models.CIPERunGroup
@@ -19,6 +20,9 @@ import dev.nx.console.telemetry.TelemetryEvent
 import dev.nx.console.telemetry.TelemetryEventSource
 import dev.nx.console.telemetry.TelemetryService
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Service responsible for showing CIPE notifications. Simply displays notification events emitted
@@ -36,9 +40,6 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
         fun getInstance(project: Project): CIPENotificationService =
             project.getService(CIPENotificationService::class.java)
     }
-
-    private val logger = thisLogger()
-    private val telemetryService = TelemetryService.getInstance(project)
 
     override fun onNotificationEvent(event: CIPENotificationEvent) {
         val notificationSetting = getCIPENotificationSetting()
@@ -74,8 +75,7 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
 
     private fun showCIPEFailedNotification(cipe: CIPEInfo) {
         showNotification(
-            title = "CI Pipeline Failed",
-            content = "CI Pipeline Execution for #${cipe.branch} has failed",
+            content = " CI failed for #${cipe.branch}.",
             type = NotificationType.ERROR,
             cipe = cipe,
             commitUrl = cipe.commitUrl
@@ -91,8 +91,7 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
             }
 
         showNotification(
-            title = "Run Failed",
-            content = "\"$command\" has failed on #${cipe.branch}",
+            content = "\"$command\" failed on #${cipe.branch}.",
             type = NotificationType.ERROR,
             cipe = cipe,
             commitUrl = cipe.commitUrl,
@@ -102,8 +101,7 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
 
     private fun showCIPESucceededNotification(cipe: CIPEInfo) {
         showNotification(
-            title = "CI Pipeline Succeeded",
-            content = "CI Pipeline Execution for #${cipe.branch} has completed",
+            content = "CI succeeded for #${cipe.branch}.",
             type = NotificationType.INFORMATION,
             cipe = cipe,
             commitUrl = cipe.commitUrl
@@ -111,22 +109,12 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
     }
 
     private fun showAiFixNotification(cipe: CIPEInfo, runGroup: CIPERunGroup) {
-        telemetryService.featureUsed(TelemetryEvent.CLOUD_SHOW_AI_FIX_NOTIFICATION)
-
-        val taskDisplay = runGroup.aiFix?.taskIds?.firstOrNull() ?: "task"
-        val taskCount = runGroup.aiFix?.taskIds?.size ?: 0
-
-        val content =
-            if (taskCount > 1) {
-                "Nx Cloud suggested a fix for $taskDisplay and ${taskCount - 1} other task${if (taskCount > 2) "s" else ""} in #${cipe.branch}"
-            } else {
-                "Nx Cloud suggested a fix for $taskDisplay in #${cipe.branch}"
-            }
+        TelemetryService.getInstance(project)
+            .featureUsed(TelemetryEvent.CLOUD_SHOW_AI_FIX_NOTIFICATION)
 
         val notification =
             NOTIFICATION_GROUP.createNotification(
-                title = "CI Failed. Nx AI suggested a fix.",
-                content = content,
+                content = "CI failed. Nx Cloud AI has a fix for #${cipe.branch}",
                 type = NotificationType.ERROR
             )
 
@@ -134,22 +122,22 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
             ShowSuggestedFixAction(cipe.ciPipelineExecutionId, runGroup.runGroup)
         )
         notification.addAction(RejectAiFixAction(cipe, runGroup))
+        notification.isSuggestionType = true
 
         notification.notify(project)
     }
 
     private fun showNotification(
-        title: String,
         content: String,
         type: NotificationType,
         cipe: CIPEInfo,
         commitUrl: String? = null,
         resultsUrl: String? = null
     ) {
-        telemetryService.featureUsed(TelemetryEvent.CLOUD_SHOW_CIPE_NOTIFICATION)
+        TelemetryService.getInstance(project)
+            .featureUsed(TelemetryEvent.CLOUD_SHOW_CIPE_NOTIFICATION)
 
-        val notification =
-            NOTIFICATION_GROUP.createNotification(title = title, content = content, type = type)
+        val notification = NOTIFICATION_GROUP.createNotification(content = content, type = type)
 
         if (type == NotificationType.ERROR) {
             val runGroupWithFix = cipe.runGroups.find { it.aiFix != null }
@@ -181,10 +169,11 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
     private inner class ViewResultsAction(private val url: String) :
         NotificationAction("View Results") {
         override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-            telemetryService.featureUsed(
-                TelemetryEvent.CLOUD_VIEW_CIPE,
-                mapOf("source" to TelemetryEventSource.NOTIFICATION),
-            )
+            TelemetryService.getInstance(project)
+                .featureUsed(
+                    TelemetryEvent.CLOUD_VIEW_CIPE,
+                    mapOf("source" to TelemetryEventSource.NOTIFICATION),
+                )
             BrowserUtil.browse(url)
             notification.expire()
         }
@@ -193,10 +182,11 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
     private inner class ViewCommitAction(private val url: String) :
         NotificationAction("View Commit") {
         override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-            telemetryService.featureUsed(
-                TelemetryEvent.CLOUD_VIEW_CIPE_COMMIT,
-                mapOf("source" to TelemetryEventSource.NOTIFICATION),
-            )
+            TelemetryService.getInstance(project)
+                .featureUsed(
+                    TelemetryEvent.CLOUD_VIEW_CIPE_COMMIT,
+                    mapOf("source" to TelemetryEventSource.NOTIFICATION),
+                )
             BrowserUtil.browse(url)
             notification.expire()
         }
@@ -207,7 +197,7 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
         private val runGroupId: String
     ) : NotificationAction("View AI Fix") {
         override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-            telemetryService.featureUsed(TelemetryEvent.CLOUD_OPEN_FIX_DETAILS)
+            TelemetryService.getInstance(project).featureUsed(TelemetryEvent.CLOUD_OPEN_FIX_DETAILS)
 
             CloudFixUIService.getInstance(project).openCloudFixWebview(cipeId, runGroupId)
 
@@ -220,12 +210,12 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
         private val runGroupId: String
     ) : NotificationAction("Show Fix") {
         override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-            telemetryService.featureUsed(
-                TelemetryEvent.CLOUD_SHOW_AI_FIX,
-                mapOf("source" to TelemetryEventSource.NOTIFICATION)
-            )
+            TelemetryService.getInstance(project)
+                .featureUsed(
+                    TelemetryEvent.CLOUD_SHOW_AI_FIX,
+                    mapOf("source" to TelemetryEventSource.NOTIFICATION)
+                )
 
-            // Open the cloud fix webview
             CloudFixUIService.getInstance(project).openCloudFixWebview(cipeId, runGroupId)
 
             notification.expire()
@@ -237,21 +227,32 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
         private val runGroup: CIPERunGroup
     ) : NotificationAction("Reject") {
         override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-            // Will implement AI fix rejection (implement in later commit)
-            telemetryService.featureUsed(
-                TelemetryEvent.CLOUD_REJECT_AI_FIX,
-                mapOf("source" to TelemetryEventSource.NOTIFICATION)
-            )
-            notification.expire()
+            TelemetryService.getInstance(project)
+                .featureUsed(
+                    TelemetryEvent.CLOUD_REJECT_AI_FIX,
+                    mapOf("source" to TelemetryEventSource.NOTIFICATION)
+                )
+            val aiFixId = runGroup.aiFix?.aiFixId ?: return
+            val cloudApiService = NxCloudApiService.getInstance(project)
+            cs.launch {
+                val success =
+                    cloudApiService.updateSuggestedFix(aiFixId, AITaskFixUserAction.REJECTED)
+
+                if (success) {
+                    CIPEPollingService.getInstance(project).forcePoll()
+                }
+                withContext(Dispatchers.EDT) { notification.expire() }
+            }
         }
     }
 
     private inner class HelpMeFixErrorAction : NotificationAction("Help me fix this error") {
         override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-            telemetryService.featureUsed(
-                TelemetryEvent.CLOUD_FIX_CIPE_ERROR,
-                mapOf("source" to TelemetryEventSource.NOTIFICATION)
-            )
+            TelemetryService.getInstance(project)
+                .featureUsed(
+                    TelemetryEvent.CLOUD_FIX_CIPE_ERROR,
+                    mapOf("source" to TelemetryEventSource.NOTIFICATION)
+                )
 
             // Try to execute the existing AI assistant action if available
             val assistantReady =

--- a/apps/intellij/src/main/kotlin/dev/nx/console/cloud/CIPENotificationService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/cloud/CIPENotificationService.kt
@@ -125,9 +125,9 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
 
         val notification =
             NOTIFICATION_GROUP.createNotification(
-                title = "AI Fix Available",
+                title = "CI Failed. Nx AI suggested a fix.",
                 content = content,
-                type = NotificationType.INFORMATION
+                type = NotificationType.ERROR
             )
 
         notification.addAction(
@@ -218,7 +218,7 @@ class CIPENotificationService(private val project: Project, private val cs: Coro
     private inner class ShowSuggestedFixAction(
         private val cipeId: String,
         private val runGroupId: String
-    ) : NotificationAction("Show Suggested Fix") {
+    ) : NotificationAction("Show Fix") {
         override fun actionPerformed(e: AnActionEvent, notification: Notification) {
             telemetryService.featureUsed(
                 TelemetryEvent.CLOUD_SHOW_AI_FIX,

--- a/apps/intellij/src/main/kotlin/dev/nx/console/cloud/cloud_fix_ui/NxCloudFixFileImpl.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/cloud/cloud_fix_ui/NxCloudFixFileImpl.kt
@@ -493,7 +493,7 @@ class NxCloudFixFileImpl(
             try {
                 val cloudApiService = NxCloudApiService.getInstance(project)
                 val success =
-                    cloudApiService.updateSuggestedFix(aiFixId, AITaskFixUserAction.APPLIED_LOCALLY)
+                    cloudApiService.updateSuggestedFix(aiFixId, AITaskFixUserAction.REJECTED)
 
                 if (success) {
                     CIPEPollingService.getInstance(project).forcePoll()

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
@@ -504,7 +504,10 @@ describe('CIPE Notifications', () => {
         );
         expect(window.showErrorMessage).not.toHaveBeenCalled();
         expect(window.showInformationMessage).toHaveBeenCalledWith(
-          'New AI Fix available for test-task-1 in #feature',
+          '_7171214.JPG
+_7171216.JPG
+_7171223.JPG
+_7171228.JPG test-task-1 in #feature',
           'Show Suggested Fix',
           'Reject',
         );
@@ -518,7 +521,10 @@ describe('CIPE Notifications', () => {
         );
         expect(window.showErrorMessage).not.toHaveBeenCalled();
         expect(window.showInformationMessage).toHaveBeenCalledWith(
-          'New AI Fix available for test-task-2 in #feature',
+          '_7171214.JPG
+_7171216.JPG
+_7171223.JPG
+_7171228.JPG test-task-2 in #feature',
           'Show Suggested Fix',
           'Reject',
         );
@@ -611,7 +617,10 @@ describe('CIPE Notifications', () => {
         );
         expect(window.showErrorMessage).not.toHaveBeenCalled();
         expect(window.showInformationMessage).toHaveBeenCalledWith(
-          'New AI Fix available for test-task-1 in #feature',
+          '_7171214.JPG
+_7171216.JPG
+_7171223.JPG
+_7171228.JPG test-task-1 in #feature',
           'Show Suggested Fix',
           'Reject',
         );

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
@@ -449,13 +449,13 @@ describe('CIPE Notifications', () => {
       ['failWithAiFix', 'failWithAiFix', 'no'], // Same state, no notification
       ['progressWithAiFixWithSuggestion', 'progressFailedRunWithAiFix', 'no'], // Both have suggestions, no notification
       ['empty', 'progressWithAiFixNotStarted', 'no'], // AI fix not started, no notification
-      ['progressWithAiFixNotStarted', 'progressFailedRunWithAiFix', 'info'], // AI fix becomes available, notification
+      ['progressWithAiFixNotStarted', 'progressFailedRunWithAiFix', 'error'], // AI fix becomes available, notification
       [
         'progressWithAiFixNotStarted',
         'progressWithAiFixWithSuggestion',
-        'info',
+        'error',
       ], // AI fix becomes available, notification
-      ['progressWithAiFixNotStarted', 'failWithAiFix', 'info'], // AI fix becomes available, notification
+      ['progressWithAiFixNotStarted', 'failWithAiFix', 'error'], // AI fix becomes available, notification
     ] as const;
 
     test.each(cases)(

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
@@ -428,17 +428,17 @@ describe('CIPE Notifications', () => {
       ['success', 'progressFailedRun', 'no'],
       ['success', 'fail', 'no'],
       // AI fix test cases
-      ['empty', 'failWithAiFix', 'info'], // AI fix with suggestion appears
-      ['progress', 'failWithAiFix', 'info'], // AI fix with suggestion appears
-      ['empty', 'progressFailedRunWithAiFix', 'info'], // AI fix with suggestion appears
-      ['progress', 'progressFailedRunWithAiFix', 'info'], // AI fix with suggestion appears
-      ['progressWithAiFixNoSuggestion', 'progressFailedRunWithAiFix', 'info'], // Different AI fix with suggestion
-      ['progressWithAiFixNoSuggestion', 'failWithAiFix', 'info'], // Different AI fix with suggestion
-      ['progressFailedRun', 'progressWithAiFixWithSuggestion', 'info'], // Transition from no AI fix to AI fix with suggestion
+      ['empty', 'failWithAiFix', 'error'], // AI fix with suggestion appears
+      ['progress', 'failWithAiFix', 'error'], // AI fix with suggestion appears
+      ['empty', 'progressFailedRunWithAiFix', 'error'], // AI fix with suggestion appears
+      ['progress', 'progressFailedRunWithAiFix', 'error'], // AI fix with suggestion appears
+      ['progressWithAiFixNoSuggestion', 'progressFailedRunWithAiFix', 'error'], // Different AI fix with suggestion
+      ['progressWithAiFixNoSuggestion', 'failWithAiFix', 'error'], // Different AI fix with suggestion
+      ['progressFailedRun', 'progressWithAiFixWithSuggestion', 'error'], // Transition from no AI fix to AI fix with suggestion
       [
         'progressWithAiFixNoSuggestion',
         'progressWithAiFixWithSuggestion',
-        'info',
+        'error',
       ], // AI fix gets suggestion
       ['progressFailedRun', 'progressWithAiFixNoSuggestion', 'no'], // AI fix without suggestion doesn't notify
       [
@@ -502,13 +502,10 @@ describe('CIPE Notifications', () => {
           pipelineExamples.progress,
           pipelineExamples.failWithAiFix,
         );
-        expect(window.showErrorMessage).not.toHaveBeenCalled();
-        expect(window.showInformationMessage).toHaveBeenCalledWith(
-          '_7171214.JPG
-_7171216.JPG
-_7171223.JPG
-_7171228.JPG test-task-1 in #feature',
-          'Show Suggested Fix',
+        expect(window.showInformationMessage).not.toHaveBeenCalled();
+        expect(window.showErrorMessage).toHaveBeenCalledWith(
+          'CI failed. Nx Cloud AI has a fix for #feature',
+          'Show Fix',
           'Reject',
         );
 
@@ -519,13 +516,10 @@ _7171228.JPG test-task-1 in #feature',
           pipelineExamples.progress,
           pipelineExamples.progressFailedRunWithAiFix,
         );
-        expect(window.showErrorMessage).not.toHaveBeenCalled();
-        expect(window.showInformationMessage).toHaveBeenCalledWith(
-          '_7171214.JPG
-_7171216.JPG
-_7171223.JPG
-_7171228.JPG test-task-2 in #feature',
-          'Show Suggested Fix',
+        expect(window.showInformationMessage).not.toHaveBeenCalled();
+        expect(window.showErrorMessage).toHaveBeenCalledWith(
+          'CI failed. Nx Cloud AI has a fix for #feature',
+          'Show Fix',
           'Reject',
         );
       });
@@ -615,13 +609,10 @@ _7171228.JPG test-task-2 in #feature',
           pipelineExamples.progress,
           mixedRunGroups,
         );
-        expect(window.showErrorMessage).not.toHaveBeenCalled();
-        expect(window.showInformationMessage).toHaveBeenCalledWith(
-          '_7171214.JPG
-_7171216.JPG
-_7171223.JPG
-_7171228.JPG test-task-1 in #feature',
-          'Show Suggested Fix',
+        expect(window.showInformationMessage).not.toHaveBeenCalled();
+        expect(window.showErrorMessage).toHaveBeenCalledWith(
+          'CI failed. Nx Cloud AI has a fix for #feature',
+          'Show Fix',
           'Reject',
         );
       });
@@ -658,11 +649,11 @@ _7171228.JPG test-task-1 in #feature',
           );
 
           if (shouldNotify) {
-            expect(window.showInformationMessage).toHaveBeenCalled();
+            expect(window.showErrorMessage).toHaveBeenCalled();
           } else {
-            expect(window.showInformationMessage).not.toHaveBeenCalled();
+            expect(window.showErrorMessage).not.toHaveBeenCalled();
           }
-          expect(window.showErrorMessage).not.toHaveBeenCalled();
+          expect(window.showInformationMessage).not.toHaveBeenCalled();
         });
       });
     });

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.spec.ts
@@ -504,7 +504,7 @@ describe('CIPE Notifications', () => {
         );
         expect(window.showErrorMessage).not.toHaveBeenCalled();
         expect(window.showInformationMessage).toHaveBeenCalledWith(
-          'Nx Cloud suggested a fix for test-task-1 in #feature',
+          'New AI Fix available for test-task-1 in #feature',
           'Show Suggested Fix',
           'Reject',
         );
@@ -518,7 +518,7 @@ describe('CIPE Notifications', () => {
         );
         expect(window.showErrorMessage).not.toHaveBeenCalled();
         expect(window.showInformationMessage).toHaveBeenCalledWith(
-          'Nx Cloud suggested a fix for test-task-2 in #feature',
+          'New AI Fix available for test-task-2 in #feature',
           'Show Suggested Fix',
           'Reject',
         );
@@ -611,7 +611,7 @@ describe('CIPE Notifications', () => {
         );
         expect(window.showErrorMessage).not.toHaveBeenCalled();
         expect(window.showInformationMessage).toHaveBeenCalledWith(
-          'Nx Cloud suggested a fix for test-task-1 in #feature',
+          'New AI Fix available for test-task-1 in #feature',
           'Show Suggested Fix',
           'Reject',
         );

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -163,11 +163,11 @@ function showAiFixNotification(cipe: CIPEInfo, runGroup: CIPERunGroup) {
   const telemetry = getTelemetry();
   telemetry.logUsage('cloud.show-ai-fix-notification');
 
-  type MessageCommand = 'Show Suggested Fix' | 'Reject';
-  const messageCommands: MessageCommand[] = ['Show Suggested Fix', 'Reject'];
+  type MessageCommand = 'Show Fix' | 'Reject';
+  const messageCommands: MessageCommand[] = ['Show Fix', 'Reject'];
 
   const handleResults = async (selection: MessageCommand | undefined) => {
-    if (selection === 'Show Suggested Fix') {
+    if (selection === 'Show Fix') {
       telemetry.logUsage('cloud.show-ai-fix', {
         source: 'notification',
       });
@@ -185,9 +185,7 @@ function showAiFixNotification(cipe: CIPEInfo, runGroup: CIPERunGroup) {
 
   const message = getAIFixMessage(runGroup.aiFix?.taskIds[0], cipe.branch);
 
-  window
-    .showInformationMessage(message, ...messageCommands)
-    .then(handleResults);
+  window.showErrorMessage(message, ...messageCommands).then(handleResults);
 }
 
 export function disposeAiFixStatusBarItem() {
@@ -252,5 +250,5 @@ export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
 }
 
 function getAIFixMessage(task: string, branch: string) {
-  return `New AI Fix available for ${task} in #${branch}`;
+  return `CI failed. Nx AI suggested a fix for ${task} in #${branch}`;
 }

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -183,10 +183,8 @@ function showAiFixNotification(cipe: CIPEInfo, runGroup: CIPERunGroup) {
     }
   };
 
-  const taskDisplay = runGroup.aiFix?.taskIds[0];
-  const message = `Nx Cloud suggested a fix for ${taskDisplay} in #${cipe.branch}`;
+  const message = getAIFixMessage(runGroup.aiFix?.taskIds[0], cipe.branch);
 
-  // Show notification
   window
     .showInformationMessage(message, ...messageCommands)
     .then(handleResults);
@@ -229,8 +227,10 @@ export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
       );
     }
 
-    const taskDisplay = foundFix.runGroup.aiFix?.taskIds[0];
-    const message = `Nx Cloud suggested a fix for ${taskDisplay} in #${foundFix.cipe.branch}`;
+    const message = getAIFixMessage(
+      foundFix.runGroup.aiFix?.taskIds[0],
+      foundFix.cipe.branch,
+    );
 
     aiFixStatusBarItem.text = `$(wrench) Nx Cloud AI Fix`;
     aiFixStatusBarItem.tooltip = message;
@@ -249,4 +249,8 @@ export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
     // Hide status bar if no fixes available
     hideAiFixStatusBarItem();
   }
+}
+
+function getAIFixMessage(task: string, branch: string) {
+  return `New AI Fix available for ${task} in #${branch}`;
 }

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications.ts
@@ -82,7 +82,7 @@ export function compareCIPEDataAndSendNotification(
 
     if (newCIPEIsFailed && !hasAiFix) {
       showMessageWithResultAndCommit(
-        `CI Pipeline Execution for #${newCIPE.branch} has failed`,
+        `CI failed for #${newCIPE.branch}.`,
         newCIPE.cipeUrl,
         newCIPE.commitUrl,
         'error',
@@ -93,14 +93,14 @@ export function compareCIPEDataAndSendNotification(
           ? newCIPEFailedRun.command.substring(0, 60) + '[...]'
           : newCIPEFailedRun.command;
       showMessageWithResultAndCommit(
-        `"${command}" has failed on #${newCIPE.branch}`,
+        `"${command}" failed on #${newCIPE.branch}.`,
         newCIPEFailedRun.runUrl,
         newCIPE.commitUrl,
         'error',
       );
     } else if (newCipeIsSucceeded && nxCloudNotificationsSetting === 'all') {
       showMessageWithResultAndCommit(
-        `CI Pipeline Execution for #${newCIPE.branch} has completed`,
+        `CI succeeded for #${newCIPE.branch}.`,
         newCIPE.cipeUrl,
         newCIPE.commitUrl,
         'information',
@@ -183,7 +183,7 @@ function showAiFixNotification(cipe: CIPEInfo, runGroup: CIPERunGroup) {
     }
   };
 
-  const message = getAIFixMessage(runGroup.aiFix?.taskIds[0], cipe.branch);
+  const message = getAIFixMessage(cipe.branch);
 
   window.showErrorMessage(message, ...messageCommands).then(handleResults);
 }
@@ -225,10 +225,7 @@ export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
       );
     }
 
-    const message = getAIFixMessage(
-      foundFix.runGroup.aiFix?.taskIds[0],
-      foundFix.cipe.branch,
-    );
+    const message = getAIFixMessage(foundFix.cipe.branch);
 
     aiFixStatusBarItem.text = `$(wrench) Nx Cloud AI Fix`;
     aiFixStatusBarItem.tooltip = message;
@@ -249,6 +246,6 @@ export function updateAiFixStatusBar(cipeData: CIPEInfo[]) {
   }
 }
 
-function getAIFixMessage(task: string, branch: string) {
-  return `CI failed. Nx AI suggested a fix for ${task} in #${branch}`;
+function getAIFixMessage(branch: string) {
+  return `CI failed. Nx Cloud AI has a fix for #${branch}`;
 }


### PR DESCRIPTION
AI fix notifications:
<img width="410" height="82" alt="image" src="https://github.com/user-attachments/assets/17f2535e-0910-4f6c-a0f4-3c0824340ae9" />
<img width="372" height="97" alt="image" src="https://github.com/user-attachments/assets/d1d75bf0-0540-4fe3-a00a-a926f0a5c302" />

(I forgot to take a new screenshot of the intellij notification, it also has the `#` to mark the branch)

