### PR TITLE
fix(vscode): fix AIFAIL filter not catching wrapped error messages

### DIFF
--- a/libs/vscode/telemetry/src/lib/google-analytics-sender.ts
+++ b/libs/vscode/telemetry/src/lib/google-analytics-sender.ts
@@ -74,7 +74,7 @@ export class GoogleAnalyticsSender implements TelemetrySender {
 
     // there is a special case of error that we handle but still want to get more details on in rollbar - don't track those in GA
     // disabled for now while we evaluate rollbar signal
-    if (error.message.startsWith('AIFAIL')) {
+    if (error.message.includes('AIFAIL')) {
       // eslint-disable-next-line no-constant-condition
       if (false) {
         this.rollbar.error(error);


### PR DESCRIPTION
## Summary
- AIFAIL errors were leaking into Rollbar despite the filter at `sendErrorData` meant to suppress them
- The filter used `startsWith('AIFAIL')` but the thrown error wraps the AIFAIL strings in `"Error 1: \n AIFAIL|..."` format, so the check never matched
- Changed to `includes('AIFAIL')` so the filter catches these wrapped messages