### PR TITLE
Investigate and fix null to object error

### DIFF
--- a/libs/shared/nx-cloud/jest.config.ts
+++ b/libs/shared/nx-cloud/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+  displayName: 'shared-nx-cloud',
+  preset: '../../../jest.preset.js',
+  globals: {},
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: 'test-output/jest/coverage',
+};

--- a/libs/shared/nx-cloud/project.json
+++ b/libs/shared/nx-cloud/project.json
@@ -1,0 +1,26 @@
+{
+  "name": "shared-nx-cloud",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared/nx-cloud/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/shared/nx-cloud",
+        "main": "libs/shared/nx-cloud/src/index.ts",
+        "tsConfig": "libs/shared/nx-cloud/tsconfig.lib.json",
+        "assets": ["libs/shared/nx-cloud/*.md"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/shared/nx-cloud/jest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/shared/nx-cloud/src/lib/is-nx-cloud-used.spec.ts
+++ b/libs/shared/nx-cloud/src/lib/is-nx-cloud-used.spec.ts
@@ -1,0 +1,181 @@
+import { isNxCloudUsed } from './is-nx-cloud-used';
+import * as npmModule from '@nx-console/shared-npm';
+
+jest.mock('@nx-console/shared-npm');
+
+describe('isNxCloudUsed', () => {
+  const mockReadNxJson = npmModule.readNxJson as jest.MockedFunction<
+    typeof npmModule.readNxJson
+  >;
+  const mockImportNxPackagePath = npmModule.importNxPackagePath as jest.MockedFunction<
+    typeof npmModule.importNxPackagePath
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.NX_NO_CLOUD;
+    delete process.env.NX_CLOUD_ACCESS_TOKEN;
+  });
+
+  it('should return false when readNxJson throws', async () => {
+    mockReadNxJson.mockRejectedValueOnce(new Error('File not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when NX_NO_CLOUD is true', async () => {
+    process.env.NX_NO_CLOUD = 'true';
+    mockReadNxJson.mockResolvedValueOnce({});
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false when neverConnectToCloud is true', async () => {
+    mockReadNxJson.mockResolvedValueOnce({ neverConnectToCloud: true });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true when NX_CLOUD_ACCESS_TOKEN is set', async () => {
+    process.env.NX_CLOUD_ACCESS_TOKEN = 'token123';
+    mockReadNxJson.mockResolvedValueOnce({});
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when nxCloudAccessToken is set', async () => {
+    mockReadNxJson.mockResolvedValueOnce({ nxCloudAccessToken: 'token123' });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when nxCloudId is set', async () => {
+    mockReadNxJson.mockResolvedValueOnce({ nxCloudId: 'id123' });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(true);
+  });
+
+  it('should handle tasksRunnerOptions being null', async () => {
+    mockReadNxJson.mockResolvedValueOnce({ tasksRunnerOptions: null as any });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should handle tasksRunnerOptions being undefined', async () => {
+    mockReadNxJson.mockResolvedValueOnce({ tasksRunnerOptions: undefined });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should handle tasksRunnerOptions being a non-object value', async () => {
+    mockReadNxJson.mockResolvedValueOnce({ tasksRunnerOptions: 'invalid' as any });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should handle tasksRunnerOptions being an array', async () => {
+    mockReadNxJson.mockResolvedValueOnce({ tasksRunnerOptions: [] as any });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true when tasksRunnerOptions contains nx-cloud runner', async () => {
+    mockReadNxJson.mockResolvedValueOnce({
+      tasksRunnerOptions: {
+        default: {
+          runner: 'nx-cloud',
+        },
+      },
+    });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(true);
+  });
+
+  it('should return true when tasksRunnerOptions contains @nrwl/nx-cloud runner', async () => {
+    mockReadNxJson.mockResolvedValueOnce({
+      tasksRunnerOptions: {
+        default: {
+          runner: '@nrwl/nx-cloud',
+        },
+      },
+    });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(true);
+  });
+
+  it('should handle runner being null or undefined', async () => {
+    mockReadNxJson.mockResolvedValueOnce({
+      tasksRunnerOptions: {
+        default: {
+          runner: null,
+        },
+        other: {
+          runner: undefined,
+        },
+      },
+    });
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should handle nxJson being null (edge case)', async () => {
+    // This simulates a case where nxJson might be null
+    mockReadNxJson.mockResolvedValueOnce(null as any);
+    mockImportNxPackagePath.mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(false);
+  });
+
+  it('should use nx utils when available', async () => {
+    const mockIsNxCloudUsed = jest.fn().mockReturnValue(true);
+    mockReadNxJson.mockResolvedValueOnce({});
+    mockImportNxPackagePath.mockResolvedValueOnce({
+      isNxCloudUsed: mockIsNxCloudUsed,
+    });
+
+    const result = await isNxCloudUsed('/workspace');
+
+    expect(result).toBe(true);
+    expect(mockIsNxCloudUsed).toHaveBeenCalledWith({});
+  });
+});

--- a/libs/shared/nx-cloud/src/lib/is-nx-cloud-used.ts
+++ b/libs/shared/nx-cloud/src/lib/is-nx-cloud-used.ts
@@ -23,17 +23,23 @@ export async function isNxCloudUsed(
   } catch (e) {
     // fallback implementation, copied from nx
     getIsNxCloudUsed = (nxJson: NxJsonConfiguration) => {
-      if (process.env.NX_NO_CLOUD === 'true' || nxJson.neverConnectToCloud) {
+      if (process.env.NX_NO_CLOUD === 'true' || nxJson?.neverConnectToCloud) {
         return false;
       }
 
+      // Ensure nxJson exists and tasksRunnerOptions is a valid object
+      const tasksRunnerOptions = nxJson?.tasksRunnerOptions;
+      const hasCloudRunner = tasksRunnerOptions && typeof tasksRunnerOptions === 'object' && !Array.isArray(tasksRunnerOptions)
+        ? !!Object.values(tasksRunnerOptions).find(
+            (r) => r?.runner === '@nrwl/nx-cloud' || r?.runner === 'nx-cloud',
+          )
+        : false;
+
       return (
         !!process.env.NX_CLOUD_ACCESS_TOKEN ||
-        !!nxJson.nxCloudAccessToken ||
-        !!nxJson.nxCloudId ||
-        !!Object.values(nxJson.tasksRunnerOptions ?? {}).find(
-          (r) => r.runner == '@nrwl/nx-cloud' || r.runner == 'nx-cloud',
-        )
+        !!nxJson?.nxCloudAccessToken ||
+        !!nxJson?.nxCloudId ||
+        hasCloudRunner
       );
     };
   }

--- a/libs/shared/nx-cloud/tsconfig.json
+++ b/libs/shared/nx-cloud/tsconfig.json
@@ -14,6 +14,9 @@
     },
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/libs/shared/nx-cloud/tsconfig.spec.json
+++ b/libs/shared/nx-cloud/tsconfig.spec.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "out-tsc/jest",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes `TypeError` in `isNxCloudUsed` by adding robust null/undefined and type checking for `nx.json` properties.

The `TypeError: Cannot convert undefined or null to object` occurred when `nxJson.tasksRunnerOptions` was explicitly `null` or a non-object value, leading `Object.values()` to throw an error. This PR adds defensive checks to gracefully handle malformed `nx.json` configurations.

---

[Open in Web](https://cursor.com/agents?id=bc-2efb7a38-4ba8-433d-ac7e-6a05fbb28766) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2efb7a38-4ba8-433d-ac7e-6a05fbb28766) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)