### PR TITLE
feat(mcp): optimize nx_workspace tool & gradually drop information if result is too large

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-workspace.test.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-workspace.test.ts
@@ -1,0 +1,193 @@
+import { getTokenLimitedToolResult } from './nx-workspace';
+import { NxWorkspace, NxError } from '@nx-console/shared-types';
+import {
+  getNxJsonPrompt,
+  getProjectGraphPrompt,
+  getProjectGraphErrorsPrompt,
+} from '@nx-console/shared-llm-context';
+
+jest.mock('@nx-console/shared-llm-context', () => ({
+  getNxJsonPrompt: jest.fn(),
+  getProjectGraphPrompt: jest.fn(),
+  getProjectGraphErrorsPrompt: jest.fn(),
+}));
+
+const mockGetNxJsonPrompt = getNxJsonPrompt as jest.MockedFunction<
+  typeof getNxJsonPrompt
+>;
+const mockGetProjectGraphPrompt = getProjectGraphPrompt as jest.MockedFunction<
+  typeof getProjectGraphPrompt
+>;
+const mockGetProjectGraphErrorsPrompt =
+  getProjectGraphErrorsPrompt as jest.MockedFunction<
+    typeof getProjectGraphErrorsPrompt
+  >;
+
+describe('getTokenLimitedToolResult', () => {
+  const mockWorkspace: NxWorkspace = {
+    nxJson: {},
+    projectGraph: {
+      nodes: {},
+      dependencies: {},
+    },
+    errors: undefined,
+    isPartial: false,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('nx-json-result');
+    mockGetProjectGraphPrompt.mockReturnValue('project-graph-result');
+    mockGetProjectGraphErrorsPrompt.mockReturnValue('errors-result');
+  });
+
+  it('should return results without optimization when under token limit', () => {
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('small');
+    mockGetProjectGraphPrompt.mockReturnValue('small');
+    mockGetProjectGraphErrorsPrompt.mockReturnValue('small');
+
+    const result = getTokenLimitedToolResult(mockWorkspace, 1000);
+
+    expect(result).toEqual(['small', 'small', '']);
+    expect(mockGetProjectGraphPrompt).toHaveBeenCalledTimes(1);
+    expect(mockGetProjectGraphPrompt).toHaveBeenCalledWith(
+      mockWorkspace.projectGraph,
+    );
+  });
+
+  it('should apply first optimization when over token limit', () => {
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('short');
+    // Use string that will exceed low token limit when divided by 3
+    const largeString = 'x'.repeat(200);
+    mockGetProjectGraphPrompt
+      .mockReturnValueOnce(largeString) // First call - triggers optimization
+      .mockReturnValueOnce('short'); // Second call - stops optimization
+
+    // Use a very low token limit to trigger optimization
+    const result = getTokenLimitedToolResult(mockWorkspace, 50);
+
+    expect(mockGetProjectGraphPrompt).toHaveBeenCalledTimes(2);
+    expect(mockGetProjectGraphPrompt).toHaveBeenNthCalledWith(
+      1,
+      mockWorkspace.projectGraph,
+    );
+    expect(mockGetProjectGraphPrompt).toHaveBeenNthCalledWith(
+      2,
+      mockWorkspace.projectGraph,
+      {
+        skipOwners: true,
+        skipTechnologies: true,
+      },
+    );
+  });
+
+  it('should apply second optimization when still over token limit', () => {
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('short');
+    const largeString = 'x'.repeat(200);
+    mockGetProjectGraphPrompt
+      .mockReturnValueOnce(largeString) // First call - triggers optimization
+      .mockReturnValueOnce(largeString) // Second call - still large, continues optimization
+      .mockReturnValueOnce('short'); // Third call - stops optimization
+
+    const result = getTokenLimitedToolResult(mockWorkspace, 50);
+
+    expect(mockGetProjectGraphPrompt).toHaveBeenCalledTimes(3);
+    expect(mockGetProjectGraphPrompt).toHaveBeenNthCalledWith(
+      2,
+      mockWorkspace.projectGraph,
+      {
+        skipOwners: true,
+        skipTechnologies: true,
+      },
+    );
+    expect(mockGetProjectGraphPrompt).toHaveBeenNthCalledWith(
+      3,
+      mockWorkspace.projectGraph,
+      {
+        skipOwners: true,
+        skipTechnologies: true,
+        truncateTargets: true,
+      },
+    );
+  });
+
+  it('should apply third optimization when still over token limit', () => {
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('short');
+    const largeString = 'x'.repeat(200);
+    mockGetProjectGraphPrompt
+      .mockReturnValueOnce(largeString) // First call - triggers optimization
+      .mockReturnValueOnce(largeString) // Second call - still large, continues
+      .mockReturnValueOnce(largeString) // Third call - still large, continues
+      .mockReturnValueOnce('short'); // Fourth call - stops optimization
+
+    const result = getTokenLimitedToolResult(mockWorkspace, 50);
+
+    expect(mockGetProjectGraphPrompt).toHaveBeenCalledTimes(4);
+    expect(mockGetProjectGraphPrompt).toHaveBeenNthCalledWith(
+      4,
+      mockWorkspace.projectGraph,
+      {
+        skipOwners: true,
+        skipTechnologies: true,
+        skipTags: true,
+        truncateTargets: true,
+      },
+    );
+  });
+
+  it('should stop optimization after 3 attempts even if still over limit', () => {
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('short');
+    const largeString = 'x'.repeat(200);
+    mockGetProjectGraphPrompt
+      .mockReturnValueOnce(largeString)
+      .mockReturnValueOnce(largeString)
+      .mockReturnValueOnce(largeString)
+      .mockReturnValueOnce(largeString);
+
+    const result = getTokenLimitedToolResult(mockWorkspace, 50);
+
+    expect(mockGetProjectGraphPrompt).toHaveBeenCalledTimes(4);
+  });
+
+  it('should include errors result when workspace has errors', () => {
+    const mockError: NxError = { message: 'Some error' };
+    const workspaceWithErrors: NxWorkspace = {
+      ...mockWorkspace,
+      errors: [mockError],
+    };
+
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('small');
+    mockGetProjectGraphPrompt.mockReturnValue('small');
+    mockGetProjectGraphErrorsPrompt.mockReturnValue('error-result');
+
+    const result = getTokenLimitedToolResult(workspaceWithErrors, 1000);
+
+    expect(mockGetProjectGraphErrorsPrompt).toHaveBeenCalledWith(
+      [mockError],
+      false,
+    );
+    expect(result).toEqual(['small', 'small', 'error-result']);
+  });
+
+  it('should handle workspace without errors', () => {
+    const workspaceWithoutErrors: NxWorkspace = {
+      ...mockWorkspace,
+      errors: undefined,
+    };
+
+    jest.clearAllMocks();
+    mockGetNxJsonPrompt.mockReturnValue('small');
+    mockGetProjectGraphPrompt.mockReturnValue('small');
+
+    const result = getTokenLimitedToolResult(workspaceWithoutErrors, 1000);
+
+    expect(mockGetProjectGraphErrorsPrompt).not.toHaveBeenCalled();
+    expect(result).toEqual(['small', 'small', '']);
+  });
+});

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-workspace.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-workspace.ts
@@ -1,0 +1,131 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  getNxJsonPrompt,
+  getProjectGraphErrorsPrompt,
+  getProjectGraphPrompt,
+  NX_WORKSPACE,
+} from '@nx-console/shared-llm-context';
+import { checkIsNxWorkspace } from '@nx-console/shared-npm';
+import { NxConsoleTelemetryLogger } from '@nx-console/shared-telemetry';
+import { Logger } from '@nx-console/shared-utils';
+import { NxWorkspaceInfoProvider } from '../nx-mcp-server';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { NxWorkspace } from '@nx-console/shared-types';
+
+export function registerNxWorkspaceTool(
+  workspacePath: string,
+  server: McpServer,
+  logger: Logger,
+  nxWorkspaceInfoProvider: NxWorkspaceInfoProvider,
+  telemetry?: NxConsoleTelemetryLogger,
+) {
+  server.tool(
+    NX_WORKSPACE,
+    'Returns a readable representation of the nx project graph and the nx.json that configures nx. If there are project graph errors, it also returns them. Use it to answer questions about the nx workspace and architecture',
+    {
+      destructiveHint: false,
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    async () => {
+      telemetry?.logUsage('ai.tool-call', {
+        tool: NX_WORKSPACE,
+      });
+      try {
+        if (!workspacePath) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'Error: Workspace path not set' }],
+          };
+        }
+        if (!(await checkIsNxWorkspace(workspacePath))) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: 'Error: The provided root is not a valid nx workspace.',
+              },
+            ],
+          };
+        }
+
+        const workspace = await nxWorkspaceInfoProvider.nxWorkspace(
+          workspacePath,
+          logger,
+        );
+        if (!workspace) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: 'Error: Workspace not found' }],
+          };
+        }
+        const results = getTokenLimitedToolResult(workspace);
+        const content: CallToolResult['content'] = results
+          .filter((result) => !!result)
+          .map((result) => ({
+            type: 'text',
+            text: result,
+          }));
+
+        return {
+          content,
+        };
+      } catch (e) {
+        return {
+          content: [{ type: 'text', text: String(e) }],
+        };
+      }
+    },
+  );
+}
+
+export function getTokenLimitedToolResult(
+  workspace: NxWorkspace,
+  maxTokens = 25000,
+): string[] {
+  const nxJsonResult = getNxJsonPrompt(workspace.nxJson);
+  let projectGraphResult = getProjectGraphPrompt(workspace.projectGraph);
+  const errorsResult = workspace.errors
+    ? getProjectGraphErrorsPrompt(workspace.errors, !!workspace.isPartial)
+    : '';
+
+  const getEstimatedTokenCount = () => {
+    return (
+      (nxJsonResult.length + projectGraphResult.length + errorsResult.length) /
+      3
+    );
+  };
+
+  let optimizationCounter = 0;
+  while (getEstimatedTokenCount() >= maxTokens && optimizationCounter <= 2) {
+    switch (optimizationCounter) {
+      case 0:
+        projectGraphResult = getProjectGraphPrompt(workspace.projectGraph, {
+          skipOwners: true,
+          skipTechnologies: true,
+        });
+        break;
+      case 1:
+        projectGraphResult = getProjectGraphPrompt(workspace.projectGraph, {
+          skipOwners: true,
+          skipTechnologies: true,
+          truncateTargets: true,
+        });
+        break;
+      case 2:
+        projectGraphResult = getProjectGraphPrompt(workspace.projectGraph, {
+          skipOwners: true,
+          skipTechnologies: true,
+          skipTags: true,
+          truncateTargets: true,
+        });
+        break;
+      default:
+        break;
+    }
+    optimizationCounter++;
+  }
+
+  return [nxJsonResult, projectGraphResult, errorsResult];
+}

