### PR TITLE
chore(gradle): remove incremental cache from compileKotlin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,12 @@ allprojects {
     plugin("org.jetbrains.kotlin.jvm")
     plugin("org.jetbrains.kotlin.plugin.serialization")
   }
+
+  tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    compilerOptions {
+      incremental = System.getenv("CI") == null
+    }
+  }
 }
 
 tasks {

--- a/nx.json
+++ b/nx.json
@@ -154,7 +154,7 @@
   "defaultBase": "master",
   "nxCloudUrl": "https://snapshot.nx.app",
   "nxCloudId": "697890bce47a1e5245e880ad",
-  "bust": 2,
+  "bust": 4,
   "release": {
     "version": {
       "preVersionCommand": "node ./tools/scripts/ensure-release-branch.js"


### PR DESCRIPTION
Nx caches task outputs to speed up future runs. When compileKotlin runs, its output directory (dist/apps/intellij/kotlin/compileKotlin/) gets cached, including the caches-jvm subdirectory.
  This caches-jvm directory contains Kotlin's incremental compilation cache - files like class-attributes.tab, supertypes.tab, etc. that track internal state tied to a specific Kotlin daemon
  session.

  When a later CI run (or a different agent) restores this cached output, a new Kotlin daemon starts and tries to use those .tab files. But the files contain registration data from the old
  daemon, so the new daemon fails with "Storage already registered."
  
Turn off incremental caching when in CI

Closes NXC-3777