### PR TITLE
fix(nxls): increase default set of ignored branches to align with nx cloud

### DIFF
--- a/libs/shared/nx-cloud/src/lib/get-recent-cipe-data.ts
+++ b/libs/shared/nx-cloud/src/lib/get-recent-cipe-data.ts
@@ -136,7 +136,16 @@ function getRecentlyCommittedGitBranches(
 }
 
 export function getIgnoredBranches(workspacePath: string): string[] {
-  const ignoredBranches = ['main', 'master'];
+  const ignoredBranches = [
+    'main',
+    'master',
+    'trunk',
+    'next',
+    'dev',
+    'development',
+    'stable',
+    'canary',
+  ];
 
   // Check refs/remotes/origin/HEAD
   try {


### PR DESCRIPTION
nx cloud disregards these anyways so we don't have to send requests