### PR TITLE
fix(vscode): escape html to fix PDV help script injection

### DIFF
--- a/libs/vscode/graph-base/src/load-graph-error-html.ts
+++ b/libs/vscode/graph-base/src/load-graph-error-html.ts
@@ -1,4 +1,5 @@
 import { NxError } from '@nx-console/shared-types';
+import { escapeHtml } from '@nx-console/vscode-utils';
 
 export function loadGraphErrorHtml(errors: NxError[]) {
   return /*html*/ `
@@ -13,7 +14,8 @@ export function loadGraphErrorHtml(errors: NxError[]) {
       <p>Unable to load the project graph. The following error occurred:</p>
       ${errors
         .map(
-          (error) => `<pre>${error.message ?? ''} \n ${error.stack ?? ''}</pre>`
+          (error) =>
+            `<pre>${escapeHtml(error.message ?? '')} \n ${escapeHtml(error.stack ?? '')}</pre>`,
         )
         .join('')}
     `;

--- a/libs/vscode/project-graph/src/legacy-implementation/load-html.ts
+++ b/libs/vscode/project-graph/src/legacy-implementation/load-html.ts
@@ -3,6 +3,7 @@ import {
   getProjectGraphOutput,
 } from '@nx-console/vscode-nx-workspace';
 import { vscodeLogger } from '@nx-console/vscode-output-channels';
+import { escapeHtml } from '@nx-console/vscode-utils';
 import { Uri, WebviewPanel, workspace } from 'vscode';
 import { MessageType } from './graph-message-type';
 import { gte } from '@nx-console/nx-version';
@@ -45,7 +46,7 @@ export function loadError(errorMessage: string | null) {
         }
       </style>
       <p>Unable to load the project graph. The following error occured:</p>
-      <pre>${errorMessage}</pre>
+      <pre>${escapeHtml(errorMessage)}</pre>
     `;
   }
   return html`

--- a/libs/vscode/utils/src/index.ts
+++ b/libs/vscode/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/abstract-tree-provider';
+export * from './lib/html-utils';
 export * from './lib/dependency-versioning';
 export * from './lib/empty-state-messages';
 export { getWorkspacePath } from './lib/get-workspace-path';

--- a/libs/vscode/utils/src/lib/html-utils.ts
+++ b/libs/vscode/utils/src/lib/html-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * HTML content escaping for text inside HTML elements.
+ * Prevents XSS by escaping characters that have special meaning in HTML.
+ */
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * JavaScript string escaping for values inside JS string literals.
+ * Use when embedding untrusted data inside JavaScript strings in templates.
+ */
+export function escapeJsString(unsafe: string): string {
+  return unsafe
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e');
+}
+
+/**
+ * Safe JSON embedding in script tags.
+ * Prevents injection attacks like </script> breaking out of script context.
+ */
+export function safeJsonStringify(data: unknown): string {
+  return escapeScriptTag(JSON.stringify(data));
+}
+
+/**
+ * Escapes < and > in already-serialized JSON for safe embedding in script tags.
+ * Use this when you have a pre-serialized JSON string.
+ */
+export function escapeScriptTag(serializedJson: string): string {
+  return serializedJson.replace(/</g, '\\u003c').replace(/>/g, '\\u003e');
+}


### PR DESCRIPTION
by throwing an error in a plugin, plugin authors could execute arbitrary code through the help callback in the PDV. Anything in those error messages is now escaped.