### PR TITLE
fix(nxls): remove faulty secondary entry point filtering logic

### DIFF
--- a/apps/nxls-e2e/src/generators/generator-local-plugin.test.ts
+++ b/apps/nxls-e2e/src/generators/generator-local-plugin.test.ts
@@ -35,8 +35,10 @@ describe('generator local plugin', () => {
 
     const workspacePath = join(e2eCwd, workspaceName);
 
+    console.log('creating local plugin');
+
     // Install @nx/plugin and create a local plugin using nx generators
-    execSync('npm install -D @nx/plugin --legacy-peer-deps', {
+    execSync('npm install -D @nx/plugin --force', {
       cwd: workspacePath,
       stdio: 'pipe',
     });

--- a/libs/shared/nx-workspace-info/src/lib/read-collections.ts
+++ b/libs/shared/nx-workspace-info/src/lib/read-collections.ts
@@ -48,13 +48,8 @@ export async function readCollections(
         packageName: string;
         packageJson: any;
       }[] = [];
-      try {
-        secondaryEntryPoints = await getExportBasedSecondaryEntryPoints(c);
-      } catch (error) {
-        logger?.log(
-          `Failed to get secondary entry points for ${c.packageName}: ${error}`,
-        );
-      }
+      secondaryEntryPoints = await getExportBasedSecondaryEntryPoints(c);
+
       return [c, ...secondaryEntryPoints];
     }),
   );


### PR DESCRIPTION
When implementing the secondary entry point detection, we also implemented a filter to avoid duplicate entries. 
This was too aggressive since it made a wrong assumption about the structure of these secondary entry points. 

With this fix, everything in the new secondary entry point detection is purely additive so it won't interfere with any other generator detection logic. 
Also, wrapped everything in a try/catch just to be sure.

FIxes https://github.com/nrwl/nx-console/issues/2663