### PR TITLE
fix(vscode): repair current running tasks tool in cursor

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-tasks.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-tasks.ts
@@ -11,17 +11,12 @@ import {
 import { IdeProvider } from '../ide-provider';
 import { RunningTasksMap } from '@nx-console/shared-running-tasks';
 
-let isRegistered = false;
-
 export function registerNxTaskTools(
   server: McpServer,
   ideProvider: IdeProvider,
   logger: Logger,
   telemetry?: NxConsoleTelemetryLogger,
 ): void {
-  if (isRegistered) {
-    return;
-  }
   server.tool(
     NX_CURRENT_RUNNING_TASKS_DETAILS,
     `Returns a list of running commands (also called tasks) from currently running Nx CLI processes. This will include the process ID of the Nx CLI processes with task IDs and their status.
@@ -50,7 +45,6 @@ export function registerNxTaskTools(
     nxCurrentlyRunningTaskOutput(telemetry, ideProvider),
   );
 
-  isRegistered = true;
   logger.log('Registered Nx task tools');
 }
 

--- a/libs/vscode/mcp/src/lib/data-providers.ts
+++ b/libs/vscode/mcp/src/lib/data-providers.ts
@@ -44,7 +44,7 @@ export const nxWorkspaceInfoProvider: NxWorkspaceInfoProvider = {
 
 export const ideProvider: IdeProvider = {
   isAvailable: () => true,
-  onConnectionChange: () => () => {
+  onConnectionChange: (_: (available: boolean) => void) => () => {
     // noop in vscode
   },
   dispose: () => {


### PR DESCRIPTION
cursor connects to the MCP over and over again which means after the first time these tools weren't registered anymore. We have instance-level (vs module-level) duplicate detection available which is why we don't need this.