### PR TITLE
feat(vscode): improve migrate ui with commands for individual actions

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/telemetry/TelemetryTypes.kt
@@ -18,6 +18,10 @@ enum class TelemetryEvent(val eventName: String) {
     MISC_OPEN_PROJECT_DETAILS_CODELENS("misc.open-project-details-codelens"),
     MISC_EXCEPTION("misc.exception"),
 
+    // Migrate
+    MIGRATE_OPEN("migrate.open"),
+    MIGRATE_START("migrate.start"),
+
     // AI
     AI_ADD_MCP("ai.add-mcp"),
     AI_CHAT_MESSAGE("ai.chat-message"),

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -444,6 +444,18 @@
         {
           "command": "nx.addAgentRules",
           "when": "isNxWorkspace && hasNxMcpConfigured && !config.nxConsole.generateAiAgentRules && (isInCursor || isInVSCode)"
+        },
+        {
+          "command": "nxMigrate.viewDiff",
+          "when": "isNxWorkspace && nxMigrate.state.pendingPackageUpdates"
+        },
+        {
+          "command": "nxMigrate.open",
+          "when": "isNxWorkspace && nxMigrate.state.inProgress"
+        },
+        {
+          "command": "nxMigrate.startMigrationCustom",
+          "when": "isNxWorkspace && nxMigrate.state.notStarted"
         }
       ]
     },
