### PR TITLE
fix(intellij): use built-in HttpRequests class for http requests instead of ktor

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/cloud/NxCloudApiService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/cloud/NxCloudApiService.kt
@@ -3,13 +3,12 @@ package dev.nx.console.cloud
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
+import com.intellij.util.io.HttpRequests
 import dev.nx.console.models.AITaskFixUserAction
 import dev.nx.console.nxls.NxlsService
-import io.ktor.client.*
-import io.ktor.client.engine.okhttp.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
+import java.net.HttpURLConnection
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -25,7 +24,6 @@ class NxCloudApiService(private val project: Project) {
     }
 
     private val logger = thisLogger()
-    private val httpClient = HttpClient(OkHttp)
     private val json = Json {
         ignoreUnknownKeys = true
         isLenient = true
@@ -37,45 +35,69 @@ class NxCloudApiService(private val project: Project) {
         val actionOrigin: String = "NX_CONSOLE_INTELLIJ"
     }
 
-    suspend fun updateSuggestedFix(aiFixId: String, action: AITaskFixUserAction): Boolean {
-        try {
-            val cloudStatus = NxlsService.getInstance(project).cloudStatus()
-            val nxCloudUrl = cloudStatus?.nxCloudUrl ?: DEFAULT_CLOUD_URL
+    suspend fun updateSuggestedFix(aiFixId: String, action: AITaskFixUserAction): Boolean =
+        withContext(Dispatchers.IO) {
+            try {
+                val cloudStatus = NxlsService.getInstance(project).cloudStatus()
+                val nxCloudUrl = cloudStatus?.nxCloudUrl ?: DEFAULT_CLOUD_URL
 
-            if (cloudStatus?.isConnected != true) {
-                logger.warn("Nx Cloud is not connected. Status: $cloudStatus")
-                return false
-            }
-
-            val authHeaders = NxlsService.getInstance(project).cloudAuthHeaders()
-            if (authHeaders == null) {
-                logger.warn("Failed to get Nx Cloud auth headers")
-                return false
-            }
-
-            val response =
-                httpClient.post("$nxCloudUrl/nx-cloud/update-suggested-fix") {
-                    contentType(ContentType.Application.Json)
-                    authHeaders.nxCloudId?.let { header("Nx-Cloud-Id", it) }
-                    authHeaders.nxCloudPersonalAccessToken?.let {
-                        header("Nx-Cloud-Personal-Access-Token", it)
-                    }
-                    authHeaders.authorization?.let { header("Authorization", it) }
-                    setBody(json.encodeToString(UpdateSuggestedFixRequest(aiFixId, action)))
-                    logger.info(
-                        "suggested fix stringified ${json.encodeToString(UpdateSuggestedFixRequest(aiFixId, action))}"
-                    )
+                if (cloudStatus?.isConnected != true) {
+                    logger.warn("Nx Cloud is not connected. Status: $cloudStatus")
+                    return@withContext false
                 }
 
-            if (response.status.value == 401) {
-                logger.error("Authentication failed (401). Please check your Nx Cloud credentials.")
-                logger.error("Response body: ${response.bodyAsText()}")
-            }
+                val authHeaders = NxlsService.getInstance(project).cloudAuthHeaders()
+                if (authHeaders == null) {
+                    logger.warn("Failed to get Nx Cloud auth headers")
+                    return@withContext false
+                }
 
-            return response.status.isSuccess()
-        } catch (e: Exception) {
-            logger.error("Failed to update suggested fix", e)
-            return false
+                val requestBody = json.encodeToString(UpdateSuggestedFixRequest(aiFixId, action))
+                logger.info("suggested fix stringified $requestBody")
+
+                val response =
+                    HttpRequests.post(
+                            "$nxCloudUrl/nx-cloud/update-suggested-fix",
+                            "application/json"
+                        )
+                        .tuner { connection ->
+                            authHeaders.nxCloudId?.let {
+                                connection.setRequestProperty("Nx-Cloud-Id", it)
+                            }
+                            authHeaders.nxCloudPersonalAccessToken?.let {
+                                connection.setRequestProperty("Nx-Cloud-Personal-Access-Token", it)
+                            }
+                            authHeaders.authorization?.let {
+                                connection.setRequestProperty("Authorization", it)
+                            }
+                        }
+                        .connect { request ->
+                            request.write(requestBody)
+
+                            val httpConnection = request.connection as HttpURLConnection
+                            val statusCode = httpConnection.responseCode
+
+                            if (statusCode == 401) {
+                                val errorResponse =
+                                    try {
+                                        httpConnection.errorStream?.bufferedReader()?.readText()
+                                            ?: ""
+                                    } catch (e: Exception) {
+                                        "Unable to read error response"
+                                    }
+                                logger.error(
+                                    "Authentication failed (401). Please check your Nx Cloud credentials."
+                                )
+                                logger.error("Response body: $errorResponse")
+                            }
+
+                            statusCode in 200..299
+                        }
+
+                return@withContext response
+            } catch (e: Exception) {
+                logger.error("Failed to update suggested fix", e)
+                return@withContext false
+            }
         }
-    }
 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryService.kt
@@ -4,8 +4,6 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import dev.nx.console.utils.isDevelopmentInstance
-import io.ktor.client.*
-import io.ktor.client.engine.okhttp.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -27,7 +25,7 @@ class TelemetryService(private val cs: CoroutineScope) {
         if (isDevelopmentInstance) {
             LoggerTelemetryService()
         } else {
-            MeasurementProtocolService(HttpClient(OkHttp))
+            MeasurementProtocolService()
         }
 
     fun featureUsed(feature: TelemetryEvent, data: Map<String, Any>? = null) {


### PR DESCRIPTION
By not using `ktor` (which is also used by lsp4j) we avoid all kinds of weird classloader issues that sometimes crop up (see https://github.com/nrwl/nx-console/issues/2588)

Our usage of http requests is very basic anyways so no need to use smth non-standard