### PR TITLE
fix(nx-mcp): make polygraph tools opt-in for now

### DIFF
--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -121,6 +121,16 @@ async function main() {
     logger.log('Minimal mode enabled, hiding workspace analysis tools');
   }
 
+  // When --experimental-polygraph is not set (default), exclude polygraph tools
+  if (!argv.experimentalPolygraph) {
+    const polygraphExcludedTools = ['!cloud_polygraph_*'];
+    toolsFilter = toolsFilter
+      ? [...toolsFilter, ...polygraphExcludedTools]
+      : polygraphExcludedTools;
+  } else {
+    logger.log('Experimental Polygraph tools enabled');
+  }
+
   if (toolsFilter && toolsFilter.length > 0) {
     logger.log(`Tools filter: ${toolsFilter.join(', ')}`);
   }

--- a/apps/nx-mcp/src/yargs-config.ts
+++ b/apps/nx-mcp/src/yargs-config.ts
@@ -11,6 +11,7 @@ export interface ArgvType {
   debugLogs: boolean;
   tools?: string | string[];
   minimal: boolean;
+  experimentalPolygraph: boolean;
   _: (string | number)[];
   $0: string;
   [x: string]: unknown;
@@ -77,6 +78,12 @@ export function createYargsConfig(args: string[]): Argv<any> {
     .option('minimal', {
       describe:
         'Hide workspace analysis tools (nx_available_plugins, nx_workspace_path, nx_workspace, nx_project_details, nx_generators, nx_generator_schema)',
+      type: 'boolean',
+      default: false,
+    })
+    .option('experimental-polygraph', {
+      describe:
+        'Enable experimental Polygraph tools for multi-repo orchestration',
       type: 'boolean',
       default: false,
     })

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud-polygraph.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud-polygraph.ts
@@ -207,7 +207,12 @@ export function registerPolygraphTools(
   toolsFilter?: string[],
 ) {
   const nxCloudClient = getCloudLightClient(logger, workspacePath);
-  if (nxCloudClient == null) return;
+  if (nxCloudClient == null) {
+    logger.log(
+      'Polygraph tools not registered: could not load Nx Cloud light client',
+    );
+    return;
+  }
   registerInit(toolsFilter, logger, registry, nxCloudClient, workspacePath);
   registerDelegate(toolsFilter, logger, registry, workspacePath, nxCloudClient);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only gates tool registration behind a new CLI flag and improves logging when the Nx Cloud light client is unavailable; no core execution flow or data handling is altered.
> 
> **Overview**
> Polygraph MCP tools are now *opt-in* by default: `main.ts` automatically adds `!cloud_polygraph_*` to the tools filter unless `--experimental-polygraph` is provided.
> 
> Adds the `--experimental-polygraph` CLI option in `yargs-config.ts`, and improves diagnostics in `registerPolygraphTools` by logging when Polygraph tools are skipped due to a missing Nx Cloud light client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0efeb44001444d2021d99aa32479ad8dbf5bf04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->