### PR TITLE
feat(nx-mcp): expose recent CIPEs as MCP resources

### DIFF
--- a/apps/nx-mcp/README.md
+++ b/apps/nx-mcp/README.md
@@ -63,7 +63,7 @@ More info:
 
 ## Available Tools
 
-Currently, the Nx MCP server provides a set of tools. Resources, Roots and Prompts aren't supported yet.
+The Nx MCP server provides a comprehensive set of tools for interacting with your Nx workspace.
 
 - **nx_docs**: Returns documentation sections relevant to user queries about Nx
 - **nx_available_plugins**: Lists available Nx plugins from the core team and local workspace plugins
@@ -89,6 +89,11 @@ Currently, the Nx MCP server provides a set of tools. Resources, Roots and Promp
 - **nx_cloud_tasks_details**: Returns detailed task execution information
 
 When no workspace path is specified, only the `nx_docs` and `nx_available_plugins` tools will be available.
+
+## Available Resources
+
+When connected to an Nx Cloud-enabled workspace, the Nx MCP server automatically exposes recent CI Pipeline Executions (CIPEs) as MCP resources.
+Resources appear in your AI tool's resource picker, allowing the LLM to access detailed information about CI runs including failed tasks, terminal output, and affected files.
 
 ## Contributing & Development
 

--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -8,7 +8,7 @@ import {
   NxWorkspaceInfoProvider,
 } from '@nx-console/nx-mcp-server';
 import { checkIsNxWorkspace } from '@nx-console/shared-npm';
-import { isNxCloudUsed } from '@nx-console/shared-nx-cloud';
+import { isNxCloudUsed, getRecentCIPEData } from '@nx-console/shared-nx-cloud';
 import {
   getGenerators,
   getNxVersion,
@@ -115,6 +115,8 @@ async function main() {
     },
     isNxCloudEnabled: async () =>
       nxWorkspacePath ? await isNxCloudUsed(nxWorkspacePath) : false,
+    getRecentCIPEData: async (workspacePath, logger) =>
+      await getRecentCIPEData(workspacePath, logger),
   };
 
   // Detect if IDE is running and create IDE client if available

--- a/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server.ts
@@ -9,9 +9,13 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { NxGeneratorsRequestOptions } from '@nx-console/language-server-types';
 import { GeneratorCollectionInfo } from '@nx-console/shared-schema';
-import { NxWorkspace } from '@nx-console/shared-types';
+import { NxWorkspace, CIPEInfo, CIPEInfoError } from '@nx-console/shared-types';
 import { IdeProvider } from './ide-provider';
 import { registerNxCloudTools } from './tools/nx-cloud';
