### PR TITLE
fix(nxls): fix projectsByPaths request that was dropped during refactor

### DIFF
--- a/apps/nxls-e2e/src/projects-by-paths/projects-by-paths.default.test.ts
+++ b/apps/nxls-e2e/src/projects-by-paths/projects-by-paths.default.test.ts
@@ -1,0 +1,88 @@
+import { NxProjectsByPathsRequest } from '@nx-console/language-server-types';
+import {
+  defaultVersion,
+  e2eCwd,
+  newWorkspace,
+  uniq,
+} from '@nx-console/shared-e2e-utils';
+import type { ProjectConfiguration } from 'nx/src/devkit-exports';
+import { join } from 'path';
+import { NxlsWrapper } from '../nxls-wrapper';
+
+let nxlsWrapper: NxlsWrapper;
+const workspaceName = uniq('workspace');
+
+describe('projects by paths', () => {
+  beforeAll(async () => {
+    newWorkspace({
+      name: workspaceName,
+      options: {
+        preset: 'react-monorepo',
+        bundler: 'vite',
+        e2eTestRunner: 'cypress',
+        style: 'css',
+      },
+      version: defaultVersion,
+    });
+
+    nxlsWrapper = new NxlsWrapper();
+    await nxlsWrapper.startNxls(join(e2eCwd, workspaceName));
+  });
+
+  it('should return projects for multiple paths', async () => {
+    const appPackageJson = join(
+      e2eCwd,
+      workspaceName,
+      'apps',
+      workspaceName,
+      'package.json',
+    );
+
+    const e2ePackageJson = join(
+      e2eCwd,
+      workspaceName,
+      'apps',
+      `${workspaceName}-e2e`,
+      'package.json',
+    );
+
+    const result = await nxlsWrapper.sendRequest({
+      ...NxProjectsByPathsRequest,
+      params: {
+        paths: [appPackageJson, e2ePackageJson],
+      },
+    });
+
+    const projectsMap = result.result as {
+      [path: string]: ProjectConfiguration | undefined;
+    };
+
+    expect(projectsMap[appPackageJson]?.name).toEqual(
+      `@${workspaceName}/${workspaceName}`,
+    );
+    expect(projectsMap[e2ePackageJson]?.name).toEqual(
+      `@${workspaceName}/${workspaceName}-e2e`,
+    );
+  });
+
+  it('should return undefined for paths not in any project', async () => {
+    const nxJson = join(e2eCwd, workspaceName, 'nx.json');
+
+    const result = await nxlsWrapper.sendRequest({
+      ...NxProjectsByPathsRequest,
+      params: {
+        paths: [nxJson],
+      },
+    });
+
+    const projectsMap = result.result as {
+      [path: string]: ProjectConfiguration | undefined;
+    };
+
+    expect(projectsMap[nxJson]).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    return await nxlsWrapper.stopNxls();
+  });
+});

--- a/apps/nxls/src/requests.ts
+++ b/apps/nxls/src/requests.ts
@@ -16,6 +16,7 @@ import {
   NxProjectByRootRequest,
   NxProjectFolderTreeRequest,
   NxProjectGraphOutputRequest,
+  NxProjectsByPathsRequest,
   NxRecentCIPEDataRequest,
   NxSourceMapFilesToProjectsMapRequest,
   NxStartDaemonRequest,
@@ -38,6 +39,7 @@ import {
   getProjectByRoot,
   getProjectFolderTree,
   getProjectGraphOutput,
+  getProjectsByPaths,
   getSourceMapFilesToProjectsMap,
   getStartupMessage,
   getTargetsForConfigFile,
@@ -161,6 +163,20 @@ export function registerRequests(
         );
       }
       return await getProjectByRoot(args.projectRoot, WORKING_PATH);
+    },
+  );
+
+  connection.onRequest(
+    NxProjectsByPathsRequest,
+    async (args: { paths: string[] }) => {
+      const WORKING_PATH = getWorkingPath();
+      if (!WORKING_PATH) {
+        return new ResponseError(
+          1000,
+          'Unable to get Nx info: no workspace path',
+        );
+      }
+      return await getProjectsByPaths(args.paths, WORKING_PATH);
     },
   );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: restores a previously dropped language-server request handler and adds an e2e test to prevent regressions; no auth, persistence, or protocol changes beyond wiring.
> 
> **Overview**
> Restores support for `NxProjectsByPathsRequest` in `apps/nxls/src/requests.ts` by registering a request handler that validates `WORKING_PATH` and delegates to `getProjectsByPaths`.
> 
> Adds a new e2e spec (`projects-by-paths.default.test.ts`) that creates a workspace and verifies the request returns the expected project mapping for multiple file paths, and `undefined` for paths outside any project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b59710af0973d8127749146bf5e0aeecf05b8af0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->