### PR TITLE
fix(vscode): handle no install state better for agent rules manager

### DIFF
--- a/libs/vscode/mcp/src/lib/agent-rules-manager.ts
+++ b/libs/vscode/mcp/src/lib/agent-rules-manager.ts
@@ -85,6 +85,10 @@ export class AgentRulesManager {
       return;
     }
 
+    if (this.nxVersion === undefined || this.nxVersion === '0.0.0') {
+      return; // Avoid writing rules if Nx version is not available
+    }
+
     const wrappedContent = ruleInfo.wrapContent(
       nxConsoleRules(this.packageManager, this.nxVersion, this.usingCloud),
     );
@@ -113,8 +117,8 @@ export class AgentRulesManager {
     this.context.subscriptions.push(
       onWorkspaceRefreshed(async () => {
         if (
-          (await this.checkEnvironmentChanges()) &&
-          GlobalConfigurationStore.instance.get(GENERATE_RULES_KEY, false)
+          GlobalConfigurationStore.instance.get(GENERATE_RULES_KEY, false) &&
+          (await this.checkEnvironmentChanges())
         ) {
           await this.writeAgentRules();
         }
@@ -123,10 +127,6 @@ export class AgentRulesManager {
   }
 
   public async checkEnvironmentChanges(): Promise<boolean> {
-    if (!GlobalConfigurationStore.instance.get(GENERATE_RULES_KEY, false)) {
-      return false;
-    }
-
     const workspacePath = getNxWorkspacePath();
     const newUsingCloud = await isNxCloudUsed(workspacePath, vscodeLogger);
     const newPackageManager = await detectPackageManager(


### PR DESCRIPTION
We write dynamic workspace info into the agent rules file, like the version & package manager. If these aren't available right now (because the nxls isn't started because of no node_modules, for example), we shouldn't write default values in there.