### PR TITLE
feat(nx-mcp): add hints and structured fields to MCP tool outputs

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -998,9 +998,20 @@ const getCIInformation =
     }
 
     // Build disclaimer if we retrieved a different CIPE than the URL pointed to
+    const retrievedDifferentCipeDisclaimer = ` The URL pointed to an older CI Pipeline Execution. Showing the most recent CI information for branch "${branch}" instead.`;
     const disclaimer = retrievedDifferentCipe
-      ? `**Note:** The URL pointed to an older CI Pipeline Execution. Showing the most recent CI information for branch "${branch}" instead.\n\n`
+      ? `**Note:** ${retrievedDifferentCipeDisclaimer} \n\n`
       : '';
+
+    // Build hints for structured content
+    const hints: string[] = [];
+    if (retrievedDifferentCipe) {
+      hints.push(retrievedDifferentCipeDisclaimer);
+    }
+    hints.push(
+      'remoteTaskSummary contains output from tasks that ran on CI machines. localTaskSummary contains output from the self-healing agent machine.',
+    );
+    output.hints = hints;
 
     // Branch based on select parameter
     if (!params.select) {
@@ -1284,6 +1295,7 @@ const handleUpdateSelfHealingFix =
     });
 
     let aiFixId = params.aiFixId;
+    let resolvedShortLink: string | null = params.shortLink ?? null;
 
     // If shortLink provided, extract the aiFixId from the fix diff API
     if (!aiFixId && params.shortLink) {
@@ -1292,6 +1304,9 @@ const handleUpdateSelfHealingFix =
         const output: UpdateSelfHealingFixOutput = {
           success: false,
           message: `Invalid shortLink format: ${params.shortLink}. Expected format like "abc123-def456".`,
+          aiFixId: null,
+          action: params.action,
+          shortLink: resolvedShortLink,
         };
         return {
           content: [{ type: 'text', text: output.message }],
@@ -1311,6 +1326,9 @@ const handleUpdateSelfHealingFix =
         const output: UpdateSelfHealingFixOutput = {
           success: false,
           message: `Failed to retrieve fix from shortLink: ${fixResult.error?.message ?? 'aiFixId not found'}`,
+          aiFixId: null,
+          action: params.action,
+          shortLink: resolvedShortLink,
         };
         return {
           content: [{ type: 'text', text: output.message }],
@@ -1330,6 +1348,9 @@ const handleUpdateSelfHealingFix =
           success: false,
           message:
             'Could not determine the current git branch. Please provide aiFixId, shortLink, or branch explicitly.',
+          aiFixId: null,
+          action: params.action,
+          shortLink: null,
         };
         return {
           content: [{ type: 'text', text: output.message }],
@@ -1345,6 +1366,9 @@ const handleUpdateSelfHealingFix =
         const output: UpdateSelfHealingFixOutput = {
           success: false,
           message: `Failed to retrieve CI information: ${cipeResult.error.message}`,
+          aiFixId: null,
+          action: params.action,
+          shortLink: null,
         };
         return {
           content: [{ type: 'text', text: output.message }],
@@ -1361,6 +1385,9 @@ const handleUpdateSelfHealingFix =
         const output: UpdateSelfHealingFixOutput = {
           success: false,
           message: `No CI pipeline execution found for branch "${branch}".`,
+          aiFixId: null,
+          action: params.action,
+          shortLink: null,
         };
         return {
           content: [{ type: 'text', text: output.message }],
@@ -1382,6 +1409,9 @@ const handleUpdateSelfHealingFix =
         const output: UpdateSelfHealingFixOutput = {
           success: false,
           message: `No AI fix found for branch "${branch}".`,
+          aiFixId: null,
+          action: params.action,
+          shortLink: null,
         };
         return {
           content: [{ type: 'text', text: output.message }],
@@ -1391,6 +1421,7 @@ const handleUpdateSelfHealingFix =
       }
 
       aiFixId = aiFix.aiFixId;
+      resolvedShortLink = aiFix.shortLink ?? null;
     }
 
     // Map APPLY/REJECT/RERUN_ENVIRONMENT_STATE to APPLIED/REJECTED/RERUN_REQUESTED
@@ -1413,6 +1444,9 @@ const handleUpdateSelfHealingFix =
       const output: UpdateSelfHealingFixOutput = {
         success: false,
         message: `Failed to ${params.action.toLowerCase()} fix: ${result.error?.message ?? 'Unknown error'}`,
+        aiFixId,
+        action: params.action,
+        shortLink: resolvedShortLink,
       };
       return {
         content: [{ type: 'text', text: output.message }],
@@ -1427,9 +1461,19 @@ const handleUpdateSelfHealingFix =
         : params.action === 'RERUN_ENVIRONMENT_STATE'
           ? 'requested rerun for'
           : 'rejected';
+    const hints: string[] = [];
+    if (resolvedShortLink && params.action !== 'APPLY') {
+      hints.push(
+        `Use the shortLink '${resolvedShortLink}' to apply this fix via the update_self_healing_fix tool.`,
+      );
+    }
     const output: UpdateSelfHealingFixOutput = {
       success: true,
       message: `Successfully ${actionVerb} the fix (aiFixId: ${aiFixId}).`,
+      aiFixId,
+      action: params.action,
+      shortLink: resolvedShortLink,
+      ...(hints.length > 0 ? { hints } : {}),
     };
     return {
       content: [{ type: 'text', text: output.message }],

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
@@ -53,12 +53,17 @@ export interface CIInformationOutput {
   confidence: number | null;
   confidenceReasoning: string | null;
   error: string | null;
+  hints?: string[];
   [key: string]: unknown;
 }
 
 export interface UpdateSelfHealingFixOutput {
   success: boolean;
   message: string;
+  aiFixId?: string | null;
+  action?: string | null;
+  shortLink?: string | null;
+  hints?: string[];
   [key: string]: unknown;
 }
 
@@ -67,6 +72,13 @@ export const updateSelfHealingFixOutputSchema = {
   properties: {
     success: { type: 'boolean' },
     message: { type: 'string' },
+    aiFixId: { type: ['string', 'null'] },
+    action: {
+      type: ['string', 'null'],
+      enum: ['APPLY', 'REJECT', 'RERUN_ENVIRONMENT_STATE', null],
+    },
+    shortLink: { type: ['string', 'null'] },
+    hints: { type: 'array', items: { type: 'string' } },
   },
   required: ['success', 'message'],
 };
@@ -142,6 +154,7 @@ export const ciInformationOutputSchema = {
     confidence: { type: ['number', 'null'] },
     confidenceReasoning: { type: ['string', 'null'] },
     error: { type: ['string', 'null'] },
+    hints: { type: 'array', items: { type: 'string' } },
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `hints` string array to `CIInformationOutput` and `UpdateSelfHealingFixOutput` structured content schemas so agents get contextual guidance via JSON instead of only text
- Add `aiFixId`, `action`, and `shortLink` fields to `UpdateSelfHealingFixOutput` so agents can correlate which fix was acted upon
- `ci_information` hints include: disclaimer when a different CIPE was retrieved, context about remote vs local task summary sources
- `update_self_healing_fix` hints include: shortLink usage guidance when action is not APPLY

## Test plan
- [x] Existing tests pass (`nx run nx-mcp-server:test -- nx-cloud.spec` — 28/28)
- [x] Lint passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)