### PR TITLE
fix(intellij): prevent errors from multiple events being processed by PDV state machine simultaneously

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/project_details/browsers/NewProjectDetailsBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/project_details/browsers/NewProjectDetailsBrowser.kt
@@ -131,11 +131,7 @@ class NewProjectDetailsBrowser(private val project: Project, private val file: V
     private val stateMachineMutex = Mutex()
 
     private fun safeProcessEvent(event: Event) {
-        scope.launch {
-            stateMachineMutex.withLock {
-                stateMachine.processEvent(event)
-            }
-        }
+        scope.launch { stateMachineMutex.withLock { stateMachine.processEvent(event) } }
     }
 
     init {
@@ -778,9 +774,7 @@ class NewProjectDetailsBrowser(private val project: Project, private val file: V
             )
             subscribe(
                 NxlsService.NX_WORKSPACE_REFRESH_STARTED_TOPIC,
-                NxWorkspaceRefreshStartedListener {
-                    safeProcessEvent(Events.RefreshStarted())
-                },
+                NxWorkspaceRefreshStartedListener { safeProcessEvent(Events.RefreshStarted()) },
             )
             subscribe(
                 UISettingsListener.TOPIC,


### PR DESCRIPTION
added a mutex to prevent errors in the state machine with concurrent access like this one:

```
Unhandled exception in [Kernel@kv00ut4upb91sq7118pp, Rete(abortOnError=false, commands=capacity=2147483647,data=[onReceive], reteState=kotlinx.coroutines.flow.StateFlowImpl@3fc79729, dbSource=ReteDbSource(reteState=kotlinx.coroutines.flow.StateFlowImpl@3fc79729)), DbSourceContextElement(kernel Kernel@kv00ut4upb91sq7118pp), ComponentManager(ProjectImpl@135208459), com.intellij.codeWithMe.ClientIdContextElementPrecursor@69fa50f0, CoroutineName(dev.nx.console.utils.ProjectLevelCoroutineHolderService), Dispatchers.Default]

java.lang.IllegalStateException: Event queue is not empty, internal error (should never happen). Double check that you don't break multi-threading usage rules, if you see this error. Usually it is related to concurrent collection modification.
	at ru.nsk.kstatemachine.statemachine.QueuePendingEventHandlerImpl.checkEmpty(PendingEventHandler.kt:34)
	at ru.nsk.kstatemachine.statemachine.StateMachineImpl.eventProcessingScope(StateMachineImpl.kt:274)
	 [...]
```