### PR TITLE
fix(vscode): misc fixes around json parsing

### DIFF
--- a/libs/language-server/capabilities/code-completion/src/lib/schema-completion.ts
+++ b/libs/language-server/capabilities/code-completion/src/lib/schema-completion.ts
@@ -4,6 +4,7 @@ import {
   lspLogger,
 } from '@nx-console/language-server-utils';
 import { getProjectByRoot } from '@nx-console/language-server-workspace';
+import { readAndParseJson } from '@nx-console/shared-file-system';
 import {
   CompletionType,
   getNxJsonSchema,
@@ -215,9 +216,7 @@ async function getPackageJsonSchema(
       join('schemas', 'project-schema.json'),
     );
     if (projectJsonSchemaPath) {
-      const nxProjectSchema = JSON.parse(
-        await readFile(projectJsonSchemaPath, 'utf-8'),
-      );
+      const nxProjectSchema = await readAndParseJson(projectJsonSchemaPath);
       return {
         type: 'object',
         properties: {

--- a/libs/language-server/capabilities/code-completion/tsconfig.json
+++ b/libs/language-server/capabilities/code-completion/tsconfig.json
@@ -7,6 +7,9 @@
       "path": "../../../shared/schema"
     },
     {
+      "path": "../../../shared/file-system"
+    },
+    {
       "path": "../../workspace"
     },
     {

--- a/libs/language-server/capabilities/code-completion/tsconfig.lib.json
+++ b/libs/language-server/capabilities/code-completion/tsconfig.lib.json
@@ -11,6 +11,9 @@
       "path": "../../../shared/schema/tsconfig.lib.json"
     },
     {
+      "path": "../../../shared/file-system/tsconfig.lib.json"
+    },
+    {
       "path": "../../workspace/tsconfig.lib.json"
     },
     {

--- a/libs/shared/npm/src/lib/local-nx-utils/read-json.ts
+++ b/libs/shared/npm/src/lib/local-nx-utils/read-json.ts
@@ -20,7 +20,7 @@ export async function readJsonFile<T>(
       expectComments: true,
     }) as any;
   } else {
-    const filePath = join(workspacePath, 'nx.json');
+    const filePath = join(workspacePath, jsonPath);
     const content = readFileSync(filePath, 'utf8');
     return JSON.parse(content);
   }

--- a/libs/shared/nx-workspace-info/src/lib/get-nx-version.ts
+++ b/libs/shared/nx-workspace-info/src/lib/get-nx-version.ts
@@ -2,6 +2,7 @@ import { findNxPackagePath } from '@nx-console/shared-npm';
 import { NxVersion } from '@nx-console/nx-version';
 import { coerce, SemVer } from 'semver';
 import { readFileSync } from 'node:fs';
+import { readAndParseJson } from '@nx-console/shared-file-system';
 
 let nxWorkspacePackageJsonVersion: string | undefined;
 let loadedNxPackage = false;
@@ -23,7 +24,8 @@ export async function getNxVersion(
       };
     }
 
-    nxWorkspacePackageJsonVersion = readVersionFromPackageJson(packagePath);
+    nxWorkspacePackageJsonVersion =
+      await readVersionFromPackageJson(packagePath);
     loadedNxPackage = true;
   }
 
@@ -57,9 +59,9 @@ export async function resetNxVersionCache() {
   nxWorkspacePackageJsonVersion = undefined;
 }
 
-function readVersionFromPackageJson(packagePath: string) {
+async function readVersionFromPackageJson(packagePath: string) {
   try {
-    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+    const packageJson = await readAndParseJson(packagePath);
     return packageJson.version;
   } catch (error) {
     return undefined;

--- a/libs/shared/telemetry/src/lib/google-analytics.ts
+++ b/libs/shared/telemetry/src/lib/google-analytics.ts
@@ -88,6 +88,9 @@ export class GoogleAnalytics {
       url,
       data: JSON.stringify(body),
       type: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
     })
       .then((response) => {
         if (this.mode !== 'production' && response.responseText.length > 0) {

--- a/libs/vscode/telemetry/src/lib/google-analytics-sender.ts
+++ b/libs/vscode/telemetry/src/lib/google-analytics-sender.ts
@@ -3,7 +3,7 @@ import { env, ExtensionContext, extensions, TelemetrySender } from 'vscode';
 
 import { onWorkspaceRefreshed } from '@nx-console/vscode-lsp-client';
 import { getNxVersion } from '@nx-console/vscode-nx-workspace';
-import { getOutputChannel } from '@nx-console/vscode-output-channels';
+import { vscodeLogger } from '@nx-console/vscode-output-channels';
 
 import Rollbar = require('rollbar/src/browser/rollbar');
 
@@ -30,10 +30,6 @@ export class GoogleAnalyticsSender implements TelemetrySender {
     private production: boolean,
     context: ExtensionContext,
   ) {
-    const logger = {
-      log: (message: string) => getOutputChannel().append(message),
-    };
-
     this.analytics = new GoogleAnalytics(
       this.production ? 'production' : 'debug_view',
       env.machineId,
@@ -41,7 +37,7 @@ export class GoogleAnalyticsSender implements TelemetrySender {
       env.sessionId,
       this._version,
       env.appName.toLowerCase().includes('cursor') ? 'cursor' : 'vscode',
-      logger,
+      vscodeLogger,
       this._nxVersion,
     );
 
@@ -74,7 +70,7 @@ export class GoogleAnalyticsSender implements TelemetrySender {
       return;
     }
 
-    getOutputChannel().appendLine(`Uncaught Exception: ${error}`);
+    vscodeLogger.log(`Uncaught Exception: ${error}`);
 
     const shouldLogToRollbar = this.production
       ? Math.floor(Math.random() * 5) === 0


### PR DESCRIPTION
- JSON parsing was falling back to `nx.json` which is just wrong
- we should use our JSON utilities more instead of using JSON.parse
- some folks are getting errors when sending telemetry events, the header should help