### PR TITLE
fix(intellij): update arguments when reusing Run Anything configurations

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
@@ -13,6 +13,8 @@ fun getOrCreateRunnerConfigurationSettings(
 ): RunnerAndConfigurationSettings {
     val runManager = RunManager.getInstance(project)
 
+    val arguments = args.drop(1).joinToString(" ")
+
     return runManager
         .getConfigurationSettingsList(NxCommandConfigurationType.Util.getInstance())
         .firstOrNull {
@@ -21,6 +23,11 @@ fun getOrCreateRunnerConfigurationSettings(
             nxRunSettings.nxTargets == nxTarget &&
                 nxRunSettings.nxProjects == nxProject &&
                 nxRunSettings.nxTargetsConfiguration == nxTargetConfiguration
+        }
+        ?.also {
+            (it.configuration as NxCommandConfiguration).apply {
+                nxRunSettings = nxRunSettings.copy(arguments = arguments)
+            }
         }
         ?: runManager
             .createConfiguration(
@@ -34,7 +41,7 @@ fun getOrCreateRunnerConfigurationSettings(
                             nxProjects = nxProject,
                             nxTargets = nxTarget,
                             nxTargetsConfiguration = nxTargetConfiguration,
-                            arguments = args.drop(1).joinToString(" "),
+                            arguments = arguments,
                         )
                 }
             }

--- a/apps/intellij/src/test/kotlin/dev/nx/console/run/GetOrCreateRunnerAndConfigurationSettingsTest.kt
+++ b/apps/intellij/src/test/kotlin/dev/nx/console/run/GetOrCreateRunnerAndConfigurationSettingsTest.kt
@@ -1,0 +1,106 @@
+package dev.nx.console.run
+
+import com.intellij.execution.RunManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlin.test.assertEquals
+
+class GetOrCreateRunnerAndConfigurationSettingsTest : BasePlatformTestCase() {
+
+    fun testCreatesNewConfigurationWithArguments() {
+        val settings =
+            getOrCreateRunnerConfigurationSettings(
+                project,
+                "myapp",
+                "build",
+                "",
+                listOf("myapp:build", "--prod", "--verbose"),
+            )
+
+        val config = settings.configuration as NxCommandConfiguration
+        assertEquals("myapp", config.nxRunSettings.nxProjects)
+        assertEquals("build", config.nxRunSettings.nxTargets)
+        assertEquals("--prod --verbose", config.nxRunSettings.arguments)
+    }
+
+    fun testCreatesNewConfigurationWithoutArguments() {
+        val settings = getOrCreateRunnerConfigurationSettings(project, "myapp", "build")
+
+        val config = settings.configuration as NxCommandConfiguration
+        assertEquals("myapp", config.nxRunSettings.nxProjects)
+        assertEquals("build", config.nxRunSettings.nxTargets)
+        assertEquals("", config.nxRunSettings.arguments)
+    }
+
+    fun testReusesExistingConfigurationAndUpdatesArguments() {
+        val runManager = RunManager.getInstance(project)
+
+        val first =
+            getOrCreateRunnerConfigurationSettings(
+                project,
+                "myapp",
+                "build",
+                "",
+                listOf("myapp:build"),
+            )
+        runManager.addConfiguration(first)
+
+        val second =
+            getOrCreateRunnerConfigurationSettings(
+                project,
+                "myapp",
+                "build",
+                "",
+                listOf("myapp:build", "--prod", "--configuration=production"),
+            )
+
+        assertEquals(
+            first.configuration,
+            second.configuration,
+            "Should reuse the same configuration",
+        )
+
+        val config = second.configuration as NxCommandConfiguration
+        assertEquals("--prod --configuration=production", config.nxRunSettings.arguments)
+    }
+
+    fun testReusesExistingConfigurationAndClearsArguments() {
+        val runManager = RunManager.getInstance(project)
+
+        val first =
+            getOrCreateRunnerConfigurationSettings(
+                project,
+                "myapp",
+                "build",
+                "",
+                listOf("myapp:build", "--prod"),
+            )
+        runManager.addConfiguration(first)
+
+        val second = getOrCreateRunnerConfigurationSettings(project, "myapp", "build")
+
+        assertEquals(
+            first.configuration,
+            second.configuration,
+            "Should reuse the same configuration",
+        )
+
+        val config = second.configuration as NxCommandConfiguration
+        assertEquals("", config.nxRunSettings.arguments)
+    }
+
+    fun testDifferentTargetConfigurationsAreNotReused() {
+        val runManager = RunManager.getInstance(project)
+
+        val first = getOrCreateRunnerConfigurationSettings(project, "myapp", "build", "production")
+        runManager.addConfiguration(first)
+
+        val second =
+            getOrCreateRunnerConfigurationSettings(project, "myapp", "build", "development")
+
+        assertNotSame(
+            "Different target configurations should create separate configurations",
+            first.configuration,
+            second.configuration,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- When running `nx run myapp:build --someArg` from IntelliJ's Run Anything dialog, arguments after the target were silently dropped on every run after the first. The existing config lookup returned a cached configuration without updating its arguments. Now we write the current arguments into the matched config before returning it.
- Added tests covering argument propagation, argument clearing, and target configuration separation.

## Key decisions

- Used `.also { }` on the matched config to update `nxRunSettings` in place rather than creating a new configuration each time. This preserves the user's other run config customizations (e.g. environment variables).
- Extracted `args.drop(1).joinToString(" ")` into a shared `arguments` val so both the reuse path and the creation path use the same value.

Closes #1890
