### PR TITLE
feat(nx-mcp): add streamable http as a transport option & restructure args slightly

### DIFF
--- a/apps/nx-mcp/jest.config.ts
+++ b/apps/nx-mcp/jest.config.ts
@@ -1,0 +1,12 @@
+/* eslint-disable */
+export default {
+  displayName: 'nx-mcp',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/apps/nx-mcp',
+  passWithNoTests: true,
+};

--- a/apps/nx-mcp/package.json
+++ b/apps/nx-mcp/package.json
@@ -86,6 +86,12 @@
         "dependsOn": [
           "build"
         ]
+      },
+      "serve": {
+        "command": "npx @modelcontextprotocol/inspector@latest node dist/apps/nx-mcp/main.js",
+        "dependsOn": [
+          "build"
+        ]
       }
     }
   }

--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -96,13 +96,13 @@ async function main() {
           undefined,
           telemetryLogger,
         );
-
         const connection = { transport, server: connectionServer };
         connections.add(connection);
 
         // Clean up on connection close
         res.on('close', () => {
           connections.delete(connection);
+          connectionServer.getMcpServer().close();
           console.log('Streamable HTTP connection closed');
         });
 

--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -1,5 +1,6 @@
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   NxMcpServerWrapper,
   NxWorkspaceInfoProvider,
@@ -13,68 +14,15 @@ import {
   NxConsoleTelemetryLogger,
 } from '@nx-console/shared-telemetry';
 import { randomUUID } from 'crypto';
-import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import express from 'express';
 import { isNxCloudUsed } from '@nx-console/shared-nx-cloud';
 import { checkIsNxWorkspace } from '@nx-console/shared-npm';
 import { resolve } from 'path';
