### PR TITLE
fix: include system CA for fetch requests to enable talking to self-signed nx cloud instances

### DIFF
--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -24,6 +24,7 @@ import {
 } from '@nx-console/shared-telemetry';
 import { IIdeJsonRpcClient } from '@nx-console/shared-types';
 import {
+  configureCustomCACertificates,
   consoleLogger,
   killGroup,
   loadRootEnvFiles,
@@ -40,6 +41,8 @@ import { getPackageVersion } from './utils';
 import { ArgvType, createYargsConfig } from './yargs-config';
 
 async function main() {
+  configureCustomCACertificates();
+
   const argv = createYargsConfig(hideBin(process.argv)).parseSync() as ArgvType;
 
   const mcpServer = new McpServer(

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -37,6 +37,7 @@ import {
 } from '@nx-console/shared-nx-workspace-info';
 import { NxWorkspace } from '@nx-console/shared-types';
 import {
+  configureCustomCACertificates,
   formatError,
   killGroup,
   loadRootEnvFiles,
@@ -62,6 +63,8 @@ import {
 import { URI } from 'vscode-uri';
 import { ensureOnlyJsonRpcStdout } from './ensureOnlyJsonRpcStdout';
 import { registerRequests } from './requests';
+
+configureCustomCACertificates();
 
 const connection = createConnection(ProposedFeatures.all);
 

--- a/apps/vscode/src/main.ts
+++ b/apps/vscode/src/main.ts
@@ -12,7 +12,11 @@ import {
   workspace,
 } from 'vscode';
 
-import { killGroup, withTimeout } from '@nx-console/shared-utils';
+import {
+  configureCustomCACertificates,
+  killGroup,
+  withTimeout,
+} from '@nx-console/shared-utils';
 import {
   GlobalConfigurationStore,
   WorkspaceConfigurationStore,
@@ -86,6 +90,8 @@ let isNxWorkspace = false;
 let hasInitializedExtensionPoints = false;
 
 export async function activate(c: ExtensionContext) {
+  configureCustomCACertificates();
+
   try {
     vscodeLogger.log(`Activating Nx Console (pid ${process.pid})`);
     const startTime = Date.now();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts Node’s default TLS trust store at process startup, which can change how all outbound HTTPS requests are validated (especially in environments with custom/system CAs). The change is guarded to no-op on older Node versions, but still affects network/security behavior when supported.
> 
> **Overview**
> Ensures outbound `fetch()` calls can connect to Nx Cloud instances secured with system-installed/self-signed certificates by merging OS-trusted CAs into Node’s default CA store (Node 22+), with a silent no-op fallback otherwise.
> 
> Invokes `configureCustomCACertificates()` at startup in the VS Code extension, `nxls`, and `nx-mcp` so all network requests in these processes use the updated trust store.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 263123c76951850deaecad1a4d58579eee636365. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->