### PR TITLE
feat(intellij): resolve style preprocessor include paths from rspack …

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/angular/NxAngularProject.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/angular/NxAngularProject.kt
@@ -2,17 +2,42 @@ package dev.nx.console.angular
 
 import com.intellij.lang.Language
 import com.intellij.lang.css.CSSLanguage
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import org.angular2.cli.config.AngularJsonProject
 import org.angular2.cli.config.AngularLintConfiguration
 import org.angular2.cli.config.AngularProject
 
+private val LOG = Logger.getInstance("dev.nx.console.angular.NxAngularProject")
+
 class NxAngularProject(
     override val name: String,
     private val ngProject: AngularJsonProject,
     private val workspaceFolder: VirtualFile,
+    private val projectFolder: VirtualFile? = null,
+    private val rspackConfigFile: VirtualFile? = null,
 ) : AngularProject(workspaceFolder) {
+
+    // Cached as (modificationStamp, paths) to invalidate when the file changes.
+    @Volatile private var rspackPathsCache: Pair<Long, List<String>>? = null
+
+    private fun getRspackIncludePaths(): List<String> {
+        val file = rspackConfigFile ?: return emptyList()
+        return try {
+            val stamp = file.modificationStamp
+            rspackPathsCache?.let { if (it.first == stamp) return it.second }
+            val paths = parseRspackIncludePaths(file)
+            rspackPathsCache = Pair(stamp, paths)
+            paths
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: Exception) {
+            LOG.debug("Failed to parse rspack include paths from ${file.path}", e)
+            emptyList()
+        }
+    }
 
     override val rootDir
         get() = workspaceFolder
@@ -34,9 +59,18 @@ class NxAngularProject(
 
     override val stylePreprocessorIncludeDirs
         get() =
-            ngProject.targets?.build?.options?.stylePreprocessorOptions?.includePaths?.mapNotNull {
-                workspaceFolder.findFileByRelativePath(it)
-            } ?: emptyList()
+            ((ngProject.targets
+                    ?.build
+                    ?.options
+                    ?.stylePreprocessorOptions
+                    ?.includePaths
+                    ?.mapNotNull { workspaceFolder.findFileByRelativePath(it) } ?: emptyList()) +
+                    getRspackIncludePaths().mapNotNull { path ->
+                        val normalized = path.removePrefix("./")
+                        projectFolder?.findFileByRelativePath(normalized)
+                            ?: workspaceFolder.findFileByRelativePath(normalized)
+                    })
+                .distinct()
 
     override val tsConfigFile: VirtualFile?
         get() = resolveFile(ngProject.targets?.build?.options?.tsConfig)

--- a/apps/intellij/src/main/kotlin/dev/nx/console/angular/RspackConfigParser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/angular/RspackConfigParser.kt
@@ -1,0 +1,84 @@
+package dev.nx.console.angular
+
+import com.intellij.lang.ecmascript6.psi.JSExportAssignment
+import com.intellij.lang.javascript.psi.JSArrayLiteralExpression
+import com.intellij.lang.javascript.psi.JSCallExpression
+import com.intellij.lang.javascript.psi.JSFile
+import com.intellij.lang.javascript.psi.JSLiteralExpression
+import com.intellij.lang.javascript.psi.JSObjectLiteralExpression
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.ProjectLocator
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.PsiTreeUtil
+import dev.nx.console.utils.computableReadAction
+
+private val LOG = Logger.getInstance("dev.nx.console.angular.RspackConfigParser")
+
+fun findRspackConfigFile(projectJsonFile: VirtualFile): VirtualFile? {
+    val dir = projectJsonFile.parent ?: return null
+    return dir.findChild("rspack.config.ts") ?: dir.findChild("rspack.config.js")
+}
+
+fun parseRspackIncludePaths(rspackConfigFile: VirtualFile): List<String> {
+    return computableReadAction {
+        val project =
+            ProjectLocator.getInstance().guessProjectForFile(rspackConfigFile)
+                ?: run {
+                    LOG.debug("no project for ${rspackConfigFile.path}")
+                    return@computableReadAction emptyList()
+                }
+
+        val psiFile =
+            PsiManager.getInstance(project).findFile(rspackConfigFile) as? JSFile
+                ?: run {
+                    LOG.debug("not a JSFile for ${rspackConfigFile.path}")
+                    return@computableReadAction emptyList()
+                }
+
+        val createConfigCall =
+            findCreateConfigCall(psiFile) ?: return@computableReadAction emptyList()
+
+        val args = createConfigCall.arguments
+        if (args.isEmpty()) return@computableReadAction emptyList()
+
+        val firstArg =
+            args[0] as? JSObjectLiteralExpression ?: return@computableReadAction emptyList()
+
+        val optionsObj =
+            firstArg.findProperty("options")?.value as? JSObjectLiteralExpression
+                ?: return@computableReadAction emptyList()
+
+        val stylePreprocessorOptionsObj =
+            optionsObj.findProperty("stylePreprocessorOptions")?.value as? JSObjectLiteralExpression
+                ?: return@computableReadAction emptyList()
+
+        val includePathsArray =
+            stylePreprocessorOptionsObj.findProperty("includePaths")?.value
+                as? JSArrayLiteralExpression ?: return@computableReadAction emptyList()
+
+        val paths =
+            includePathsArray.expressions.filterIsInstance<JSLiteralExpression>().mapNotNull {
+                it.stringValue
+            }
+        paths
+    }
+}
+
+/**
+ * Finds the `createConfig(...)` call expression in the file. Tries the direct export default path
+ * first (simple case), then falls back to a file-wide search to support webpack-merge patterns
+ * where `createConfig` is assigned to a variable before being passed to `merge(...)`.
+ */
+private fun findCreateConfigCall(psiFile: JSFile): JSCallExpression? {
+    // Primary: export default createConfig(...)
+    val exportAssignment = PsiTreeUtil.findChildOfType(psiFile, JSExportAssignment::class.java)
+    val directCall = exportAssignment?.expression as? JSCallExpression
+    if (directCall?.methodExpression?.text == "createConfig") {
+        return directCall
+    }
+
+    // Fallback: const config = createConfig(...); export default async () => merge(config, ...)
+    val allCalls = PsiTreeUtil.findChildrenOfType(psiFile, JSCallExpression::class.java)
+    return allCalls.firstOrNull { it.methodExpression?.text == "createConfig" }
+}


### PR DESCRIPTION
…config

Reads stylePreprocessorOptions.includePaths from rspack.config.ts/js and merges them with Angular project.json paths so the IDE resolves SCSS imports correctly for rspack-based projects.

Handles both default exported `createConfig` and more advanced case when `createConfig` is stored in a constant to return a modified config (e.g., when using webpack-merge).

**Before:**

<img width="559" height="249" alt="image" src="https://github.com/user-attachments/assets/54265629-a40f-486b-b2b0-1c6369a23b69" />


**After:**

<img width="542" height="395" alt="image" src="https://github.com/user-attachments/assets/a8c5eff3-a1ac-4e59-999c-92b137f2738c" />