### PR TITLE
feat(nx-mcp): add new tools for polygraph

### DIFF
--- a/libs/shared/llm-context/src/lib/tool-names.ts
+++ b/libs/shared/llm-context/src/lib/tool-names.ts
@@ -35,3 +35,11 @@ export const UPDATE_SELF_HEALING_FIX = 'update_self_healing_fix';
 export const CLOUD_POLYGRAPH_INIT = 'cloud_polygraph_init';
 
 export const CLOUD_POLYGRAPH_DELEGATE = 'cloud_polygraph_delegate';
+
+export const CLOUD_POLYGRAPH_PUSH_BRANCH = 'cloud_polygraph_push_branch';
+
+export const CLOUD_POLYGRAPH_CREATE_PRS = 'cloud_polygraph_create_prs';
+
+export const CLOUD_POLYGRAPH_QUERY_PRS = 'cloud_polygraph_query_prs';
+
+export const CLOUD_POLYGRAPH_MARK_READY = 'cloud_polygraph_mark_ready';


### PR DESCRIPTION
- Add tool name constants for push, create-prs, query-prs, mark-ready
- Register cloud_polygraph_push_branch tool for git push operations
- Register cloud_polygraph_create_prs tool for batch PR creation
- Register cloud_polygraph_query_prs tool for PR status queries
- Register cloud_polygraph_mark_ready tool for marking drafts ready
- All tools gated by --experimentalPolygraph flag (cloud_polygraph_* pattern)
- All tools call client-bundle handlers via getCloudLightClient
- Zod schemas provide input validation for each tool
