### PR TITLE
chore(repo): turn off verbose logging

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NX_CI_EXECUTION_ENV: 'linux'
-      NX_VERBOSE_LOGGING: false
+      NX_VERBOSE_LOGGING: true
     steps:
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -28,6 +28,8 @@ common-init-steps: &common-init-steps
     steps:
       - name: Install Node Modules
         uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-node-modules/main.yaml'
+      - name: Generate workspace data
+        script: npx nx show projects
   - name: Install Browsers
     uses: 'nrwl/nx-cloud-workflows/v4/workflow-steps/install-browsers/main.yaml'
 


### PR DESCRIPTION
Reverts nrwl/nx-console#2819

Do not need to run off verbose anymore. Gradle plugin logging is controlled by another env variable `NX_GRADLE_VERBOSE_LOGGING` so we don't see any agent failures due to too many logs.