### PR TITLE
feat(vscode): refresh cloud PR view when expanding it

### DIFF
--- a/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
+++ b/libs/vscode/nx-cloud-view/src/cloud-recent-cipe-view.ts
@@ -525,6 +525,11 @@ export class CloudRecentCIPEProvider extends AbstractTreeProvider<BaseRecentCIPE
     extensionContext.subscriptions.push(
       window.registerFileDecorationProvider(fileDecorationProvider),
       CloudRecentCIPEProvider.treeView,
+      CloudRecentCIPEProvider.treeView.onDidChangeVisibility((e) => {
+        if (e.visible) {
+          commands.executeCommand('nxCloud.refresh');
+        }
+      }),
       commands.registerCommand(
         'nxCloud.showCIPEInApp',
         async (treeItem: BaseRecentCIPETreeItem) => {


### PR DESCRIPTION
When the Cloud PR panel is closed and you open it, it doesn't refresh, only after you click the refresh icon. This PR fixes that.

<img width="443" height="111" alt="image" src="https://github.com/user-attachments/assets/c1e02f1e-1318-485d-9904-41c5fd159cbe" />
