### PR TITLE
fix(vscode): only poll v frequently for active AI fixes

### DIFF
--- a/libs/shared/types/src/lib/cloud-info.ts
+++ b/libs/shared/types/src/lib/cloud-info.ts
@@ -38,6 +38,7 @@ export type NxAiFix = {
   suggestedFixReasoning?: string;
   verificationStatus: AITaskFixStatus;
   userAction: AITaskFixUserAction;
+  failureClassification?: string;
   shortLinkId?: string;
   userActionOrigin?: AITaskFixUserActionOrigin;
   couldAutoApplyTasks?: boolean;


### PR DESCRIPTION
currently we just check if an AI fix exists, not whether it's active

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update polling to trigger fast refresh only for active AI fixes via `isAIFixActive`, and extend `NxAiFix` with `failureClassification`.
> 
> - **VS Code Cloud View (`cloud-view-state-machine.ts`)**:
>   - **Polling logic**: Use `isAIFixActive(rg.aiFix)` to apply `AI_FIX_POLLING_TIME` only when an AI fix is actively generating or verifying; log reason updated to "AI fix in progress".
>   - **Helper**: Add `isAIFixActive` considering `userAction`, `suggestedFixStatus`, `verificationStatus`, and `failureClassification` (treat `undefined` as needing verification).
> - **Shared Types (`cloud-info.ts`)**:
>   - Extend `NxAiFix` with optional `failureClassification` to indicate verification necessity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d4cc2c212ef6aa112eb3524d732973a0ce358f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->