### PR TITLE
fix(vscode): catch errors during messaging server initialization

### DIFF
--- a/libs/vscode/messaging/src/lib/messaging-server.ts
+++ b/libs/vscode/messaging/src/lib/messaging-server.ts
@@ -119,15 +119,21 @@ export async function initMessagingServer(
   context: ExtensionContext,
   workspacePath: string,
 ) {
-  if (existingServer) {
-    existingServer.dispose();
+  try {
+    if (existingServer) {
+      existingServer.dispose();
+    }
+
+    const socketPath = getNxConsoleSocketPath(workspacePath);
+    const messagingServer = new NxMessagingServer(socketPath, context);
+    messagingServer.listen();
+
+    context.subscriptions.push(messagingServer);
+
+    existingServer = messagingServer;
+  } catch (e) {
+    vscodeLogger.log(
+      `Error initializing Nx Console JSON-RPC messaging server: ${e}`,
+    );
   }
-
-  const socketPath = getNxConsoleSocketPath(workspacePath);
-  const messagingServer = new NxMessagingServer(socketPath, context);
-  messagingServer.listen();
-
-  context.subscriptions.push(messagingServer);
-
-  existingServer = messagingServer;
 }


### PR DESCRIPTION
I'm getting some errors in rollbar that the socket is already in use - the only instance I can trace where this could happen is windows if you have multiple instances of the same workspace open. Catching the error for now since the messaging server isn't super critical. 