### PR TITLE
fix(vscode): dont load .env files into process.env on main extension process

### DIFF
--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -101,8 +101,6 @@ export async function activate(c: ExtensionContext) {
     GlobalConfigurationStore.fromContext(context);
     WorkspaceConfigurationStore.fromContext(context);
 
-    loadRootEnvFiles(getNxWorkspacePath());
-
     createNxlsClient(context);
     initTelemetry(context);
     initMcp(context);
@@ -277,7 +275,6 @@ async function setWorkspace(workspacePath: string) {
   }
 
   getNxlsClient().setWorkspacePath(workspacePath);
-  loadRootEnvFiles(workspacePath);
 
   WorkspaceConfigurationStore.instance.set('nxWorkspacePath', workspacePath);
 

--- a/libs/shared/utils/src/lib/loadRootEnvFiles.ts
+++ b/libs/shared/utils/src/lib/loadRootEnvFiles.ts
@@ -8,11 +8,29 @@ import { join } from 'path';
  * - .local.env
  * - .env.local
  */
-export function loadRootEnvFiles(root: string) {
+export function loadRootEnvFiles(
+  root: string,
+  targetEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  let expandedEnv: NodeJS.ProcessEnv = {
+    ...targetEnv,
+  };
   for (const file of ['.local.env', '.env.local', '.env']) {
     const myEnv = loadDotEnvFile({
       path: join(root, file),
+      processEnv: targetEnv,
+      override: true,
     });
-    expand(myEnv);
+    const expanded = expand({
+      ...myEnv,
+      processEnv: expandedEnv,
+    });
+    if (expanded.parsed) {
+      expandedEnv = {
+        ...expandedEnv,
+        ...expanded.parsed,
+      };
+    }
   }
+  return expandedEnv;
 }

--- a/libs/vscode/messaging/src/lib/messaging-server.ts
+++ b/libs/vscode/messaging/src/lib/messaging-server.ts
@@ -27,6 +27,7 @@ import {
   MessagingRequest0,
 } from './messaging-notification';
 import { vscodeLogger } from '@nx-console/vscode-output-channels';
+import { loadRootEnvFiles } from '@nx-console/shared-utils';
 
 const messages: Array<MessagingNotification | MessagingNotification2> = [
   NxTerminalMessage,
@@ -144,7 +145,15 @@ export async function initMessagingServer(
       await existingServer.dispose();
     }
 
-    const socketPath = await getNxConsoleSocketPath(workspacePath);
+    const envWithLocalFiles = loadRootEnvFiles(workspacePath, {
+      ...process.env,
+    });
+
+    const socketPath = await getNxConsoleSocketPath(
+      workspacePath,
+      envWithLocalFiles,
+    );
+
     const messagingServer = new NxMessagingServer(socketPath, context);
     await messagingServer.listen();
 

--- a/libs/vscode/messaging/tsconfig.json
+++ b/libs/vscode/messaging/tsconfig.json
@@ -4,6 +4,9 @@
   "include": [],
   "references": [
     {
+      "path": "../../shared/utils"
+    },
+    {
       "path": "../../shared/socket-utils"
     },
     {

--- a/libs/vscode/messaging/tsconfig.lib.json
+++ b/libs/vscode/messaging/tsconfig.lib.json
@@ -13,6 +13,9 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../../shared/utils/tsconfig.lib.json"
+    },
+    {
       "path": "../../shared/socket-utils/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
Currently we load `.env`, `.env.local` etc. in the main nx console process because we need some of that information later on. `NX_SOCKET_DIR` and `NX_DAEMON_SOCKET_DIR`, to be specific.
Since the extension host process can contain multiple extensions, this process env might be shared with other extensions. We don't want to pollute their env and cause unpredictable behaviours so I reworked this area to respect these env vars without loading them into `process.env`