### PR TITLE
fix(intellij): restructure CIPE tree with ai fixes at runGroup level

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/cloud_tree/CIPETree.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/cloud_tree/CIPETree.kt
@@ -46,10 +46,11 @@ class CIPETree(private val project: Project) : SimpleTree() {
         TelemetryService.getInstance(project)
             .featureUsed(TelemetryEvent.CLOUD_OPEN_FIX_DETAILS, mapOf("source" to "cipe_tree"))
 
-        val runGroupId = fixNode.parent.parent.runGroup.runGroup
+        val runGroupId = fixNode.getRunGroup()?.runGroup
+
         val cipeId = findAncestor<CIPESimpleNode.CIPENode>(fixNode)?.cipeInfo?.ciPipelineExecutionId
 
-        if (cipeId == null) {
+        if (cipeId == null || runGroupId == null) {
             Notifier.notifyAnything(
                 project,
                 "Couldn't find CIPE for AI fix",


### PR DESCRIPTION
fixes can now handle multiple failed tasks so having them at the task level doesn't really make sense