### PR TITLE
fix(vscode): write valid migrations.json when no migrations exist

### DIFF
--- a/libs/vscode/migrate/src/lib/commands/start-migration.ts
+++ b/libs/vscode/migrate/src/lib/commands/start-migration.ts
@@ -92,7 +92,10 @@ export async function startMigration(custom = false) {
 
   const migrationJsonPath = join(workspacePath, 'migrations.json');
   if (!existsSync(migrationJsonPath)) {
-    writeFileSync(migrationJsonPath, JSON.stringify({ migrations: [] }, null, 2));
+    writeFileSync(
+      migrationJsonPath,
+      JSON.stringify({ migrations: [] }, null, 2),
+    );
   }
 
   const migrateUiApi = await importMigrateUIApi(workspacePath);


### PR DESCRIPTION
## Summary
- Fix `nx migrate --run-migrations` failing when Migrate UI had previously run a migration with no code migrations to apply
- When no migrations exist, Nx Console now writes `{ "migrations": [] }` instead of `{}`, making the file compatible with the Nx CLI

Closes nrwl/nx#34454