### PR TITLE
fix(nx-mcp): handle process suspension cases

### DIFF
--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -445,6 +445,12 @@ async function main() {
     mcpStdioConnected = true;
 
     transport.onclose = () => exitHandler('SIGINT');
+
+    // Handle stdin close (client disconnect) - the MCP SDK doesn't detect EOF
+    process.stdin.on('end', () => {
+      logger.log('stdin closed, shutting down...');
+      exitHandler('SIGINT');
+    });
   }
 
   // ensure the daemon is running if possible
@@ -482,6 +488,11 @@ async function main() {
   process.on('SIGTERM', () => {
     logger.log('Received SIGTERM signal. Server shutting down...');
     exitHandler('SIGTERM');
+  });
+
+  process.on('SIGHUP', () => {
+    logger.log('Received SIGHUP signal. Server shutting down...');
+    exitHandler('SIGHUP');
   });
 
   // Keep the process alive


### PR DESCRIPTION
nx-mcp processes were accumulating over time and blocking ports. 
                                                                                                                                                  
  1. stdin EOF not detected: The MCP SDK's StdioServerTransport only listens for data and error events on stdin—it doesn't handle the end event. When an MCP client disconnects (closing stdin), the server would hang forever waiting for input that would never come.                          
  2. SIGHUP not handled: When a terminal window is closed, SIGHUP is sent to foreground processes. Without a handler, Node.js terminates the process abruptly without running cleanup code, potentially leaving resources in an inconsistent state.                                          
      