### PR TITLE
fix(vscode,intellij): update broken nx.dev troubleshooting URLs

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolMainComponents.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolMainComponents.kt
@@ -242,7 +242,7 @@ class NxToolMainComponents(private val project: Project) {
                 }
                 row {
                     text(
-                        "If the problems persist, you can try running <code>nx reset</code> and then <a href='refresh'>refresh the workspace</a><br /> For more information, look for errors in <a href='open-idea-log'>idea.log</a> and refer to the <a href='https://nx.dev/troubleshooting/troubleshoot-nx-install-issues?utm_source=nxconsole'>Nx Troubleshooting Guide </a> and the <a href='https://nx.dev/recipes/nx-console/console-troubleshooting?utm_source=nxconsole'>Nx Console Troubleshooting Guide</a>."
+                        "If the problems persist, you can try running <code>nx reset</code> and then <a href='refresh'>refresh the workspace</a><br /> For more information, look for errors in <a href='open-idea-log'>idea.log</a> and refer to the <a href='https://nx.dev/docs/troubleshooting/troubleshoot-nx-install-issues?utm_source=nxconsole'>Nx Troubleshooting Guide </a> and the <a href='https://nx.dev/docs/troubleshooting/console-troubleshooting?utm_source=nxconsole'>Nx Console Troubleshooting Guide</a>."
                     ) {
                         if (it.description == "refresh") {
                             NxRefreshWorkspaceService.getInstance(project).refreshWorkspace()

--- a/libs/vscode/nvm-tip/src/lib/nvm-tip.ts
+++ b/libs/vscode/nvm-tip/src/lib/nvm-tip.ts
@@ -13,7 +13,7 @@ export async function initNvmTip(context: ExtensionContext) {
     commands.registerCommand('nxConsole.showNodeVersion', async () => {
       const nodeVersion = await getNodeVersion();
       window.showInformationMessage(
-        `VSCode loaded Node ${nodeVersion}. [If that seems wrong, read more here.](https://nx.dev/recipes/nx-console/console-troubleshooting#vscode-nvm-issues)`,
+        `VSCode loaded Node ${nodeVersion}. [If that seems wrong, read more here.](https://nx.dev/docs/troubleshooting/console-troubleshooting#vscode-nvm-issues)`,
       );
     }),
   );
@@ -27,7 +27,7 @@ export async function initNvmTip(context: ExtensionContext) {
   const nodeVersion = await getNodeVersion();
   window
     .showInformationMessage(
-      `VSCode loaded Node ${nodeVersion}. [If that seems wrong, read more here.](https://nx.dev/recipes/nx-console/console-troubleshooting#vscode-nvm-issues)`,
+      `VSCode loaded Node ${nodeVersion}. [If that seems wrong, read more here.](https://nx.dev/docs/troubleshooting/console-troubleshooting#vscode-nvm-issues)`,
       'OK',
       "Don't show again",
     )

--- a/libs/vscode/nx-help-and-feedback-view/src/lib/nx-help-and-feedback-provider.ts
+++ b/libs/vscode/nx-help-and-feedback-view/src/lib/nx-help-and-feedback-provider.ts
@@ -21,7 +21,7 @@ export class NxHelpAndFeedbackProvider extends AbstractTreeProvider<NxHelpAndFee
       [
         [
           'Nx Console Documentation',
-          'https://nx.dev/core-features/integrate-with-editors#nx-console-for-vscode?utm_source=nxconsole',
+          'https://nx.dev/docs/getting-started/editor-setup?utm_source=nxconsole',
           {
             light: Uri.file(
               join(
@@ -57,12 +57,12 @@ export class NxHelpAndFeedbackProvider extends AbstractTreeProvider<NxHelpAndFee
         ],
         [
           'Nx Console Troubleshooting Guide',
-          'https://nx.dev/recipes/nx-console/console-troubleshooting?utm_source=nxconsole',
+          'https://nx.dev/docs/troubleshooting/console-troubleshooting?utm_source=nxconsole',
           new ThemeIcon('tools'),
         ],
         [
           'Nx Troubleshooting Guide',
-          'https://nx.dev/recipes/troubleshooting/troubleshoot-nx-install-issues?utm_source=nxconsole',
+          'https://nx.dev/docs/troubleshooting/troubleshoot-nx-install-issues?utm_source=nxconsole',
           new ThemeIcon('tools'),
         ],
       ] as const

--- a/nx.json
+++ b/nx.json
@@ -207,7 +207,7 @@
   "defaultBase": "master",
   "nxCloudUrl": "https://snapshot.nx.app",
   "nxCloudId": "698fe56d9c60351a0e65a82b",
-  "bust": 9,
+  "bust": 10,
   "release": {
     "version": {
       "preVersionCommand": "node ./tools/scripts/ensure-release-branch.js"


### PR DESCRIPTION
## Summary
- The nx.dev docs site restructured their URLs, so all troubleshooting and editor setup links were returning 404s. Updated all affected URLs in the VS Code and IntelliJ extensions to point to the correct new paths.

Closes #3093