### PR TITLE
fix(vscode): skip minification

### DIFF
--- a/apps/vscode/project.json
+++ b/apps/vscode/project.json
@@ -30,7 +30,7 @@
           "*/nx.wasi.cjs"
         ],
         "thirdParty": true,
-        "minify": true,
+        "minify": false,
         "sourcemap": false,
         "outputPath": "dist/apps/vscode",
         "outputFileName": "main.js",
@@ -95,7 +95,7 @@
         },
         "production": {
           "skipTypeCheck": true,
-          "minify": true,
+          "minify": false,
           "sourcemap": false
         },
         "debug": {


### PR DESCRIPTION
It's not very critical and the repo is OSS anyways. This will make it a lot easier to debug issues in rollbar and provide a better vscode experience.