### PR TITLE
chore(repo): re-enable nxls publishing

### DIFF
--- a/.github/workflows/publish-nxls.yml
+++ b/.github/workflows/publish-nxls.yml
@@ -42,4 +42,4 @@ jobs:
         run: |
           npx nx run nxls:build --skip-nx-cache
           cd dist/apps/nxls
-          npm publish --dry-run
+          npm publish


### PR DESCRIPTION
we're back to a state where things _should_ work so let's try without `--dry-run`

https://github.com/nrwl/nx-console/actions/runs/20270778085/job/58205727456