### PR TITLE
chore(repo): setup nx release for nxls

### DIFF
--- a/.github/workflows/publish-nxls.yml
+++ b/.github/workflows/publish-nxls.yml
@@ -1,0 +1,45 @@
+name: Publish NXLS
+
+on:
+  push:
+    tags:
+      - 'nxls-v*.*.*'
+env:
+  node_version: 24
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ env.node_version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node_version }}
+          check-latest: true
+          cache: yarn
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1.0.5
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+      - run: yarn install --immutable
+        shell: bash
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v3
+        with:
+          main-branch-name: 'master'
+      - name: publish
+        run: |
+          npx nx run nxls:package --skip-nx-cache
+          cd dist/packages/nxls
+          npm publish --dry-run

--- a/apps/nxls/package.json
+++ b/apps/nxls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxls",
-  "version": "1.5.0",
+  "version": "0.0.0",
   "main": "main.js",
   "bin": "bin/nxls",
   "license": "MIT",

--- a/nx.json
+++ b/nx.json
@@ -239,6 +239,16 @@
         "changelog": {
           "projectChangelogs": true
         }
+      },
+      "nxls": {
+        "projects": ["nxls"],
+        "projectsRelationship": "independent",
+        "version": {
+          "conventionalCommits": true
+        },
+        "changelog": {
+          "projectChangelogs": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -146,6 +146,9 @@
       "release:nx-mcp": {
         "command": "npx nx release --group nx-mcp --skip-publish"
       },
+      "release:nxls": {
+        "command": "npx nx release --group nxls --skip-publish"
+      },
       "telemetry-check": {
         "command": "node tools/scripts/check-telemetry-sync.js"
       }


### PR DESCRIPTION
now that we have a new pipeline, we can start releasing the nxls to npm again (--dry-run for now just to see if things work)