### PR TITLE
fix(vscode): fix integrated nx-mcp behaviour in non-nx workspace

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/index.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/index.ts
@@ -1,2 +1,2 @@
-export * from './lib/nx-mcp-server';
+export * from './lib/nx-mcp-server-wrapper';
 export * from './lib/ide-provider';

--- a/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server-wrapper.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server-wrapper.ts
@@ -139,8 +139,6 @@ export class NxMcpServerWrapper {
       },
     );
 
-    logger?.log(`has workspaceinfoprovier ${!!nxWorkspaceInfoProvider}`);
-
     registerNxCoreTools(
       server.server,
       server.logger,
@@ -158,12 +156,16 @@ export class NxMcpServerWrapper {
   }
 
   async setNxWorkspacePath(path: string) {
-    this.logger.log(`Setting nx workspace path to ${path}`);
-    const oldPath = this._nxWorkspacePath;
-    this._nxWorkspacePath = path;
+    this.logger.log(
+      `Setting mcp nx workspace path from ${this._nxWorkspacePath} to ${path}`,
+    );
 
     // If workspace path changed, trigger dynamic evaluation
-    if (oldPath !== path) {
+    if (this._nxWorkspacePath !== path) {
+      this._nxWorkspacePath = path;
+      this.logger.log(
+        `Nx workspace path changed, re-evaluating tools for new path: ${path}`,
+      );
       setNxWorkspacePathForCoreTools(path);
       setNxWorkspacePathForWorkspaceTools(path);
       await this.evaluateAndAddNewTools();
@@ -318,6 +320,7 @@ export class NxMcpServerWrapper {
       if (
         ideAvailable &&
         this.ideProvider &&
+        this._nxWorkspacePath &&
         !this.toolRegistrationState.nxIde &&
         this.ideProvider.isAvailable()
       ) {

--- a/libs/nx-mcp/nx-mcp-server/src/lib/resources/nx-cloud-cipe-resources.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/resources/nx-cloud-cipe-resources.ts
@@ -6,7 +6,7 @@ import { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { NX_CLOUD_CIPE_FAILURE } from '@nx-console/shared-llm-context';
 import { NxConsoleTelemetryLogger } from '@nx-console/shared-telemetry';
 import { Logger } from '@nx-console/shared-utils';
-import { NxWorkspaceInfoProvider } from '../nx-mcp-server';
+import { NxWorkspaceInfoProvider } from '../nx-mcp-server-wrapper';
 import { renderCipeDetails } from '../tools/nx-cloud';
 
 const registeredResources = new Map<string, RegisteredResource>();

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-core.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-core.ts
@@ -11,7 +11,7 @@ import { NxConsoleTelemetryLogger } from '@nx-console/shared-telemetry';
 import { NxWorkspace } from '@nx-console/shared-types';
 import { Logger } from '@nx-console/shared-utils';
 import { z } from 'zod';
-import { NxWorkspaceInfoProvider } from '../nx-mcp-server';
+import { NxWorkspaceInfoProvider } from '../nx-mcp-server-wrapper';
 
 let nxWorkspacePath: string | undefined = undefined;
 

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-workspace.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-workspace.ts
@@ -24,7 +24,7 @@ import { Logger } from '@nx-console/shared-utils';
 import { readFile } from 'fs/promises';
 import path from 'path';
 import z from 'zod';
-import { NxWorkspaceInfoProvider } from '../nx-mcp-server';
+import { NxWorkspaceInfoProvider } from '../nx-mcp-server-wrapper';
 
 let nxWorkspacePath: string | undefined = undefined;
 

--- a/libs/shared/nx-cloud/src/lib/is-nx-cloud-used.ts
+++ b/libs/shared/nx-cloud/src/lib/is-nx-cloud-used.ts
@@ -13,6 +13,10 @@ export async function isNxCloudUsed(
     return false;
   }
 
+  if (!nxJson) {
+    return false;
+  }
+
   let getIsNxCloudUsed: (nxJson: NxJsonConfiguration) => boolean;
   try {
     // try to use nx utils if they exist
@@ -32,7 +36,7 @@ export async function isNxCloudUsed(
         !!nxJson.nxCloudAccessToken ||
         !!nxJson.nxCloudId ||
         !!Object.values(nxJson.tasksRunnerOptions ?? {}).find(
-          (r) => r.runner == '@nrwl/nx-cloud' || r.runner == 'nx-cloud',
+          (r) => r?.runner == '@nrwl/nx-cloud' || r?.runner == 'nx-cloud',
         )
       );
     };

--- a/libs/vscode/mcp/src/lib/mcp-streamable-web-server.ts
+++ b/libs/vscode/mcp/src/lib/mcp-streamable-web-server.ts
@@ -13,6 +13,7 @@ import {
   Uri,
 } from 'vscode';
 import { ideProvider, nxWorkspaceInfoProvider } from './data-providers';
+import { checkIsNxWorkspace } from '@nx-console/shared-npm';
 
 export class NxMcpServerDefinitionProvider
   implements McpServerDefinitionProvider<NxMcpHttpServerDefinition>
@@ -69,8 +70,12 @@ export class McpStreamableWebServer {
             },
           },
         );
+        const providedPath = getNxWorkspacePath();
+        const nxWorkspacePath = (await checkIsNxWorkspace(providedPath))
+          ? providedPath
+          : undefined;
         const server = await NxMcpServerWrapper.create(
-          getNxWorkspacePath(),
+          nxWorkspacePath,
           nxWorkspaceInfoProvider,
           mcpServer,
           ideProvider,

--- a/libs/vscode/utils/src/lib/mcp-json.ts
+++ b/libs/vscode/utils/src/lib/mcp-json.ts
@@ -1,16 +1,16 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import * as path from 'path';
-import { workspace, window } from 'vscode';
+import { getNxWorkspacePath } from '@nx-console/vscode-configuration';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { parse } from 'jsonc-parser';
-import { isInCursor, isInWindsurf } from './editor-name-helpers';
+import * as path from 'path';
+import { window, workspace } from 'vscode';
+import { isInCursor } from './editor-name-helpers';
 
 /**
  * Gets the path to the mcp.json file.
  * @returns The path to the mcp.json file or null if the workspace path cannot be determined.
  */
 export function getMcpJsonPath(): string | null {
-  const vscodeWorkspacePath =
-    workspace.workspaceFolders && workspace.workspaceFolders[0].uri.fsPath;
+  const vscodeWorkspacePath = getNxWorkspacePath();
 
   if (!vscodeWorkspacePath) {
     return null;


### PR DESCRIPTION
- make sure agentrulesmanager is only initialized for nx workspaces
- make sure the workspace path passed to nx-mcp is an actual nx workspace
- handle `nx.json` edge case
- make sure ide tools are only registered in nx workspace