### PR TITLE
feat(vscode): remove vscode explain-cipe command

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -217,11 +217,6 @@
           "group": "inline@1"
         },
         {
-          "command": "nxCloud.explainCipeTaskFailure",
-          "when": "view == nxCloudRecentCIPE && viewItem == failedTask && github.copilot-chat.activated",
-          "group": "inline@1"
-        },
-        {
           "command": "nxCloud.helpMeFixCipeError",
           "when": "view == nxCloudRecentCIPE && viewItem == failedTask && isInCursor",
           "group": "inline@1"
@@ -949,11 +944,6 @@
         "title": "Open Workspace in Browser",
         "command": "nxCloud.openApp",
         "icon": "$(cloud)"
-      },
-      {
-        "title": "Explain CIPE Task Failure",
-        "command": "nxCloud.explainCipeTaskFailure",
-        "icon": "$(copilot)"
       },
       {
         "title": "Help me fix the latest CIPE error",

--- a/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
@@ -579,29 +579,6 @@ export class CloudRecentCIPEProvider extends AbstractTreeProvider<BaseRecentCIPE
           }
         }
       }),
-      commands.registerCommand(
-        'nxCloud.explainCipeTaskFailure',
-        async (treeItem: BaseRecentCIPETreeItem) => {
-          if (!treeItem.isFailedTaskTreeItem()) {
-            return;
-          }
-
-          getTelemetry().logUsage('cloud.explain-cipe-error');
-
-          let idPrompt = '';
-          if (treeItem.linkId) {
-            idPrompt += `linkId ${treeItem.linkId}`;
-          }
-          if (treeItem.executionId) {
-            idPrompt += ` executionId ${treeItem.executionId}`;
-          }
-
-          commands.executeCommand(
-            'workbench.action.chat.open',
-            `@nx /explain-cipe help me understand the failed output for ${treeItem.taskId} with the following ids ${idPrompt}`,
-          );
-        },
-      ),
       commands.registerCommand('nxCloud.helpMeFixCipeError', async () => {
         getTelemetry().logUsage('cloud.fix-cipe-error');
 


### PR DESCRIPTION
This was a chat participant feature and has been used a grand total of 12 times in the last month.
We can add an equivalent using the MCP but it's apparently not very important right now.