-
-interface ArgvType {
-  workspacePath?: string;
-  sse: boolean;
-  port?: number;
-  disableTelemetry: boolean;
-  keepAliveInterval: number;
-  _: (string | number)[];
-  $0: string;
-  [x: string]: unknown;
-}
+import { createYargsConfig, ArgvType } from './yargs-config';
 
 async function main() {
-  const argv = yargs(hideBin(process.argv))
-    .command('$0 [workspacePath]', 'Start the nx-mcp server', (yargs) => {
-      yargs.positional('workspacePath', {
-        describe: 'Path to the Nx workspace root',
-        type: 'string',
-      });
-    })
-    .option('workspacePath', {
-      alias: 'w',
-      describe: 'Path to the Nx workspace root',
-      type: 'string',
-    })
-    .option('sse', {
-      describe: 'Configure the server to use SSE (Server-Sent Events)',
-      type: 'boolean',
-      default: false,
-    })
-    .option('port', {
-      alias: 'p',
-      describe: 'Port to use for the SSE server (default: 9921)',
-      type: 'number',
-    })
-    .option('disableTelemetry', {
-      describe: 'Disable sending of telemetry data',
-      type: 'boolean',
-      default: false,
-    })
-    .option('keepAliveInterval', {
-      describe:
-        'Interval in milliseconds to send SSE keep-alive messages (default: 30000, 0 to disable)',
-      type: 'number',
-      default: 30000,
-    })
-    .check((argv) => {
-      if (argv.port !== undefined && !argv.sse) {
-        throw new Error(
-          'The --port option can only be used when --sse is enabled',
-        );
-      }
-      return true;
-    })
-    .help()
-    .parseSync() as ArgvType;
+  const argv = createYargsConfig(hideBin(process.argv)).parseSync() as ArgvType;
 
   const providedPath: string = resolve(
     argv.workspacePath || (argv._[0] as string) || process.cwd(),
@@ -122,51 +70,94 @@ async function main() {
     telemetryLogger,
   );
 
-  if (argv.sse) {
+  if (argv.transport === 'sse' || argv.transport === 'http') {
     const port = argv.port ?? 9921;
-
     const app = express();
-    let transport: SSEServerTransport;
-    app.get('/sse', async (req, res) => {
-      console.log('Configuring SSE transport');
-      transport = new SSEServerTransport('/messages', res);
-      await server.getMcpServer().connect(transport);
 
-      // Set up keep-alive interval if enabled
-      if (argv.keepAliveInterval > 0) {
-        const keepAliveInterval = setInterval(() => {
-          // Check if the connection is still open using the socket's writable state
-          if (!res.writableEnded && !res.writableFinished) {
-            res.write(':beat\n\n');
-          } else {
-            clearInterval(keepAliveInterval);
-            console.log('SSE connection closed, clearing keep-alive interval');
-          }
-        }, argv.keepAliveInterval);
+    if (argv.transport === 'http') {
+      // Streamable HTTP mode
+      const connections = new Set<{
+        transport: StreamableHTTPServerTransport;
+        server: NxMcpServerWrapper;
+      }>();
 
-        // Clean up interval if the client disconnects
-        req.on('close', () => {
-          clearInterval(keepAliveInterval);
-          console.log('SSE connection closed by client');
+      app.use(express.json());
+
+      // Streamable HTTP endpoint
+      app.all('/mcp', async (req, res) => {
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
         });
-      }
-    });
 
-    app.post('/messages', async (req, res) => {
-      if (!transport) {
-        console.log('No transport found.');
-        res.status(400).send('No transport found');
-        return;
-      }
-      await transport.handlePostMessage(req, res);
-    });
+        // Create a new server instance for this connection
+        const connectionServer = await NxMcpServerWrapper.create(
+          nxWorkspacePath,
+          nxWorkspaceInfoProvider,
+          undefined,
+          telemetryLogger,
+        );
+
+        const connection = { transport, server: connectionServer };
+        connections.add(connection);
+
+        // Clean up on connection close
+        res.on('close', () => {
+          connections.delete(connection);
+          console.log('Streamable HTTP connection closed');
+        });
+
+        await connectionServer.getMcpServer().connect(transport);
+        await transport.handleRequest(req, res, req.body);
+      });
+
+      console.log(`Nx MCP server (Streamable HTTP) listening on port ${port}`);
+    } else {
+      // SSE mode
+      let transport: SSEServerTransport;
+      app.get('/sse', async (req, res) => {
+        console.log('Configuring SSE transport');
+        transport = new SSEServerTransport('/messages', res);
+        await server.getMcpServer().connect(transport);
+
+        // Set up keep-alive interval if enabled
+        if (argv.keepAliveInterval > 0) {
+          const keepAliveInterval = setInterval(() => {
+            // Check if the connection is still open using the socket's writable state
+            if (!res.writableEnded && !res.writableFinished) {
+              res.write(':beat\n\n');
+            } else {
+              clearInterval(keepAliveInterval);
+              console.log(
+                'SSE connection closed, clearing keep-alive interval',
+              );
+            }
+          }, argv.keepAliveInterval);
+
+          // Clean up interval if the client disconnects
+          req.on('close', () => {
+            clearInterval(keepAliveInterval);
+            console.log('SSE connection closed by client');
+          });
+        }
+      });
+
+      app.post('/messages', async (req, res) => {
+        if (!transport) {
+          console.log('No transport found.');
+          res.status(400).send('No transport found');
+          return;
+        }
+        await transport.handlePostMessage(req, res);
+      });
+
+      console.log(`Nx MCP server (SSE) listening on port ${port}`);
+    }
 
     const server_instance = app.listen(port);
 
     process.on('exit', () => {
       server_instance.close();
     });
-    console.log(`Nx MCP server listening on port ${port}`);
   } else {
     const transport = new StdioServerTransport();
     server.getMcpServer().connect(transport);

--- a/apps/nx-mcp/src/yargs-config.spec.ts
+++ b/apps/nx-mcp/src/yargs-config.spec.ts
@@ -1,0 +1,160 @@
+import { createYargsConfig } from './yargs-config';
+
+describe('createYargsConfig', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+  let processExitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    processExitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
+
+  describe('deprecated --sse option', () => {
+    it('should warn when using deprecated --sse flag', () => {
+      const argv = createYargsConfig(['--sse']).parseSync();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Warning: --sse option is deprecated. Please use --transport sse instead.',
+      );
+    });
+
+    it('should set transport to sse when using deprecated --sse flag', () => {
+      const argv = createYargsConfig(['--sse']).parseSync();
+
+      expect(argv.transport).toBe('sse');
+      expect(argv.sse).toBe(true);
+    });
+
+    it('should throw error when using --sse with --transport http', () => {
+      expect(() => {
+        createYargsConfig(['--sse', '--transport', 'http']).parseSync();
+      }).toThrow('process.exit called');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should allow --sse with --transport sse', () => {
+      const argv = createYargsConfig([
+        '--sse',
+        '--transport',
+        'sse',
+      ]).parseSync();
+
+      expect(argv.transport).toBe('sse');
+      expect(argv.sse).toBe(true);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Warning: --sse option is deprecated. Please use --transport sse instead.',
+      );
+    });
+  });
+
+  describe('conflicting options', () => {
+    it('should throw error when using both --sse and --http', () => {
+      expect(() => {
+        createYargsConfig(['--sse', '--transport', 'http']).parseSync();
+      }).toThrow('process.exit called');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should not throw error when using only --transport', () => {
+      expect(() => {
+        createYargsConfig(['--transport', 'http']).parseSync();
+      }).not.toThrow();
+    });
+  });
+
+  describe('port validation', () => {
+    it('should throw error when using --port with stdio transport', () => {
+      expect(() => {
+        createYargsConfig(['--port', '9922']).parseSync();
+      }).toThrow('process.exit called');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should throw error when using --port with explicit stdio transport', () => {
+      expect(() => {
+        createYargsConfig([
+          '--transport',
+          'stdio',
+          '--port',
+          '9922',
+        ]).parseSync();
+      }).toThrow('process.exit called');
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should allow --port with sse transport', () => {
+      expect(() => {
+        createYargsConfig(['--transport', 'sse', '--port', '9922']).parseSync();
+      }).not.toThrow();
+    });
+
+    it('should allow --port with http transport', () => {
+      expect(() => {
+        createYargsConfig([
+          '--transport',
+          'http',
+          '--port',
+          '9922',
+        ]).parseSync();
+      }).not.toThrow();
+    });
+
+    it('should allow --port with deprecated --sse flag', () => {
+      expect(() => {
+        createYargsConfig(['--sse', '--port', '9922']).parseSync();
+      }).not.toThrow();
+    });
+  });
+
+  describe('default values', () => {
+    it('should default to stdio transport', () => {
+      const argv = createYargsConfig([]).parseSync();
+
+      expect(argv.transport).toBe('stdio');
+    });
+
+    it('should have default values for all options', () => {
+      const argv = createYargsConfig([]).parseSync();
+
+      expect(argv.transport).toBe('stdio');
+      expect(argv.sse).toBe(false);
+      expect(argv.disableTelemetry).toBe(false);
+      expect(argv.keepAliveInterval).toBe(30000);
+      expect(argv.port).toBeUndefined();
+    });
+  });
+
+  describe('transport option', () => {
+    it('should accept stdio transport', () => {
+      const argv = createYargsConfig(['--transport', 'stdio']).parseSync();
+      expect(argv.transport).toBe('stdio');
+    });
+
+    it('should accept sse transport', () => {
+      const argv = createYargsConfig(['--transport', 'sse']).parseSync();
+      expect(argv.transport).toBe('sse');
+    });
+
+    it('should accept http transport', () => {
+      const argv = createYargsConfig(['--transport', 'http']).parseSync();
+      expect(argv.transport).toBe('http');
+    });
+
+    it('should reject invalid transport values', () => {
+      expect(() => {
+        createYargsConfig(['--transport', 'invalid']).parseSync();
+      }).toThrow();
+    });
+  });
+});

--- a/apps/nx-mcp/src/yargs-config.ts
+++ b/apps/nx-mcp/src/yargs-config.ts
@@ -54,6 +54,8 @@ export function createYargsConfig(args: string[]): Argv<any> {
       describe:
         'Interval in milliseconds to send SSE keep-alive messages (default: 30000, 0 to disable)',
       type: 'number',
+      deprecated: true,
+      hidden: true,
       default: 30000,
     })
     .check((argv) => {

--- a/apps/nx-mcp/src/yargs-config.ts
+++ b/apps/nx-mcp/src/yargs-config.ts
@@ -1,0 +1,84 @@
+import yargs, { Argv } from 'yargs';
+
+export interface ArgvType {
+  workspacePath?: string;
+  transport?: 'stdio' | 'sse' | 'http';
+  sse: boolean;
+  http: boolean;
+  port?: number;
+  disableTelemetry: boolean;
+  keepAliveInterval: number;
+  _: (string | number)[];
+  $0: string;
+  [x: string]: unknown;
+}
+
+export function createYargsConfig(args: string[]): Argv<any> {
+  return yargs(args)
+    .command('$0 [workspacePath]', 'Start the nx-mcp server', (yargs) => {
+      yargs.positional('workspacePath', {
+        describe: 'Path to the Nx workspace root',
+        type: 'string',
+      });
+    })
+    .option('workspacePath', {
+      alias: 'w',
+      describe: 'Path to the Nx workspace root',
+      type: 'string',
+    })
+    .option('transport', {
+      describe: 'Transport protocol to use',
+      choices: ['stdio', 'sse', 'http'] as const,
+      default: 'stdio',
+      type: 'string',
+    })
+    .option('sse', {
+      describe:
+        'Configure the server to use SSE (Server-Sent Events) [DEPRECATED: Use --transport sse instead]',
+      type: 'boolean',
+      default: false,
+      deprecated: true,
+      hidden: true,
+    })
+    .option('port', {
+      alias: 'p',
+      describe: 'Port to use for the HTTP/SSE server (default: 9921)',
+      type: 'number',
+    })
+    .option('disableTelemetry', {
+      describe: 'Disable sending of telemetry data',
+      type: 'boolean',
+      default: false,
+    })
+    .option('keepAliveInterval', {
+      describe:
+        'Interval in milliseconds to send SSE keep-alive messages (default: 30000, 0 to disable)',
+      type: 'number',
+      default: 30000,
+    })
+    .check((argv) => {
+      // Check for conflicting options
+      if (argv.sse && argv.transport === 'http') {
+        throw new Error('Cannot use both sse and http transport together');
+      }
+      // Handle backward compatibility
+      if (argv.sse) {
+        console.warn(
+          'Warning: --sse option is deprecated. Please use --transport sse instead.',
+        );
+        if (!argv.transport || argv.transport === 'stdio') {
+          argv.transport = 'sse';
+        }
+      }
+
+      // Validate port usage
+      if (argv.port !== undefined && argv.transport === 'stdio') {
+        throw new Error(
+          'The --port option can only be used when transport is set to sse or http',
+        );
+      }
+
+      return true;
+    })
+    .help();
+}

--- a/apps/nx-mcp/tsconfig.app.json
+++ b/apps/nx-mcp/tsconfig.app.json
@@ -5,7 +5,13 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["eslint.config.js", "eslint.config.cjs", "eslint.config.mjs"],
+  "exclude": [
+    "eslint.config.js",
+    "eslint.config.cjs",
+    "eslint.config.mjs",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ],
   "references": [
     {
       "path": "../../libs/shared/npm/tsconfig.lib.json"

--- a/apps/nx-mcp/tsconfig.json
+++ b/apps/nx-mcp/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/apps/nx-mcp/tsconfig.spec.json
+++ b/apps/nx-mcp/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "out-tsc/jest",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}


### PR DESCRIPTION
SSE is deprecated so while we still support it, we also have to support the new streamable http transport properly.
Now you can control the transport with a `--transport` param, but the `--sse` param still works for backward compat.
Also added some tests around yargs parsing.