### PR TITLE
fix: make sure run-task callback from new graph still works

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowserBase.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowserBase.kt
@@ -279,9 +279,8 @@ abstract class NxGraphBrowserBase(protected val project: Project) : Disposable {
                 return true
             }
             "run-task" -> {
-                event.payload?.taskId?.also {
-                    NxTaskExecutionManager.getInstance(project).execute(it)
-                }
+                val task = event.payload?.taskName ?: event.payload?.taskId
+                task?.also { NxTaskExecutionManager.getInstance(project).execute(it) }
                 return true
             }
             "run-help" -> {
@@ -475,6 +474,7 @@ data class NxGraphInteractionPayload(
     val targetName: String? = null,
     val url: String? = null,
     val taskId: String? = null,
+    val taskName: String? = null,
     val targetConfigString: String? = null,
     val helpCommand: String? = null,
     val helpCwd: String? = null,

--- a/libs/vscode/graph-base/src/handle-graph-interaction-event.ts
+++ b/libs/vscode/graph-base/src/handle-graph-interaction-event.ts
@@ -17,7 +17,7 @@ export async function handleGraphInteractionEventBase(event: {
 
     commands.executeCommand(
       'vscode.open',
-      Uri.file(join(workspacePath, event.payload.url))
+      Uri.file(join(workspacePath, event.payload.url)),
     );
     return true;
   }
@@ -39,7 +39,7 @@ export async function handleGraphInteractionEventBase(event: {
     });
     CliTaskProvider.instance.executeTask({
       command: 'run',
-      positional: event.payload.taskId,
+      positional: event.payload.taskName ?? event.payload.taskId,
       flags: [],
     });
     return true;
@@ -57,7 +57,7 @@ export async function handleGraphInteractionEventBase(event: {
       if (!project) return;
       importNxPackagePath<typeof import('nx/src/devkit-exports')>(
         workspacePath,
-        'src/devkit-exports'
+        'src/devkit-exports',
       ).then(({ detectPackageManager }) => {
         const pkgManager = detectPackageManager(workspacePath);
         tasks.executeTask(
@@ -77,8 +77,8 @@ export async function handleGraphInteractionEventBase(event: {
               env: {
                 NX_CONSOLE: 'true',
               },
-            })
-          )
+            }),
+          ),
         );
       });
     });


### PR DESCRIPTION
there was a change that required prefixing the taskId with `task-` in some cases so we use the `taskName` instead which is as it always was