### PR TITLE
fix(vscode): restart nxls whenever the branch changes

### DIFF
--- a/libs/vscode/lsp-client/tsconfig.json
+++ b/libs/vscode/lsp-client/tsconfig.json
@@ -4,6 +4,9 @@
   "include": [],
   "references": [
     {
+      "path": "../utils"
+    },
+    {
       "path": "../output-channels"
     },
     {

--- a/libs/vscode/lsp-client/tsconfig.lib.json
+++ b/libs/vscode/lsp-client/tsconfig.lib.json
@@ -11,6 +11,9 @@
   "include": ["**/*.ts"],
   "references": [
     {
+      "path": "../utils/tsconfig.lib.json"
+    },
+    {
       "path": "../output-channels/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
sometimes things get into weird states if there are branch changes with massive amounts of files being changed or wildly different versions of things. Resetting the nxls seems like a good call in these situations and doesn't hurt.