### PR TITLE
feat(nx-mcp): rename nx_cloud_analytics tools to just cloud_analytics

### DIFF
--- a/apps/nx-mcp/README.md
+++ b/apps/nx-mcp/README.md
@@ -103,12 +103,12 @@ The Nx MCP server provides a comprehensive set of tools for interacting with you
 
 These tools provide analytics and insights into your Nx Cloud CI/CD data, helping you track performance trends and team productivity:
 
-- **nx_cloud_analytics_pipeline_executions_search**: Analyzes historical pipeline execution data to identify trends and patterns
-- **nx_cloud_analytics_pipeline_execution_details**: Analyzes detailed data for a specific pipeline execution to investigate performance
-- **nx_cloud_analytics_runs_search**: Analyzes historical run data to track performance trends and productivity patterns
-- **nx_cloud_analytics_run_details**: Analyzes detailed data for a specific run to investigate command execution performance
-- **nx_cloud_analytics_tasks_search**: Analyzes aggregated task performance statistics including success rates and cache hit rates
-- **nx_cloud_analytics_task_executions_search**: Analyzes individual task execution data to investigate performance trends
+- **cloud_analytics_pipeline_executions_search**: Analyzes historical pipeline execution data to identify trends and patterns
+- **cloud_analytics_pipeline_execution_details**: Analyzes detailed data for a specific pipeline execution to investigate performance
+- **cloud_analytics_runs_search**: Analyzes historical run data to track performance trends and productivity patterns
+- **cloud_analytics_run_details**: Analyzes detailed data for a specific run to investigate command execution performance
+- **cloud_analytics_tasks_search**: Analyzes aggregated task performance statistics including success rates and cache hit rates
+- **cloud_analytics_task_executions_search**: Analyzes individual task execution data to investigate performance trends
 
 When no workspace path is specified, only the `nx_docs` and `nx_available_plugins` tools will be available.
 

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -1,12 +1,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
-  NX_CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
-  NX_CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
-  NX_CLOUD_ANALYTICS_RUN_DETAILS,
-  NX_CLOUD_ANALYTICS_RUNS_SEARCH,
-  NX_CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
-  NX_CLOUD_ANALYTICS_TASKS_SEARCH,
+  CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
+  CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
+  CLOUD_ANALYTICS_RUN_DETAILS,
+  CLOUD_ANALYTICS_RUNS_SEARCH,
+  CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
+  CLOUD_ANALYTICS_TASKS_SEARCH,
 } from '@nx-console/shared-llm-context/src/lib/tool-names';
 import {
   formatPipelineExecutionDetailsContent,
@@ -36,7 +36,7 @@ export function registerNxCloudTools(
 ): void {
   // Pipeline Executions Search
   server.tool(
-    NX_CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
+    CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
     'Analyze historical pipeline execution data from Nx Cloud to identify trends and patterns in CI/CD workflows. Use this analytics tool to track pipeline success rates over time, investigate performance patterns across branches or authors, and gain insights into team productivity. Filter by branch, status, author, or time range to analyze specific segments of your CI/CD history. Pipeline executions are the top-level containers in the hierarchy. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
     pipelineExecutionSearchSchema.shape,
     {
@@ -49,7 +49,7 @@ export function registerNxCloudTools(
 
   // Pipeline Execution Details
   server.tool(
-    NX_CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
+    CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
     'Analyze detailed historical data for a specific pipeline execution in Nx Cloud. Use this analytics tool to investigate the complete structure of a past CI/CD run, understand performance bottlenecks, and identify optimization opportunities. Returns the full hierarchy including run groups and their associated runs, helping you gain insights into how the pipeline was executed and where improvements can be made.',
     pipelineExecutionDetailsSchema.shape,
     {
@@ -62,7 +62,7 @@ export function registerNxCloudTools(
 
   // Runs Search
   server.tool(
-    NX_CLOUD_ANALYTICS_RUNS_SEARCH,
+    CLOUD_ANALYTICS_RUNS_SEARCH,
     'Analyze historical run data from Nx Cloud to track performance trends and team productivity patterns. Runs are mid-level containers within pipeline executions, each representing execution of a specific command (like "nx affected:build"). Use this analytics tool to identify which commands are taking the longest, track success rates across different run groups, and understand how your team\'s build patterns have evolved over time. Filter by pipeline execution, branch, run group, or status to analyze specific segments. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
     runSearchSchema.shape,
     {
@@ -75,7 +75,7 @@ export function registerNxCloudTools(
 
   // Run Details
   server.tool(
-    NX_CLOUD_ANALYTICS_RUN_DETAILS,
+    CLOUD_ANALYTICS_RUN_DETAILS,
     'Analyze detailed historical data for a specific run in Nx Cloud. Use this analytics tool to investigate command execution performance, understand task distribution patterns, and identify optimization opportunities. Returns comprehensive information including the command executed, duration, status, and all tasks that were part of this run, helping you gain insights into where time is being spent and how to improve build efficiency.',
     runDetailsSchema.shape,
     {
@@ -88,7 +88,7 @@ export function registerNxCloudTools(
 
   // Tasks Search
   server.tool(
-    NX_CLOUD_ANALYTICS_TASKS_SEARCH,
+    CLOUD_ANALYTICS_TASKS_SEARCH,
     'Analyze aggregated task performance statistics from Nx Cloud to identify optimization opportunities and track trends over time. Returns performance metrics including success rates, cache hit rates, and average durations for each task (project + target combination). Use this analytics tool to understand which tasks are the slowest, track cache effectiveness trends, identify projects with low success rates, and gain insights into overall team productivity patterns. Filter by project, target, or time range to analyze specific segments. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
     taskSearchSchema.shape,
     {
@@ -101,7 +101,7 @@ export function registerNxCloudTools(
 
   // Task Executions Search
   server.tool(
-    NX_CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
+    CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
     'Analyze individual task execution data from Nx Cloud to investigate performance trends and understand task behavior over time. Returns detailed information for each task execution including project, target, duration, cache status, and parameters. Use this analytics tool to track how specific tasks perform across different runs, identify patterns in cache misses, and gain insights into which task configurations are most efficient. Filter by project, target, or time range to analyze specific execution patterns. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
     taskDetailsSchema.shape,
     {
@@ -326,7 +326,7 @@ const nxCloudPipelineExecutionsSearch =
     params: z.infer<typeof pipelineExecutionSearchSchema>,
   ): Promise<CallToolResult> => {
     telemetry?.logUsage('ai.tool-call', {
-      tool: NX_CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
+      tool: CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
     });
 
     const result = await getPipelineExecutionsSearch(
@@ -360,7 +360,7 @@ const nxCloudPipelineExecutionDetails =
     params: z.infer<typeof pipelineExecutionDetailsSchema>,
   ): Promise<CallToolResult> => {
     telemetry?.logUsage('ai.tool-call', {
-      tool: NX_CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
+      tool: CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
     });
 
     const result = await getPipelineExecutionDetails(
@@ -393,7 +393,7 @@ const nxCloudRunsSearch =
   ) =>
   async (params: z.infer<typeof runSearchSchema>): Promise<CallToolResult> => {
     telemetry?.logUsage('ai.tool-call', {
-      tool: NX_CLOUD_ANALYTICS_RUNS_SEARCH,
+      tool: CLOUD_ANALYTICS_RUNS_SEARCH,
     });
 
     const result = await getRunsSearch(workspacePath, logger, params);
@@ -419,7 +419,7 @@ const nxCloudRunDetails =
   ) =>
   async (params: z.infer<typeof runDetailsSchema>): Promise<CallToolResult> => {
     telemetry?.logUsage('ai.tool-call', {
-      tool: NX_CLOUD_ANALYTICS_RUN_DETAILS,
+      tool: CLOUD_ANALYTICS_RUN_DETAILS,
     });
 
     const result = await getRunDetails(workspacePath, logger, params.runId);
@@ -445,7 +445,7 @@ const nxCloudTasksSearch =
   ) =>
   async (params: z.infer<typeof taskSearchSchema>): Promise<CallToolResult> => {
     telemetry?.logUsage('ai.tool-call', {
-      tool: NX_CLOUD_ANALYTICS_TASKS_SEARCH,
+      tool: CLOUD_ANALYTICS_TASKS_SEARCH,
     });
 
     const result = await getTasksSearch(workspacePath, logger, params);
@@ -473,7 +473,7 @@ const nxCloudTaskDetails =
     params: z.infer<typeof taskDetailsSchema>,
   ): Promise<CallToolResult> => {
     telemetry?.logUsage('ai.tool-call', {
-      tool: NX_CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
+      tool: CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
     });
 
     const result = await getTasksDetailsSearch(workspacePath, logger, params);

--- a/libs/shared/llm-context/src/lib/tool-names.ts
+++ b/libs/shared/llm-context/src/lib/tool-names.ts
@@ -20,13 +20,12 @@ export const NX_CURRENT_RUNNING_TASKS_DETAILS =
   'nx_current_running_tasks_details';
 export const NX_CURRENT_RUNNING_TASK_OUTPUT = 'nx_current_running_task_output';
 
-export const NX_CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH =
-  'nx_cloud_analytics_pipeline_executions_search';
-export const NX_CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS =
-  'nx_cloud_analytics_pipeline_execution_details';
-export const NX_CLOUD_ANALYTICS_RUNS_SEARCH = 'nx_cloud_analytics_runs_search';
-export const NX_CLOUD_ANALYTICS_RUN_DETAILS = 'nx_cloud_analytics_run_details';
-export const NX_CLOUD_ANALYTICS_TASKS_SEARCH =
-  'nx_cloud_analytics_tasks_search';
-export const NX_CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH =
-  'nx_cloud_analytics_task_executions_search';
+export const CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH =
+  'cloud_analytics_pipeline_executions_search';
+export const CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS =
+  'cloud_analytics_pipeline_execution_details';
+export const CLOUD_ANALYTICS_RUNS_SEARCH = 'cloud_analytics_runs_search';
+export const CLOUD_ANALYTICS_RUN_DETAILS = 'cloud_analytics_run_details';
+export const CLOUD_ANALYTICS_TASKS_SEARCH = 'cloud_analytics_tasks_search';
+export const CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH =
+  'cloud_analytics_task_executions_search';


### PR DESCRIPTION
cursor has a limit of 60 characters for server name + tool name so we want to get below that. The fact that it's nx cloud is obvious from the `nx_mcp` server name