### PR TITLE
Fix nx console issue 2631

### DIFF
--- a/apps/generate-ui-v2/src/form-values.service.ts
+++ b/apps/generate-ui-v2/src/form-values.service.ts
@@ -142,7 +142,7 @@ export class FormValuesService {
   }
 
   runGenerator(dryRun = false) {
-    const args = this.getSerializedFormValues();
+    const args = this.getSerializedFormValues(false); // Don't include quotes for execution
     args.push('--no-interactive');
     if (dryRun) {
       args.push('--dry-run');
@@ -164,7 +164,7 @@ export class FormValuesService {
   );
 
   copyCommandToClipboard() {
-    const args = this.getSerializedFormValues();
+    const args = this.getSerializedFormValues(true); // Include quotes for clipboard
     const positional = getGeneratorIdentifier(this.icc.generatorSchema);
     const command = `nx g ${positional} ${args.join(' ')}`;
     if (this.icc.editor === 'vscode') {
@@ -176,7 +176,7 @@ export class FormValuesService {
     }
   }
 
-  private getSerializedFormValues(): string[] {
+  private getSerializedFormValues(includeQuotesForShell = true): string[] {
     const args: string[] = [];
     const formValues = {
       ...this.formValues,
@@ -191,7 +191,10 @@ export class FormValuesService {
       if (compareWithDefaultValue(value, defaultValue)) return;
 
       const valueString = value?.toString() ?? '';
-      if (valueString.includes(' ')) {
+      
+      // When includeQuotesForShell is true (for clipboard), add quotes around values with spaces
+      // When false (for execution), don't add quotes as the value will be passed as a proper argument
+      if (includeQuotesForShell && valueString.includes(' ')) {
         if (valueString.includes('"')) {
           args.push(`--${key}='${value}'`);
         } else {


### PR DESCRIPTION
Fixes generator arguments with spaces being misinterpreted when run via MCP by adjusting quote handling.

Previously, arguments containing spaces were quoted by `form-values.service.ts` and then passed to `spawn` with `shell: true`. This caused the quotes to be treated as part of the argument value rather than shell delimiters, leading to truncated values. This change ensures quotes are only added for clipboard copy, not for execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c10e904-a78c-4b78-a41d-162fd4ff375c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c10e904-a78c-4b78-a41d-162fd4ff375c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

