### PR TITLE
fix(vscode): repair generate ui boolean default behaviour

### DIFF
--- a/apps/generate-ui-v2-e2e/src/e2e/boolean-defaults.cy.ts
+++ b/apps/generate-ui-v2-e2e/src/e2e/boolean-defaults.cy.ts
@@ -1,0 +1,74 @@
+import { GeneratorSchema } from '@nx-console/shared-generate-ui-types';
+import {
+  expectConsoleLogToHaveBeenCalledWith,
+  spyOnConsoleLog,
+} from '../support/console-spy';
+import { getFieldByName } from '../support/get-elements';
+import { visitGenerateUi } from '../support/visit-generate-ui';
+
+const schemaWithDefaultTrue: GeneratorSchema = {
+  collectionName: '@nx/test',
+  generatorName: 'test',
+  description: 'description',
+  options: [
+    {
+      name: 'component',
+      type: 'boolean',
+      default: true,
+      aliases: [],
+      isRequired: false,
+    },
+  ],
+};
+
+const schemaWithDefaultFalse: GeneratorSchema = {
+  ...schemaWithDefaultTrue,
+  options: [
+    {
+      ...schemaWithDefaultTrue.options[0],
+      default: false,
+    },
+  ],
+};
+
+describe('boolean defaults', () => {
+  it('should send --component=false when default true is unchecked', () => {
+    visitGenerateUi(schemaWithDefaultTrue);
+    getFieldByName('component').then((field) => {
+      expect((field.get(0) as HTMLInputElement).checked).to.eq(true);
+    });
+
+    getFieldByName('component').click();
+    getFieldByName('component').then((field) => {
+      expect((field.get(0) as HTMLInputElement).checked).to.eq(false);
+    });
+
+    spyOnConsoleLog().then((consoleLog: any) => {
+      cy.get("[data-cy='generate-button']").click();
+      expectConsoleLogToHaveBeenCalledWith(consoleLog, 'run-generator');
+      expectConsoleLogToHaveBeenCalledWith(consoleLog, '--component=false');
+    });
+  });
+
+  it('should keep false defaults as default values', () => {
+    visitGenerateUi(schemaWithDefaultFalse);
+    getFieldByName('component').then((field) => {
+      expect((field.get(0) as HTMLInputElement).checked).to.eq(false);
+    });
+
+    spyOnConsoleLog().then((consoleLog: any) => {
+      cy.get("[data-cy='generate-button']").click();
+      expectConsoleLogToHaveBeenCalledWith(consoleLog, 'run-generator');
+
+      cy.get('@consoleLog').then(() => {
+        const emittedComponentFlag = consoleLog.getCalls().some((call) => {
+          const args = Array.from(call.args);
+          return args.some((arg) =>
+            JSON.stringify(arg).includes('--component='),
+          );
+        });
+        expect(emittedComponentFlag).to.eq(false);
+      });
+    });
+  });
+});

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/use-generator-defaults-processor.spec.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/use-generator-defaults-processor.spec.ts
@@ -112,4 +112,126 @@ describe('useGeneratorDefaultsProcessor', () => {
 
     expect(processedSchema).toEqual(defaultSchema);
   });
+
+  it('should allow overriding boolean defaults to false - nested', () => {
+    const schema: GeneratorSchema = {
+      collectionName: '@nx/react',
+      generatorName: 'library',
+      description: '',
+      options: [
+        {
+          name: 'component',
+          type: 'boolean',
+          default: true,
+          aliases: [],
+          isRequired: false,
+        },
+      ],
+    };
+    const workspace = {
+      nxJson: {
+        generators: {
+          '@nx/react': {
+            library: {
+              component: false,
+            },
+          },
+        },
+      },
+    };
+
+    const processedSchema = useGeneratorDefaultsProcessor(
+      schema,
+      workspace as any as NxWorkspace,
+      mockLogger,
+    );
+
+    expect(processedSchema.options).toEqual([
+      {
+        name: 'component',
+        type: 'boolean',
+        default: false,
+        aliases: [],
+        isRequired: false,
+      },
+    ]);
+  });
+
+  it('should allow overriding boolean defaults to false - flat', () => {
+    const schema: GeneratorSchema = {
+      collectionName: '@nx/react',
+      generatorName: 'library',
+      description: '',
+      options: [
+        {
+          name: 'component',
+          type: 'boolean',
+          default: true,
+          aliases: [],
+          isRequired: false,
+        },
+      ],
+    };
+    const workspace = {
+      nxJson: {
+        generators: {
+          '@nx/react:library': {
+            component: false,
+          },
+        },
+      },
+    };
+
+    const processedSchema = useGeneratorDefaultsProcessor(
+      schema,
+      workspace as any as NxWorkspace,
+      mockLogger,
+    );
+
+    expect(processedSchema.options).toEqual([
+      {
+        name: 'component',
+        type: 'boolean',
+        default: false,
+        aliases: [],
+        isRequired: false,
+      },
+    ]);
+  });
+
+  it('should keep falsy defaults like empty string and zero', () => {
+    const workspace = {
+      nxJson: {
+        generators: {
+          'my-collection': {
+            'my-generator': {
+              option1: '',
+              option2: 0,
+            },
+          },
+        },
+      },
+    };
+
+    const processedSchema = useGeneratorDefaultsProcessor(
+      defaultSchema,
+      workspace as any as NxWorkspace,
+      mockLogger,
+    );
+
+    expect(processedSchema.options).toEqual([
+      {
+        name: 'option1',
+        default: '',
+        aliases: [],
+        isRequired: false,
+      },
+      {
+        name: 'option2',
+        default: 0,
+        aliases: [],
+        isRequired: false,
+      },
+    ]);
+  });
 });

--- a/libs/shared/nx-console-plugins/src/lib/internal-plugins/use-generator-defaults-processor.ts
+++ b/libs/shared/nx-console-plugins/src/lib/internal-plugins/use-generator-defaults-processor.ts
@@ -21,8 +21,13 @@ export const useGeneratorDefaultsProcessor: SchemaProcessor = (
   return {
     ...schema,
     options: (schema.options ?? []).map((option) => {
-      if (nxJsonGeneratorsEntry[option.name]) {
-        option.default = nxJsonGeneratorsEntry[option.name];
+      if (
+        Object.prototype.hasOwnProperty.call(nxJsonGeneratorsEntry, option.name)
+      ) {
+        return {
+          ...option,
+          default: nxJsonGeneratorsEntry[option.name],
+        };
       }
       return option;
     }),


### PR DESCRIPTION
Fix `nx.json` generator default merging to respect falsy values and add UI tests for boolean option serialization.

The `nx.json` generator defaults processor was incorrectly using a truthy check, causing `false` values (e.g., `component: false`) to be ignored when merging with schema defaults. This PR corrects that by checking for key existence instead of truthiness, ensuring `nx.json` overrides are properly applied. It also adds specific UI-level tests to confirm that users can correctly set a boolean option from `true` to `false` via the Generate UI, addressing the original issue's broader context.