@@ -981,10 +993,32 @@
         "icon": "$(wand)"
       },
       {
-        "title": "Refresh Nx Migrate View",
+        "category": "Nx Migrate",
+        "title": "Refresh View",
         "command": "nxMigrate.refresh",
         "icon": "$(refresh)",
         "when": "isNxWorkspace"
+      },
+      {
+        "category": "Nx Migrate",
+        "title": "View package.json Changes",
+        "command": "nxMigrate.viewDiff",
+        "icon": "$(diff)",
+        "when": "isNxWorkspace && nxMigrate.state.pendingPackageUpdates"
+      },
+      {
+        "category": "Nx Migrate",
+        "title": "Open Migrate UI",
+        "command": "nxMigrate.open",
+        "icon": "$(browser)",
+        "when": "isNxWorkspace && nxMigrate.state.inProgress"
+      },
+      {
+        "category": "Nx Migrate",
+        "title": "Start Migration",
+        "command": "nxMigrate.startMigrationCustom",
+        "icon": "$(play)",
+        "when": "isNxWorkspace && nxMigrate.state.notStarted"
       },
       {
         "title": "Add Nx Agent Rules",

--- a/libs/shared/telemetry/src/lib/telemetry-types.ts
+++ b/libs/shared/telemetry/src/lib/telemetry-types.ts
@@ -18,6 +18,9 @@ export type TelemetryEvents =
   | 'misc.open-pdv'
   | 'misc.open-project-details-codelens'
   | 'misc.exception'
+  // migrate
+  | 'migrate.open'
+  | 'migrate.start'
   // cloud
   | 'cloud.connect'
   | 'cloud.open-app'
@@ -28,6 +31,7 @@ export type TelemetryEvents =
   | 'cloud.view-cipe'
   | 'cloud.view-cipe-commit'
   | 'cloud.view-run'
+  | 'cloud.refresh-view'
   | 'cloud.explain-cipe-error'
   | 'cloud.fix-cipe-error'
   | 'cloud.show-ai-fix-notification'
@@ -46,7 +50,7 @@ export type TelemetryEvents =
   | 'graph.interaction-run-help'
   // tasks
   | 'tasks.run'
-  | 'tasks.init'
+  | 'task.init'
   | 'tasks.copy-to-clipboard'
   | 'tasks.run-many'
   // generate

--- a/libs/vscode/migrate/src/lib/commands/finish-migration.ts
+++ b/libs/vscode/migrate/src/lib/commands/finish-migration.ts
@@ -22,9 +22,9 @@ export async function finishMigration(squashCommits: boolean) {
         const commitMessage = squashCommits
           ? await window.showInputBox({
               prompt: 'Enter a commit message',
-              value: `chore: migrate nx to ${migrationsJsonMetadata.targetVersion}`,
+              value: `chore: migrate nx to ${migrationsJsonMetadata?.targetVersion ?? 'new version'}`,
             })
-          : `chore: migrate nx to ${migrationsJsonMetadata.targetVersion}`;
+          : `chore: migrate nx to ${migrationsJsonMetadata?.targetVersion ?? 'new version'}`;
 
         if (!commitMessage) {
           return;

--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -29,6 +29,10 @@ export function registerCommands(
     commands.registerCommand('nxMigrate.open', () => {
       migrateWebview.openMigrateUi();
     }),
+    // command to explicitly start a custom migration (shown when none is in progress)
+    commands.registerCommand('nxMigrate.startMigrationCustom', async () => {
+      await startMigration(true);
+    }),
     commands.registerCommand('nxMigrate.close', () => {
       migrateWebview.closeMigrateUi();
     }),

--- a/libs/vscode/migrate/src/lib/commands/start-migration.ts
+++ b/libs/vscode/migrate/src/lib/commands/start-migration.ts
@@ -12,8 +12,11 @@ import { major, rcompare } from 'semver';
 import { QuickPickItem, tasks, window } from 'vscode';
 import { viewPackageJsonDiff } from '../git-extension/view-diff';
 import { importMigrateUIApi } from './utils';
+import { existsSync, writeFileSync } from 'fs';
+import { getTelemetry } from '@nx-console/vscode-telemetry';
 
 export async function startMigration(custom = false) {
+  getTelemetry().logUsage('migrate.start');
   const nxVersion = await getNxVersion();
 
   let pkgInfo: PackageInformationResponse;
@@ -58,7 +61,6 @@ export async function startMigration(custom = false) {
   }
 
   const workspacePath = getNxWorkspacePath();
-  const migrationsJsonPath = join(workspacePath, 'migrations.json');
 
   const command = `nx migrate ${versionToMigrateTo}`;
 
@@ -86,6 +88,11 @@ export async function startMigration(custom = false) {
       'Migration failed, see integrated terminal for more details.',
     );
     return;
+  }
+
+  const migrationJsonPath = join(workspacePath, 'migrations.json');
+  if (!existsSync(migrationJsonPath)) {
+    writeFileSync(migrationJsonPath, '{}');
   }
 
   const migrateUiApi = await importMigrateUIApi(workspacePath);

--- a/libs/vscode/migrate/src/lib/commands/utils.ts
+++ b/libs/vscode/migrate/src/lib/commands/utils.ts
@@ -17,11 +17,19 @@ export function modifyMigrationsJsonMetadata(
   writeFileSync(migrationsJsonPath, JSON.stringify(migrationsJson, null, 2));
 }
 
-export function readMigrationsJsonMetadata(): MigrationsJsonMetadata {
-  const workspacePath = getNxWorkspacePath();
-  const migrationsJsonPath = join(workspacePath, 'migrations.json');
-  const migrationsJson = JSON.parse(readFileSync(migrationsJsonPath, 'utf-8'));
-  return migrationsJson['nx-console'];
+export function readMigrationsJsonMetadata():
+  | MigrationsJsonMetadata
+  | undefined {
+  try {
+    const workspacePath = getNxWorkspacePath();
+    const migrationsJsonPath = join(workspacePath, 'migrations.json');
+    const migrationsJson = JSON.parse(
+      readFileSync(migrationsJsonPath, 'utf-8'),
+    );
+    return migrationsJson['nx-console'];
+  } catch (e) {
+    return undefined;
+  }
 }
 
 // tries importing the migrate ui from the local nx package but falls back to the bundled one

--- a/libs/vscode/migrate/src/lib/git-extension/view-diff.ts
+++ b/libs/vscode/migrate/src/lib/git-extension/view-diff.ts
@@ -21,7 +21,7 @@ export function viewDiffForMigration(
   migration: MigrationDetailsWithId,
 ) {
   const completedMigration =
-    readMigrationsJsonMetadata().completedMigrations[migration.id];
+    readMigrationsJsonMetadata()?.completedMigrations[migration.id];
   if (completedMigration.type === 'successful') {
     const toRef = completedMigration.ref;
     const fromRef = `${toRef}^1`;
@@ -31,7 +31,7 @@ export function viewDiffForMigration(
 
 export async function viewDiff(path: string, fromRef?: string, toRef?: string) {
   if (!fromRef) {
-    fromRef = readMigrationsJsonMetadata().initialGitRef.ref;
+    fromRef = readMigrationsJsonMetadata()?.initialGitRef.ref;
   }
 
   const api = getGitApi();

--- a/libs/vscode/migrate/src/lib/migrate-webview.ts
+++ b/libs/vscode/migrate/src/lib/migrate-webview.ts
@@ -21,6 +21,7 @@ import {
   viewDocumentation,
   viewImplementation,
 } from './commands/migrate-commands';
+import { getTelemetry } from '@nx-console/vscode-telemetry';
 import { watchFile } from '@nx-console/vscode-utils';
 import { finishMigration } from './commands/finish-migration';
 import {
@@ -37,6 +38,7 @@ export class MigrateWebview {
   async openMigrateUi() {
     if (this._webviewPanel !== undefined) {
       this._webviewPanel.reveal();
+      getTelemetry().logUsage('migrate.open');
       return;
     }
     const nxInstallationLocation = await workspaceDependencyPath(
@@ -66,6 +68,8 @@ export class MigrateWebview {
     this._webviewPanel.webview.html = await this.loadMigrateHtml(
       this._webviewPanel,
     );
+
+    getTelemetry().logUsage('migrate.open');
 
     this._webviewPanel.webview.onDidReceiveMessage((message) => {
       switch (message.type) {

--- a/libs/vscode/migrate/tsconfig.json
+++ b/libs/vscode/migrate/tsconfig.json
@@ -10,13 +10,10 @@
       "path": "../../shared/types"
     },
     {
-      "path": "../../language-server/types"
-    },
-    {
       "path": "../lsp-client"
     },
     {
-      "path": "../utils"
+      "path": "../../language-server/types"
     },
     {
       "path": "../tasks"
@@ -26,6 +23,12 @@
     },
     {
       "path": "../../shared/nx-version"
+    },
+    {
+      "path": "../utils"
+    },
+    {
+      "path": "../telemetry"
     },
     {
       "path": "../../shared/npm"

--- a/libs/vscode/migrate/tsconfig.lib.json
+++ b/libs/vscode/migrate/tsconfig.lib.json
@@ -13,13 +13,10 @@
       "path": "../../shared/types/tsconfig.lib.json"
     },
     {
-      "path": "../../language-server/types/tsconfig.lib.json"
-    },
-    {
       "path": "../lsp-client/tsconfig.lib.json"
     },
     {
-      "path": "../utils/tsconfig.lib.json"
+      "path": "../../language-server/types/tsconfig.lib.json"
     },
     {
       "path": "../tasks/tsconfig.lib.json"
@@ -29,6 +26,12 @@
     },
     {
       "path": "../../shared/nx-version/tsconfig.lib.json"
+    },
+    {
+      "path": "../utils/tsconfig.lib.json"
+    },
+    {
+      "path": "../telemetry/tsconfig.lib.json"
     },
     {
       "path": "../../shared/npm/tsconfig.lib.json"


### PR DESCRIPTION
We've added commands to mirror the main actions that the migrate view sidebar provides:
- start the migration process (we default to custom migration to let user make some choices vs instantly launching into nx migrate in the command line)
- view the package.json diff
- open the migrate UI

These should each only be visible if the migration is in the correct state so we keep track of the state variables via vscode context assignments.
