### PR TITLE
feat(polygraph): pass cloud credentials through delegate tool

### DIFF
--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud-polygraph.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud-polygraph.ts
@@ -156,7 +156,15 @@ function registerDelegate(
         }
 
         try {
-          const delegateParams = { ...params, workspacePath };
+          const nxCloudUrl = await getNxCloudUrl(workspacePath);
+          const authHeaders = await nxCloudAuthHeaders(workspacePath);
+
+          const delegateParams = {
+            ...params,
+            workspacePath,
+            nxCloudUrl,
+            authHeaders,
+          };
           logger.log(
             `polygraphDelegate args: ${JSON.stringify(Object.keys(delegateParams))}`,
           );


### PR DESCRIPTION
## Summary
- Pass `nxCloudUrl` and `authHeaders` through the `cloud_polygraph_delegate` MCP tool to `polygraphDelegate()`, enabling child agent log streaming to the Nx Cloud API
- Follows the same pattern as other Polygraph tools (`cloud_polygraph_init`, `cloud_polygraph_create_prs`, etc.) which already pass these cloud credentials

Companion PR: https://github.com/nrwl/ocean/pull/new/polygraph-log-upload

## Test plan
- [ ] Verify delegate tool passes cloud credentials by checking `delegateParams` keys in logs
- [ ] Run a Polygraph session with delegation and verify child agent logs are streamed to the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)