### PR TITLE
fix(intellij): add timeout and ignore-scripts to intellij configure-ai-agents check

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/ai/PeriodicAiCheckService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/ai/PeriodicAiCheckService.kt
@@ -95,7 +95,10 @@ class PeriodicAiCheckService(private val project: Project, private val cs: Corou
             checkCommand.withEnvironment("NX_CONSOLE", "true")
             checkCommand.withEnvironment("NX_AI_FILES_USE_LOCAL", "true")
 
-            val output = withContext(Dispatchers.IO) { ExecUtil.execAndGetOutput(checkCommand) }
+            val output =
+                withContext(Dispatchers.IO) {
+                    withTimeout(360000L) { ExecUtil.execAndGetOutput(checkCommand) }
+                }
 
             if (output.stdout.contains("The following AI agents are out of date")) {
                 PropertiesComponent.getInstance(project)
@@ -124,7 +127,7 @@ class PeriodicAiCheckService(private val project: Project, private val cs: Corou
 
             val checkAllOutput =
                 withContext(Dispatchers.IO) {
-                    withTimeout(30000L) { ExecUtil.execAndGetOutput(checkAllCommand) }
+                    withTimeout(360000L) { ExecUtil.execAndGetOutput(checkAllCommand) }
                 }
 
             if (checkAllOutput.exitCode != 0) {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxGeneralCommandLine.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/NxGeneralCommandLine.kt
@@ -49,6 +49,7 @@ fun NxLatestVersionGeneralCommandLine(
         // Use npx nx@latest instead of the full binary path
         exePath = if (SystemInfo.isWindows) "npx.cmd" else "npx"
         addParameters("-y")
+        addParameters("--ignore-scripts")
         addParameters("nx@latest")
         addParameters(args)
         val workDirectory =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds 6-minute timeouts to AI agent check commands and invokes npx nx@latest with --ignore-scripts.
> 
> - **IntelliJ AI checks** (`apps/intellij/src/main/kotlin/dev/nx/console/ai/PeriodicAiCheckService.kt`):
>   - Wrap `ExecUtil.execAndGetOutput` for `configure-ai-agents --check` and `--check=all` with `withTimeout(360000L)`.
> - **Command execution** (`apps/intellij/src/main/kotlin/dev/nx/console/utils/NxGeneralCommandLine.kt`):
>   - In `NxLatestVersionGeneralCommandLine`, add `--ignore-scripts` to `npx -y nx@latest` invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 845f1289582f73c19db1d2f54c7f73a2597cfe8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->