+import {
+  registerNxCloudCipeResources,
+  clearRegisteredCipeResources,
+} from './resources/nx-cloud-cipe-resources';
 import {
   registerNxCoreTools,
   setNxWorkspacePath as setNxWorkspacePathForCoreTools,
@@ -40,6 +44,14 @@ export interface NxWorkspaceInfoProvider {
     headSha?: string,
   ) => Promise<{ path: string; diffContent: string }[] | null>;
   isNxCloudEnabled: () => Promise<boolean>;
+  getRecentCIPEData?: (
+    workspacePath: string,
+    logger: Logger,
+  ) => Promise<{
+    info?: CIPEInfo[];
+    error?: CIPEInfoError;
+    workspaceUrl?: string;
+  }>;
 }
 
 export class NxMcpServerWrapper {
@@ -51,6 +63,8 @@ export class NxMcpServerWrapper {
   private readonly PERIODIC_MONITORING_INTERVAL = 10000; // 10 seconds
   private readonly PERIODIC_MONITORING_MAX_COUNT = 5;
   private ideConnectionCleanup?: () => void;
+  private cipeRefreshInterval?: NodeJS.Timeout;
+  private readonly CIPE_REFRESH_INTERVAL = 30000; // 30 seconds
   private toolRegistrationState = {
     nxWorkspace: false,
     nxCore: false,
@@ -74,6 +88,10 @@ export class NxMcpServerWrapper {
       logging: {},
       tools: {
         listChanged: true,
+      },
+      resources: {
+        list: true,
+        subscribe: false,
       },
     });
 
@@ -170,6 +188,9 @@ export class NxMcpServerWrapper {
     // Stop periodic monitoring
     this.stopPeriodicMonitoring();
 
+    // Stop CIPE refresh interval
+    this.stopCipeRefreshInterval();
+
     // Clean up IDE connection listener
     if (this.ideConnectionCleanup) {
       this.ideConnectionCleanup();
@@ -177,6 +198,9 @@ export class NxMcpServerWrapper {
 
     // Dispose IDE provider if it exists
     this.ideProvider?.dispose();
+
+    // Clear all registered CIPE resources
+    clearRegisteredCipeResources();
   }
 
   /**
@@ -238,6 +262,19 @@ export class NxMcpServerWrapper {
           this.telemetry,
           this.nxWorkspaceInfoProvider.getGitDiffs,
         );
+
+        // Register CIPE resources
+        await registerNxCloudCipeResources(
+          this._nxWorkspacePath,
+          this.server,
+          this.logger,
+          this.telemetry,
+          this.nxWorkspaceInfoProvider,
+        );
+
+        // Start refresh interval for CIPE resources
+        this.startCipeRefreshInterval();
+
         this.toolRegistrationState.nxCloud = true;
       }
 
@@ -334,11 +371,61 @@ export class NxMcpServerWrapper {
       this.logger.log('Stopped periodic tool condition monitoring');
     }
   }
+
+  /**
+   * Start CIPE refresh interval
+   * Refreshes available CIPE resources every 30 seconds
+   */
+  private startCipeRefreshInterval(): void {
+    // Don't start if already running
+    if (this.cipeRefreshInterval) {
+      return;
+    }
+
+    // Don't start if workspace path or provider is not available
+    if (
+      !this._nxWorkspacePath ||
+      !this.nxWorkspaceInfoProvider.getRecentCIPEData
+    ) {
+      return;
+    }
+
+    this.logger.log('Starting CIPE refresh interval (every 30 seconds)');
+
+    this.cipeRefreshInterval = setInterval(async () => {
+      try {
+        await registerNxCloudCipeResources(
+          this._nxWorkspacePath!,
+          this.server,
+          this.logger,
+          this.telemetry,
+          this.nxWorkspaceInfoProvider,
+        );
+      } catch (error) {
+        this.logger.log('Error refreshing CIPE resources:', error);
+      }
+    }, this.CIPE_REFRESH_INTERVAL);
+  }
+
+  /**
+   * Stop CIPE refresh interval
+   */
+  private stopCipeRefreshInterval(): void {
+    if (this.cipeRefreshInterval) {
+      clearInterval(this.cipeRefreshInterval);
+      this.cipeRefreshInterval = undefined;
+      this.logger.log('Stopped CIPE refresh interval');
+    }
+  }
 }
 
 export const nxMcpServerCapabilities: ServerCapabilities = {
   tools: {
     listChanged: true,
+  },
+  resources: {
+    list: true,
+    subscribe: false,
   },
   logging: {},
 };

--- a/libs/nx-mcp/nx-mcp-server/src/lib/resources/nx-cloud-cipe-resources.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/resources/nx-cloud-cipe-resources.ts
@@ -1,0 +1,215 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Logger } from '@nx-console/shared-utils';
+import { NxConsoleTelemetryLogger } from '@nx-console/shared-telemetry';
+import { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { NxWorkspaceInfoProvider } from '../nx-mcp-server';
+import { NX_CLOUD_CIPE_FAILURE } from '@nx-console/shared-llm-context';
+import { CIPEInfo, CIPERun } from '@nx-console/shared-types';
+import { renderCipeDetails } from '../tools/nx-cloud';
+
+// Type for registered resource objects (they have a remove() method)
+type RegisteredResource = {
+  remove: () => void;
+};
+
+// Store registered resources by CIPE ID for management
+// The value is the registered resource object returned by server.resource()
+const registeredResources = new Map<string, RegisteredResource>();
+
+export async function registerNxCloudCipeResources(
+  workspacePath: string,
+  server: McpServer,
+  logger: Logger,
+  telemetry: NxConsoleTelemetryLogger | undefined,
+  nxWorkspaceInfoProvider: NxWorkspaceInfoProvider,
+): Promise<void> {
+  try {
+    // Check if provider supports CIPE data
+    if (!nxWorkspaceInfoProvider.getRecentCIPEData) {
+      logger.log('Provider does not support getRecentCIPEData');
+      return;
+    }
+
+    // Fetch recent CIPEs through the provider
+    const cipeData = await nxWorkspaceInfoProvider.getRecentCIPEData(
+      workspacePath,
+      logger,
+    );
+
+    if (cipeData.error) {
+      logger.log(`Error getting recent CIPE data: ${cipeData.error.message}`);
+      return;
+    }
+
+    const latestCipeIds = new Set<string>();
+
+    if (cipeData.info && cipeData.info.length > 0) {
+      // Track which CIPEs are in the latest data
+      for (const cipe of cipeData.info) {
+        latestCipeIds.add(cipe.ciPipelineExecutionId);
+      }
+    }
+
+    // Remove resources for CIPEs that no longer exist
+    const resourcesToRemove: string[] = [];
+    for (const [cipeId, resource] of registeredResources.entries()) {
+      if (!latestCipeIds.has(cipeId)) {
+        resourcesToRemove.push(cipeId);
+        try {
+          // Call .remove() on the resource object to remove it from the MCP client's list
+          resource.remove();
+        } catch (error) {
+          logger.log(`Error removing CIPE resource ${cipeId}:`, error);
+        }
+      }
+    }
+
+    // Clean up our tracking map
+    for (const cipeId of resourcesToRemove) {
+      registeredResources.delete(cipeId);
+    }
+
+    if (resourcesToRemove.length > 0) {
+      logger.log(`Removed ${resourcesToRemove.length} stale CIPE resources`);
+    }
+
+    if (!cipeData.info || cipeData.info.length === 0) {
+      logger.log('No recent CIPEs found to register as resources');
+      return;
+    }
+
+    let newResourcesCount = 0;
+
+    // Register each CIPE as an individual resource
+    for (const cipe of cipeData.info) {
+      const cipeId = cipe.ciPipelineExecutionId;
+
+      // Skip if already registered
+      if (registeredResources.has(cipeId)) {
+        continue;
+      }
+
+      // Create pretty name with branch and commit info
+      const resourceName = cipe.branch;
+      const statusText =
+        cipe.status === 'SUCCEEDED'
+          ? 'Succeeded'
+          : cipe.status === 'FAILED'
+            ? 'Failed'
+            : cipe.status === 'IN_PROGRESS'
+              ? 'In Progress'
+              : cipe.status;
+
+      // Use CIPE ID in URL for stability
+      const resourceUri = `nx-cloud://cipes/${cipeId}`;
+
+      // Register the resource and store the returned object (which has .remove(), .enable(), .disable() methods)
+      const registeredResource = server.resource(
+        resourceName,
+        resourceUri,
+        {
+          name: `${resourceName}  [${statusText}]`,
+          description: `${cipe.commitTitle || 'Unknown commit'} by ${cipe.author || 'Unknown author'}`,
+          mimeType: 'application/json',
+        },
+        async (): Promise<ReadResourceResult> => {
+          telemetry?.logUsage('ai.resource-read', {
+            resource: 'nx-cloud-cipe',
+          });
+
+          // Re-fetch to get the latest data
+          // We already checked that getRecentCIPEData exists at the start of the function
+          const latestData = await nxWorkspaceInfoProvider.getRecentCIPEData!(
+            workspacePath,
+            logger,
+          );
+
+          if (!latestData || latestData.error) {
+            return {
+              contents: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(
+                    {
+                      error: latestData.error,
+                    },
+                    null,
+                    2,
+                  ),
+                  uri: resourceUri,
+                },
+              ],
+            };
+          }
+
+          // Find the specific CIPE with latest data
+          const latestCipe = latestData.info?.find(
+            (c) => c.ciPipelineExecutionId === cipeId,
+          );
+
+          if (!latestCipe) {
+            return {
+              contents: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(
+                    {
+                      error: {
+                        type: 'not_found',
+                        message: `CIPE with ID ${cipeId} not found in recent data`,
+                      },
+                    },
+                    null,
+                    2,
+                  ),
+                  uri: resourceUri,
+                },
+              ],
+            };
+          }
+
+          const description = `This is a CI Pipeline Execution (CIPE) from Nx Cloud. To retrieve terminal output for failed tasks, use the ${NX_CLOUD_CIPE_FAILURE} tool with the executionId or linkId and the taskId from the list of failed tasks.`;
+
+          return {
+            contents: [
+              {
+                type: 'text',
+                text: `${description}\n\n${renderCipeDetails(latestCipe)}`,
+                uri: resourceUri,
+              },
+            ],
+          };
+        },
+      );
+
+      // Store the resource object so we can call .remove() on it later
+      registeredResources.set(cipeId, registeredResource);
+      newResourcesCount++;
+    }
+
+    if (newResourcesCount > 0) {
+      logger.log(
+        `Registered ${newResourcesCount} new Nx Cloud CIPE resources (${registeredResources.size} total)`,
+      );
+    }
+  } catch (error) {
+    logger.log('Error registering CIPE resources:', error);
+  }
+}
+
+/**
+ * Clear all registered CIPE resources (useful for cleanup)
+ */
+export function clearRegisteredCipeResources(): void {
+  // Remove all registered resources by calling .remove() on each resource object
+  for (const resource of registeredResources.values()) {
+    try {
+      // This removes the resource from the MCP client's resource list
+      resource.remove();
+    } catch (error) {
+      // Resource might already be removed, ignore errors
+    }
+  }
+  // Clear our tracking map
+  registeredResources.clear();
+}

