### PR TITLE
fix(nx-mcp): handle missing client bundle gracefully in polygraph tools

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud-polygraph.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud-polygraph.ts
@@ -20,6 +20,16 @@ import {
   nxCloudAuthHeaders,
 } from '@nx-console/shared-nx-cloud';
 
+const CLOUD_CLIENT_MISSING_RESULT: CallToolResult = {
+  content: [
+    {
+      type: 'text',
+      text: 'The Nx Cloud client bundle is missing. Run `npx nx@latest download-cloud-client` to install it.',
+    },
+  ],
+  isError: true,
+};
+
 const polygraphInitSchema = z.object({
   setSessionId: z
     .string()
@@ -132,6 +142,10 @@ function registerInit(
         openWorldHint: true,
       },
       handler: async (params): Promise<CallToolResult> => {
+        if (typeof nxCloudClient?.polygraphInit !== 'function') {
+          return CLOUD_CLIENT_MISSING_RESULT;
+        }
+
         const sessionId =
           params.setSessionId ??
           process.env.CLAUDE_CODE_SESSION_ID ??
@@ -180,6 +194,10 @@ function registerDelegate(
         openWorldHint: true,
       },
       handler: async (params): Promise<CallToolResult> => {
+        if (typeof nxCloudClient?.polygraphDelegate !== 'function') {
+          return CLOUD_CLIENT_MISSING_RESULT;
+        }
+
         try {
           const delegateParams = { ...params, workspacePath };
           logger.log(
@@ -237,6 +255,10 @@ function registerPushBranch(
         openWorldHint: true,
       },
       handler: async (params): Promise<CallToolResult> => {
+        if (typeof nxCloudClient?.polygraphPushBranch !== 'function') {
+          return CLOUD_CLIENT_MISSING_RESULT;
+        }
+
         const { sessionId, repoPath, branch } = params;
 
         try {
@@ -319,6 +341,10 @@ function registerCreatePRs(
         openWorldHint: true,
       },
       handler: async (params): Promise<CallToolResult> => {
+        if (typeof nxCloudClient?.polygraphCreatePRs !== 'function') {
+          return CLOUD_CLIENT_MISSING_RESULT;
+        }
+
         const { sessionId, prs } = params as z.infer<typeof createPRsSchema>;
 
         try {
@@ -401,6 +427,10 @@ function registerGetSession(
         openWorldHint: true,
       },
       handler: async (params): Promise<CallToolResult> => {
+        if (typeof nxCloudClient?.polygraphGetSession !== 'function') {
+          return CLOUD_CLIENT_MISSING_RESULT;
+        }
+
         const { sessionId } = params;
 
         try {
@@ -464,6 +494,10 @@ function registerMarkReady(
         openWorldHint: true,
       },
       handler: async (params): Promise<CallToolResult> => {
+        if (typeof nxCloudClient?.polygraphMarkReady !== 'function') {
+          return CLOUD_CLIENT_MISSING_RESULT;
+        }
+
         const { sessionId, prUrls } = params;
 
         try {
@@ -520,13 +554,6 @@ export function registerPolygraphTools(
 ) {
   const nxCloudClient = getCloudLightClient(logger, workspacePath);
 
-  // TODO(cammisuli): have a way to download the client automatically if not present
-  if (nxCloudClient == null) {
-    logger.log(
-      'Polygraph tools not registered: could not load Nx Cloud light client',
-    );
-    return;
-  }
   registerInit(toolsFilter, logger, registry, nxCloudClient, workspacePath);
   registerDelegate(toolsFilter, logger, registry, workspacePath, nxCloudClient);
   registerPushBranch(


### PR DESCRIPTION
## Summary

Instead of silently not registering polygraph tools when the Nx Cloud client bundle is missing, tools are now always registered but each handler returns a helpful error message. This improves the user experience by providing clear guidance on what to do when the client bundle is missing.

## Changes

- Added `CLOUD_CLIENT_MISSING_RESULT` constant with error message
- Removed early return in `registerPolygraphTools` that prevented tool registration when client was null
- Added guard checks in all 6 handler functions (`registerInit`, `registerDelegate`, `registerPushBranch`, `registerCreatePRs`, `registerGetSession`, `registerMarkReady`) that return the error when client function is unavailable
- Tools will now always be available but gracefully handle the missing client case

## Test plan

- Verify that when Nx Cloud client bundle is missing, polygraph tools are registered
- Verify that calling any polygraph tool without the client bundle returns the helpful error message directing users to run `npx nx@latest download-cloud-client`
- Verify that tools work normally when the client bundle is present