--- a/libs/shared/llm-context/src/lib/project-graph.ts
+++ b/libs/shared/llm-context/src/lib/project-graph.ts
@@ -3,7 +3,17 @@ import { getMessageForError } from '@nx-console/shared-utils';
 import type { ProjectGraph } from 'nx/src/devkit-exports';
 import { NX_PROJECT_DETAILS } from './tool-names';
 
-export function getProjectGraphPrompt(projectGraph: ProjectGraph): string {
+export type ProjectGraphOptimizations = {
+  skipTechnologies?: boolean;
+  skipOwners?: boolean;
+  skipTags?: boolean;
+  truncateTargets?: boolean;
+};
+
+export function getProjectGraphPrompt(
+  projectGraph: ProjectGraph,
+  optimizations?: ProjectGraphOptimizations,
+): string {
   return `
 The following is a representation of the Nx workspace. It includes all
 projects in the monorepo. The projects are separated by <></> tags including the project name.
@@ -12,48 +22,62 @@ Each project contains:
 - its available targets, marked by "targets: [...]". Targets are tasks that the user can run for each project. Individual atomized targets are excluded.
 - its type (libary, app, or e2e tests), marked by "type: [...]".
 - its source file location, marked by "root: [...]".
-- some metadata like tags, owners or technologies used.
+- ${
+    optimizations?.skipTags
+      ? ''
+      : `some metadata like tags ${optimizations?.skipOwners ? '' : ', owners'} ${
+          optimizations?.skipTechnologies ? '' : 'or technologies used'
+        }.`
+  }
 
 This data is very important. Use it to analyze the workspace and provide relevant answers to the user. 
 Some of this data is shortened to be more compact. To retrieve the full unabridged details about a project, use the ${NX_PROJECT_DETAILS} tool.
 The user cannot see this data, so don't reference it directly. It is read-only, so don't suggest modifications to it.
 
-${getRobotReadableProjectGraph(projectGraph)}
+${getRobotReadableProjectGraph(projectGraph, optimizations)}
 `.trim();
 }
 
-function getRobotReadableProjectGraph(projectGraph: ProjectGraph): string {
+function getRobotReadableProjectGraph(
+  projectGraph: ProjectGraph,
+  optimizations?: ProjectGraphOptimizations,
+): string {
   let serializedGraph = '';
   Object.entries(projectGraph.nodes).forEach(([name, node]) => {
     let nodeString = `<${name}>`;
 
+    // dependencies
     const deps = projectGraph.dependencies[name]
       .filter((dep) => !projectGraph.externalNodes?.[dep.target])
       .map((dep) => dep.target);
 
     let depsString = '';
     if (deps.length > 10) {
-      depsString = deps.slice(0, 8).join(', ') + `,...${deps.length - 8} more`;
+      depsString = deps.slice(0, 8).join(',') + `,...${deps.length - 8} more`;
     } else {
       depsString = deps.join(', ');
     }
-    nodeString += `deps:[${depsString}]`;
 
+    if (deps.length) {
+      nodeString += `deps:[${depsString}]`;
+    }
+
+    // targets
     const targetGroups = node.data.metadata?.targetGroups ?? {};
     const targetsToExclude: string[] = [];
 
     // if there are many targets in a group where one is a root target (because of atomizer), ignore the rest
     for (const group in targetGroups) {
       const targets = targetGroups[group];
-      let rootTarget = undefined;
+      const rootTargets = new Set<string>();
 
       for (const target of targets) {
         if (targets.some((t) => t !== target && t.startsWith(target))) {
-          rootTarget = target;
+          rootTargets.add(target);
         }
       }
 
-      if (rootTarget) {
+      for (const rootTarget of rootTargets) {
         targetsToExclude.push(
           ...targets.filter(
             (t) => t.startsWith(rootTarget) && t !== rootTarget,
@@ -61,36 +85,52 @@ function getRobotReadableProjectGraph(projectGraph: ProjectGraph): string {
         );
       }
     }
+    const targets = Object.keys(node.data.targets ?? {}).filter(
+      (target) =>
+        !targetsToExclude.includes(target) &&
+        target !== 'nx-release-publish' &&
+        target !== 'nxProjectGraph' &&
+        target !== 'nxProjectReport',
+    );
+    let targetsString = '';
+    if (targets.length > 10 && optimizations?.truncateTargets) {
+      targetsString =
+        targets.slice(0, 8).join(',') + `,...${targets.length - 8} more`;
+    } else {
+      targetsString = targets.join(',');
+    }
+    nodeString += `targets:[${targetsString}]`;
 
-    nodeString += `targets:[${Object.keys(node.data.targets ?? {})
-      .filter(
-        (target) =>
-          !targetsToExclude.includes(target) &&
-          target !== 'nx-release-publish' &&
-          target !== 'nxProjectGraph' &&
-          target !== 'nxProjectReport',
-      )
-      .join(', ')}]`;
+    // other metadata
     nodeString += `type:[${node.type}]`;
-    nodeString += `root:[${node.data.root}]`;
-    if (node.data.metadata?.technologies) {
-      nodeString += `technologies:[${node.data.metadata.technologies.join(
-        ', ',
+    const rootString = `root:[${node.data.root}]`;
+    nodeString += rootString;
+    if (node.data.metadata?.technologies && !optimizations?.skipTechnologies) {
+      const technologiesString = `technologies:[${node.data.metadata.technologies.join(
+        ',',
       )}]`;
+      nodeString += technologiesString;
     }
-    if (node.data.metadata?.owners) {
-      nodeString += `owners:[${Object.keys(node.data.metadata.owners).join(
-        ', ',
-      )}]`;
+    if (node.data.metadata?.owners && !optimizations?.skipOwners) {
+      const ownersString = `owners:[${Object.keys(
+        node.data.metadata.owners,
+      ).join(',')}]`;
+      nodeString += ownersString;
     }
-    if (node.data.tags) {
-      nodeString += `tags:[${node.data.tags.join(', ')}]`;
+    if (node.data.tags?.length && !optimizations?.skipTags) {
+      const tagsString = `tags:[${node.data.tags.join(',')}]`;
+      nodeString += tagsString;
     }
-    nodeString += `</${name}>\n`;
+    nodeString += `</>\n`;
     serializedGraph += nodeString;
   });
 
-  return serializedGraph;
+  return (
+    serializedGraph +
+    '\n' +
+    serializedGraph.length +
+    JSON.stringify(optimizations)
+  );
 }
 
 export function getProjectGraphErrorsPrompt(


### PR DESCRIPTION
This PR enables the `nx_workspace` mcp tool to work on much larger workspaces.
It does this through
- various small improvements to make the result shorter (drop empty arrays, skip project name in closing tags, properly handle mutliple atomized targets per project, ...)
- a process of escalating optimizations:
  - if the estimated amount of tokens of the response (naively guess `characters / 3`) is greater than `25000` (which is claude codes limit), start pruning the response
  - first, we drop ownership & technology information
  - if that still isn't enough, we start truncating the list of targets and say `...x more`
  - if that still isn't enough, we start dropping each project's tags
  - ⏳ in the future, I'll add more optimizations to make this work for even larger repos
  - ⏳ in the future, I'll add more filtering parameters to the tool so folks can use it without losing information for just parts of their workspace ([see draft PR](https://github.com/nrwl/nx-console/pull/2569))

This is more than enough to get it working on our repos, will continue testing on larger repos