### PR TITLE
chore(repo): add NX_POWERPACK_DISABLE env var to shared global cache inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -68,6 +68,7 @@
     ],
     "sharedGlobals": [
       { "runtime": "node -p '`${process.platform}_${process.arch}`'" },
+      { "env": "NX_POWERPACK_DISABLE" },
       "{workspaceRoot}/.env"
     ],
     "scripts": ["{workspaceRoot}/tools/scripts/**"]


### PR DESCRIPTION
## Summary
- Add `NX_POWERPACK_DISABLE` env var to shared global cache inputs in `nx.json`
- This ensures the Nx cache is invalidated when users toggle this env var
- Prevents subtle caching issues when switching between enterprise and non-enterprise modes
