### PR TITLE
fix(vscode): load root env when checking provenance & npm debugging configure-ai-agents

### DIFF
--- a/apps/vscode/src/nx-init.ts
+++ b/apps/vscode/src/nx-init.ts
@@ -28,7 +28,7 @@ export function initNxInit(context: ExtensionContext) {
         const workspacePath =
           workspace.workspaceFolders &&
           workspace.workspaceFolders[0].uri.fsPath;
-        const provenanceResult = await nxLatestProvenanceCheck();
+        const provenanceResult = await nxLatestProvenanceCheck(workspacePath);
         if (provenanceResult !== true) {
           getTelemetry().logUsage('misc.nx-latest-no-provenance');
           logAndShowError(noProvenanceError, provenanceResult);

--- a/libs/shared/utils/src/lib/loadRootEnvFiles.ts
+++ b/libs/shared/utils/src/lib/loadRootEnvFiles.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
  * - .env.local
  */
 export function loadRootEnvFiles(
-  root: string,
+  workspacePath: string,
   targetEnv: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
   let expandedEnv: NodeJS.ProcessEnv = {
@@ -17,7 +17,7 @@ export function loadRootEnvFiles(
   };
   for (const file of ['.local.env', '.env.local', '.env']) {
     const myEnv = loadDotEnvFile({
-      path: join(root, file),
+      path: join(workspacePath, file),
       processEnv: targetEnv,
       override: true,
     });

--- a/libs/shared/utils/src/lib/provenance.ts
+++ b/libs/shared/utils/src/lib/provenance.ts
@@ -1,12 +1,13 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
+import { loadRootEnvFiles } from './loadRootEnvFiles';
 
-/**
- * Checks the provenance of the latest version of Nx from the npm registry.
- * Returns true if the provenance is valid, otherwise returns a string describing the failure reason.
- */
-export async function nxLatestProvenanceCheck(): Promise<true | string> {
-  if (process.env.NX_SKIP_PROVENANCE_CHECK === 'true') {
+export async function nxLatestProvenanceCheck(
+  workspacePath?: string,
+): Promise<true | string> {
+  const env = workspacePath ? loadRootEnvFiles(workspacePath) : process.env;
+
+  if (env.NX_SKIP_PROVENANCE_CHECK === 'true') {
     return true;
   }
   try {

--- a/libs/vscode/nx-cloud-view/src/get-cloud-onboarding-url.ts
+++ b/libs/vscode/nx-cloud-view/src/get-cloud-onboarding-url.ts
@@ -18,7 +18,7 @@ export async function getCloudOnboardingUrl() {
     vscodeLogger,
   );
   const packageManagerCommand = await getPackageManagerCommand(workspacePath);
-  const provenanceResult = await nxLatestProvenanceCheck();
+  const provenanceResult = await nxLatestProvenanceCheck(workspacePath);
   if (provenanceResult !== true) {
     getTelemetry().logUsage('misc.nx-latest-no-provenance');
     vscodeLogger.log(provenanceResult);

--- a/libs/vscode/tasks/src/lib/cli-task.ts
+++ b/libs/vscode/tasks/src/lib/cli-task.ts
@@ -34,7 +34,7 @@ export class CliTask extends Task {
     const { isEncapsulatedNx, workspacePath } = nxWorkspace;
 
     if (definition.useLatestNxVersion) {
-      const provenanceResult = await nxLatestProvenanceCheck();
+      const provenanceResult = await nxLatestProvenanceCheck(workspacePath);
       if (provenanceResult !== true) {
         getTelemetry().logUsage('misc.nx-latest-no-provenance');
         vscodeLogger.log(provenanceResult);


### PR DESCRIPTION
this aligns it with jetbrains after root env loading was removed from the extension main process.
Also gets more information on why configure-ai-agents fails.