### PR TITLE
fix(vscode): show better error message if cipe fails with no runs

### DIFF
--- a/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
@@ -172,6 +172,18 @@ export class CIPETreeItem
 
         return items;
       }
+
+      // Pipeline completed but no runs have failed status - check if there are any runs at all
+      if (!this.cipe.runGroups.some((rg) => rg.runs && rg.runs.length > 0)) {
+        const statusMessage =
+          this.cipe.status === 'CANCELED'
+            ? 'CI pipeline was canceled'
+            : this.cipe.status === 'TIMED_OUT'
+              ? 'CI pipeline timed out'
+              : 'CI pipeline failed';
+        return [new LabelTreeItem(statusMessage)];
+      }
+      // If there are runs but none failed, fall through to show them
     }
 
     // In Progress CIPE


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Display a clear status message for completed CI pipelines with zero runs (canceled/timed out/failed).
> 
> - **VS Code Nx Cloud view**:
>   - Show explicit status label when a completed CI pipeline has no runs (`CANCELED`, `TIMED_OUT`, or generic failure), instead of showing nothing.
>   - Leave existing in-progress "waiting for Nx tasks" message unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55b77119214dc9505394256d7af06f97fcf79103. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->