### PR TITLE
fix(nxls): enable passing explicit branch to getRecentCIPEs

### DIFF
--- a/apps/nx-mcp/src/main.ts
+++ b/apps/nx-mcp/src/main.ts
@@ -166,8 +166,8 @@ async function main() {
     },
     isNxCloudEnabled: async () =>
       nxWorkspacePath ? await isNxCloudUsed(nxWorkspacePath) : false,
-    getRecentCIPEData: async (workspacePath, logger) =>
-      await getRecentCIPEData(workspacePath, logger),
+    getRecentCIPEData: async (workspacePath, logger, options) =>
+      await getRecentCIPEData(workspacePath, logger, options),
   };
 
   // Detect if IDE is running and create IDE client if available

--- a/apps/nxls/src/requests.ts
+++ b/apps/nxls/src/requests.ts
@@ -337,7 +337,7 @@ export function registerRequests(
     return await getPDVData(WORKING_PATH, args.filePath);
   });
 
-  connection.onRequest(NxRecentCIPEDataRequest, async () => {
+  connection.onRequest(NxRecentCIPEDataRequest, async (params) => {
     const WORKING_PATH = getWorkingPath();
     if (!WORKING_PATH) {
       return new ResponseError(
@@ -346,7 +346,7 @@ export function registerRequests(
       );
     }
 
-    return await getRecentCIPEData(WORKING_PATH, lspLogger);
+    return await getRecentCIPEData(WORKING_PATH, lspLogger, params);
   });
 
   connection.onRequest(

--- a/libs/language-server/types/src/index.ts
+++ b/libs/language-server/types/src/index.ts
@@ -209,7 +209,7 @@ export const NxPDVDataRequest: RequestType<
 > = new RequestType('nx/pdvData');
 
 export const NxRecentCIPEDataRequest: RequestType<
-  undefined,
+  { branch?: string } | undefined,
   { info?: CIPEInfo[]; error?: CIPEInfoError; workspaceUrl?: string },
   unknown
 > = new RequestType('nx/recentCIPEData');

--- a/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server-wrapper.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/nx-mcp-server-wrapper.ts
@@ -48,6 +48,7 @@ export interface NxWorkspaceInfoProvider {
   getRecentCIPEData?: (
     workspacePath: string,
     logger: Logger,
+    options?: { branch?: string },
   ) => Promise<{
     info?: CIPEInfo[];
     error?: CIPEInfoError;

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -841,8 +841,10 @@ const getCIInformation =
       }
     }
 
-    // Fetch CIPE data for recent branches
-    const cipeResult = await getRecentCIPEData(workspacePath, logger);
+    // Fetch CIPE data for recent branches, always include the target branch
+    const cipeResult = await getRecentCIPEData(workspacePath, logger, {
+      branch,
+    });
 
     if (cipeResult.error) {
       return {
@@ -862,7 +864,7 @@ const getCIInformation =
     );
 
     if (!cipeForBranch) {
-      const message = `No CI pipeline execution found for branch "${branch}". This branch may not be checked out locally or may not have any recent CI runs.`;
+      const message = `No CI pipeline execution found for branch "${branch}". This branch may not have any CI runs yet.`;
       return {
         content: [{ type: 'text', text: message }],
         structuredContent: {
@@ -1319,7 +1321,9 @@ const handleUpdateSelfHealingFix =
         };
       }
 
-      const cipeResult = await getRecentCIPEData(workspacePath, logger);
+      const cipeResult = await getRecentCIPEData(workspacePath, logger, {
+        branch,
+      });
       if (cipeResult.error) {
         const output: UpdateSelfHealingFixOutput = {
           success: false,

--- a/libs/vscode/mcp/src/lib/data-providers.ts
+++ b/libs/vscode/mcp/src/lib/data-providers.ts
@@ -24,9 +24,9 @@ export const nxWorkspaceInfoProvider: NxWorkspaceInfoProvider = {
   },
   isNxCloudEnabled: async () =>
     await isNxCloudUsed(getNxWorkspacePath(), vscodeLogger),
-  getRecentCIPEData: async () => {
+  getRecentCIPEData: async (_workspacePath, _logger, options) => {
     // Route through nxls - getRecentCIPEData from vscode-nx-workspace already does this
-    const result = await getRecentCIPEData();
+    const result = await getRecentCIPEData(options);
     return (
       result || { error: { type: 'other', message: 'Unable to get CIPE data' } }
     );

--- a/libs/vscode/nx-workspace/src/lib/get-recent-cipe-data.ts
+++ b/libs/vscode/nx-workspace/src/lib/get-recent-cipe-data.ts
@@ -2,8 +2,8 @@ import { NxRecentCIPEDataRequest } from '@nx-console/language-server-types';
 import { CIPEInfo, CIPEInfoError } from '@nx-console/shared-types';
 import { getNxlsClient } from '@nx-console/vscode-lsp-client';
 
-export async function getRecentCIPEData(): Promise<
-  { info?: CIPEInfo[]; error?: CIPEInfoError } | undefined
-> {
-  return await getNxlsClient().sendRequest(NxRecentCIPEDataRequest, undefined);
+export async function getRecentCIPEData(options?: {
+  branch?: string;
+}): Promise<{ info?: CIPEInfo[]; error?: CIPEInfoError } | undefined> {
+  return await getNxlsClient().sendRequest(NxRecentCIPEDataRequest, options);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk API propagation change; behavior mainly affects Nx Cloud CIPE lookups and caching, with a small chance of increased request volume when callers pass a branch explicitly.
> 
> **Overview**
> Enables callers to request `nx/recentCIPEData` for a specific branch by threading an optional `{ branch }` parameter through `NxRecentCIPEDataRequest`, NxLS request handling, and MCP/VSCode providers.
> 
> Updates `getRecentCIPEData` to **always include the explicit branch** in the Nx Cloud query and to **bypass/avoid caching** when a branch is explicitly requested, improving correctness for branches not present in the local “recent branches” list. Nx MCP Nx Cloud tools now pass the target branch explicitly and slightly simplify the “no CIPE found” message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dedb91909804f3e7c44bfd3f8e056fbd215e5887. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->