### PR TITLE
feat(vscode): add button to give more information on WHY daemon was disabled

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -220,6 +220,11 @@
           "command": "nxConsole.restartDaemonWatcher",
           "when": "view == nxProjects && viewItem == daemonWatcherNotRunning",
           "group": "inline@1"
+        },
+        {
+          "command": "nxConsole.showDaemonDisabledReason",
+          "when": "view == nxProjects && viewItem == daemonDisabled",
+          "group": "inline@1"
         }
       ],
       "editor/title": [
@@ -329,6 +334,10 @@
         },
         {
           "command": "nxCloud.openFixDetails",
+          "when": "false"
+        },
+        {
+          "command": "nxConsole.showDaemonDisabledReason",
           "when": "false"
         },
         {
@@ -709,6 +718,12 @@
         "title": "Restart Daemon Watcher",
         "command": "nxConsole.restartDaemonWatcher",
         "icon": "$(refresh)"
+      },
+      {
+        "category": "Nx",
+        "title": "Show Daemon Disabled Reason",
+        "command": "nxConsole.showDaemonDisabledReason",
+        "icon": "$(eye)"
       },
       {
         "category": "Nx Migrate",

--- a/libs/shared/nx-workspace-info/src/index.ts
+++ b/libs/shared/nx-workspace-info/src/index.ts
@@ -2,4 +2,7 @@ export * from './lib/get-nx-version';
 export * from './lib/workspace';
 export * from './lib/get-generators';
 export * from './lib/get-executors';
-export { getNxDaemonClient } from './lib/get-nx-workspace-package';
+export {
+  getNxDaemonClient,
+  getNxCacheDirectory,
+} from './lib/get-nx-workspace-package';

--- a/libs/shared/nx-workspace-info/src/lib/get-nx-workspace-package.ts
+++ b/libs/shared/nx-workspace-info/src/lib/get-nx-workspace-package.ts
@@ -4,6 +4,7 @@ import type * as NxProjectGraphFileUtils from 'nx/src/project-graph/file-map-uti
 import type * as NxDaemonClient from 'nx/src/daemon/client/client';
 import type * as NxDaemonCache from 'nx/src/daemon/cache';
 import type * as NxOutput from 'nx/src/utils/output';
+import type * as NxCacheDirectory from 'nx/src/utils/cache-directory';
 import { join } from 'path';
 import {
   findNxPackagePath,
@@ -43,6 +44,22 @@ export async function getNxOutput(
   const importPath = await findNxPackagePath(
     workspacePath,
     join('src', 'utils', 'output.js'),
+  );
+
+  if (!importPath) {
+    return;
+  }
+
+  return getNxPackage(importPath, logger);
+}
+
+export async function getNxCacheDirectory(
+  workspacePath: string,
+  logger: Logger,
+): Promise<typeof NxCacheDirectory | undefined> {
+  const importPath = await findNxPackagePath(
+    workspacePath,
+    join('src', 'utils', 'cache-directory.js'),
   );
 
   if (!importPath) {

--- a/libs/vscode/nx-project-view/tsconfig.lib.json
+++ b/libs/vscode/nx-project-view/tsconfig.lib.json
@@ -19,10 +19,13 @@
       "path": "../tasks/tsconfig.lib.json"
     },
     {
-      "path": "../configuration/tsconfig.lib.json"
+      "path": "../../shared/types/tsconfig.lib.json"
     },
     {
-      "path": "../../shared/types/tsconfig.lib.json"
+      "path": "../../shared/nx-workspace-info/tsconfig.lib.json"
+    },
+    {
+      "path": "../configuration/tsconfig.lib.json"
     },
     {
       "path": "../output-channels/tsconfig.lib.json"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new VS Code command behavior that relies on Nx internal `cache-directory` module paths to locate daemon state/log files, which may vary across Nx versions. Failures are mostly user-facing (missing file/module) and handled with an error prompt.
> 
> **Overview**
> Adds a new VS Code command, `nxConsole.showDaemonDisabledReason`, exposed as an inline action when the Projects view reports `daemonDisabled`, to open the daemon `disabled` marker file (or fall back to `daemon.log`) in the editor and offer a one-click daemon restart if nothing is found.
> 
> Extends `@nx-console/shared-nx-workspace-info` with `getNxCacheDirectory()` to dynamically load Nx’s `cache-directory` utilities and uses that to resolve the workspace’s daemon directory; updates `nx-project-view` TS project references accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afd67b5fbfcf1693acf9d0c129945df520fa1025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->