### PR TITLE
fix(nx-mcp): transform record-command taskIds to actual command

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -335,7 +335,13 @@ export const renderCipeDetails = (cipe: CIPEInfo): string => {
 
       lines.push(runPrompt);
       for (const task of run.failedTasks ?? []) {
-        lines.push(`      ---- Failed Task: ${task}`);
+        // Transform record-command tasks to use the actual command for better understanding
+        const displayTask =
+          task === 'upload-run-result:record-command' ||
+          task === 'nx-cloud-tasks-runner:record-command'
+            ? run.command
+            : task;
+        lines.push(`      ---- Failed Task: ${displayTask}`);
       }
       if (run.status === 'CANCELED') {
         lines.push(
@@ -904,7 +910,18 @@ const getCIInformation =
     for (const runGroup of cipeForBranch.runGroups) {
       for (const run of runGroup.runs) {
         if (run.failedTasks) {
-          failedTaskIds.push(...run.failedTasks);
+          for (const taskId of run.failedTasks) {
+            // Transform record-command tasks to use the actual command for better agent understanding
+            // These taskIds are internal placeholders - the real command is in run.command
+            if (
+              taskId === 'upload-run-result:record-command' ||
+              taskId === 'nx-cloud-tasks-runner:record-command'
+            ) {
+              failedTaskIds.push(run.command);
+            } else {
+              failedTaskIds.push(taskId);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
NXA-891

When collecting failedTaskIds from CIPE runs, transform the generic 'upload-run-result:record-command' and 'nx-cloud-tasks-runner:record-command' task IDs to use the actual run.command (e.g., 'nx-cloud record -- nx format:check'). This prevents the agent from misclassifying record command failures as Nx Cloud infrastructure issues when they're actually user command failures.