### PR TITLE
fix(intellij): replace deprecated ReadAction.nonBlocking(Runnable)

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGeneratorSearchEverywhereContributorFactory.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGeneratorSearchEverywhereContributorFactory.kt
@@ -83,7 +83,9 @@ class NxGeneratorSearchEverywhereContributor(private val event: AnActionEvent) :
         if (ApplicationManager.getApplication().isDispatchThread) {
             ApplicationManager.getApplication().runReadAction(task)
         } else {
-            ReadAction.nonBlocking(task).wrapProgress(progressIndicator).executeSynchronously()
+            ReadAction.nonBlocking<Unit> { task.run() }
+                .wrapProgress(progressIndicator)
+                .executeSynchronously()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `ReadAction.nonBlocking(Runnable)` with `nonBlocking(Callable<Unit>)` in `NxGeneratorSearchEverywhereContributorFactory`