--- a/libs/shared/telemetry/src/lib/telemetry-types.ts
+++ b/libs/shared/telemetry/src/lib/telemetry-types.ts
@@ -69,6 +69,7 @@ export type TelemetryEvents =
   | 'ai.feedback-bad'
   | 'ai.response-interaction'
   | 'ai.tool-call'
+  | 'ai.resource-read'
   | 'ai.add-mcp';
 
 export type TelemetryData = {

--- a/libs/vscode/mcp/src/lib/data-providers.ts
+++ b/libs/vscode/mcp/src/lib/data-providers.ts
@@ -15,6 +15,7 @@ import {
   getGenerators,
   getNxWorkspace,
   getNxWorkspaceProjects,
+  getRecentCIPEData,
 } from '@nx-console/vscode-nx-workspace';
 import {
   getGitDiffs,
@@ -32,6 +33,13 @@ export const nxWorkspaceInfoProvider: NxWorkspaceInfoProvider = {
   },
   isNxCloudEnabled: async () =>
     await isNxCloudUsed(getNxWorkspacePath(), vscodeLogger),
+  getRecentCIPEData: async () => {
+    // Route through nxls - getRecentCIPEData from vscode-nx-workspace already does this
+    const result = await getRecentCIPEData();
+    return (
+      result || { error: { type: 'other', message: 'Unable to get CIPE data' } }
+    );
+  },
 };
 
 export const ideProvider: IdeProvider = {


### PR DESCRIPTION
Expose recent CI Pipeline Executions (CIPEs) as selectable resources in the Nx MCP server.

This PR implements the requested feature to expose recent CIPEs as resources, making them available for selection and detailed viewing in the client. 
- getRecentCIPEs is properly routed through the nxls (in vscode) or directly called from the nx-cloud utils
- We refresh every thirty seconds for now, can hook up with proper client-side handling later
- Outdated CIPEs are removed from the pool of resources


