### PR TITLE
test(nxls-e2e): increase e2e timeouts across the board

### DIFF
--- a/apps/nxls-e2e/src/completion/nx-json-completion-default.test.ts
+++ b/apps/nxls-e2e/src/completion/nx-json-completion-default.test.ts
@@ -88,7 +88,7 @@ describe('nx.json completion - default', () => {
 
   it('should contain proper root keys', async () => {
     // delete all json properties so we can see all possible completions
-    modifyJsonFile(nxJsonPath, (data) => ({}));
+    modifyJsonFile(nxJsonPath, () => ({}));
 
     nxlsWrapper.sendNotification({
       method: 'textDocument/didChange',
@@ -201,7 +201,7 @@ describe('nx.json completion - default', () => {
   });
 
   it('should not error when nx-schema.json is missing', async () => {
-    await waitFor(1000);
+    await waitFor(11000);
 
     rmSync(
       join(

--- a/apps/nxls-e2e/src/nx-workspace/nx-workspace-lerna.test.ts
+++ b/apps/nxls-e2e/src/nx-workspace/nx-workspace-lerna.test.ts
@@ -49,7 +49,7 @@ xdescribe('nx/workspace - lerna.json only repo', () => {
         }
     }`,
     );
-    await waitFor(1000);
+    await waitFor(11000);
 
     nxlsWrapper = new NxlsWrapper();
     await nxlsWrapper.startNxls(workspacePath);

--- a/apps/nxls-e2e/src/parse-target-string/parse-target-string.16.test.ts
+++ b/apps/nxls-e2e/src/parse-target-string/parse-target-string.16.test.ts
@@ -42,7 +42,7 @@ describe('parse target string - default', () => {
       'project.json',
     );
 
-    await waitFor(1000);
+    await waitFor(11000);
     modifyJsonFile(projectJson, (json) => ({
       ...json,
       targets: {

--- a/apps/nxls-e2e/src/parse-target-string/parse-target-string.default.test.ts
+++ b/apps/nxls-e2e/src/parse-target-string/parse-target-string.default.test.ts
@@ -55,7 +55,7 @@ describe('parse target string - default', () => {
     await nxlsWrapper.startNxls(join(e2eCwd, workspaceName));
     nxlsWrapper.setVerbose(true);
 
-    await waitFor(1000);
+    await waitFor(11000);
     modifyJsonFile(projectJson, (json) => ({
       ...json,
       targets: {

--- a/apps/nxls-e2e/src/pdv-data/pdv-data-default.test.ts
+++ b/apps/nxls-e2e/src/pdv-data/pdv-data-default.test.ts
@@ -63,7 +63,7 @@ describe('pdv data', () => {
   });
 
   it('should contain disabledTaskSyncGenerators if set in nx.json', async () => {
-    await waitFor(1000);
+    await waitFor(11000);
 
     const nxJsonPath = join(e2eCwd, workspaceName, 'nx.json');
     modifyJsonFile(nxJsonPath, (json) => {
@@ -91,7 +91,7 @@ describe('pdv data', () => {
   });
 
   it('should contain pdv data & error for partial errors', async () => {
-    await waitFor(1000);
+    await waitFor(11000);
     viteFileContents = readFileSync(viteFilePath, 'utf-8');
 
     appendFileSync(viteFilePath, '{');
@@ -122,7 +122,7 @@ describe('pdv data', () => {
   });
 
   it('should return error if root project.json is broken', async () => {
-    await waitFor(1000);
+    await waitFor(11000);
 
     writeFileSync(viteFilePath, viteFileContents);
 
@@ -152,7 +152,7 @@ describe('pdv data', () => {
   });
 
   it('should return error if nx.json is broken', async () => {
-    await waitFor(1000);
+    await waitFor(11000);
 
     writeFileSync(projectJsonPath, projectJsonContents);
 

--- a/apps/nxls-e2e/src/project-folder-tree/project-folder-tree.test.ts
+++ b/apps/nxls-e2e/src/project-folder-tree/project-folder-tree.test.ts
@@ -42,7 +42,7 @@ describe('project folder tree', () => {
   });
 
   it('should contain projects & folder nodes for project in subfolder', async () => {
-    await waitFor(500);
+    await waitFor(11000);
 
     const projectFolder = join(e2eCwd, workspaceName, 'subfolder', 'project');
     mkdirSync(projectFolder, { recursive: true });
@@ -81,7 +81,7 @@ describe('project folder tree', () => {
   });
 
   it('should contain projects & folder info for nested projects', async () => {
-    await waitFor(500);
+    await waitFor(11000);
 
     const nestedProjectFolder = join(
       e2eCwd,
@@ -134,7 +134,7 @@ describe('project folder tree', () => {
   });
 
   it('should contain projects & folder info for deeply nested projects', async () => {
-    await waitFor(500);
+    await waitFor(11000);
     const deeplyNestedProjectFolder = join(
       e2eCwd,
       workspaceName,

--- a/apps/nxls-e2e/src/watcher/watcher.test.ts
+++ b/apps/nxls-e2e/src/watcher/watcher.test.ts
@@ -39,25 +39,25 @@ describe('watcher', () => {
   });
 
   it('should send refresh notification when project files are changed', async () => {
-    await waitFor(500);
+    await waitFor(11000);
     addRandomTargetToFile(projectJsonPath);
     await nxlsWrapper.waitForNotification(
       NxWorkspaceRefreshNotification.method,
     );
 
-    await waitFor(500);
+    await waitFor(11000);
     addRandomTargetToFile(e2eProjectJsonPath);
     await nxlsWrapper.waitForNotification(
       NxWorkspaceRefreshNotification.method,
     );
 
-    await waitFor(500);
+    await waitFor(11000);
     addRandomTargetToFile(e2eProjectJsonPath);
     await nxlsWrapper.waitForNotification(
       NxWorkspaceRefreshNotification.method,
     );
 
-    await waitFor(500);
+    await waitFor(11000);
     appendFileSync(cypressConfig, 'console.log("hello")');
     await nxlsWrapper.waitForNotification(
       NxWorkspaceRefreshNotification.method,
@@ -76,8 +76,8 @@ describe('watcher', () => {
       env: process.env,
     });
 
-    // give nxls a second to restart the daemon
-    await waitFor(6000);
+    // give nxls time to restart the daemon and handle debounced changes
+    await waitFor(12000);
 
     addRandomTargetToFile(projectJsonPath);
     await nxlsWrapper.waitForNotification(
@@ -86,7 +86,7 @@ describe('watcher', () => {
   });
 
   it('should send 4 refresh notifications after error and still handle changes', async () => {
-    await waitFor(2000);
+    await waitFor(11000);
     const oldContents = readFileSync(projectJsonPath, 'utf-8');
     writeFileSync(projectJsonPath, 'invalid json', {
       encoding: 'utf-8',
@@ -105,8 +105,8 @@ describe('watcher', () => {
     );
 
     // we need to wait until the daemon watcher ultimately fails
-    // and the native watcher is started
-    await waitFor(8000);
+    // and the native watcher is started, plus debounce time
+    await waitFor(15000);
     writeFileSync(projectJsonPath, oldContents);
     await nxlsWrapper.waitForNotification(
       NxWorkspaceRefreshNotification.method,
@@ -128,7 +128,7 @@ describe('watcher', () => {
         throw new Error('Should not have received refresh notification');
       });
 
-    await waitFor(11000);
+    await waitFor(12000);
     nxlsWrapper.cancelWaitingForNotification(
       NxWorkspaceRefreshNotification.method,
     );
@@ -155,7 +155,7 @@ describe('watcher', () => {
       }
     });
 
-    await waitFor(1000);
+    await waitFor(11000);
 
     addRandomTargetToFile(
       join(e2eCwd, workspaceName, 'react-app1', 'project.json'),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase waits to ~11–15s across nxls e2e tests, adjust daemon restart debounce window, and remove an unused callback param.
> 
> - **E2E tests (nxls)**:
>   - **Longer waits to stabilize async behavior**:
>     - Bump `waitFor` delays (mostly to `11000–15000ms`) in `completion`, `parse-target-string`, `pdv-data`, `project-folder-tree`, and `watcher` tests.
>     - Extend daemon restart window and debounce handling in `apps/nxls-e2e/src/watcher/watcher.test.ts` (e.g., `6000ms` → `12000ms`, other waits increased accordingly).
>   - **Minor fixes**:
>     - Remove unused param in `modifyJsonFile` call (`(data) => ({})` → `() => ({})`) in `apps/nxls-e2e/src/completion/nx-json-completion-default.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e039cef94b85d96b20f25af65f0bf8ef723d4c09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->