### PR TITLE
fix(vscode,intellij): update old nx.dev doc links to canonical /docs/ URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Nx Console enhances your editors AI features by providing relevant context to th
 
 Nx Console comes with an MCP server for both, [VSCode](https://nx.dev/blog/nx-mcp-vscode-copilot) and [Cursor](https://nx.dev/blog/nx-made-cursor-smarter).
 
-You can also install the MCP server separately from the Nx Console extension via the `nx-mcp` NPM package. More about that [here](./apps/nx-mcp/README.md). Learn more in [the Nx docs](https://nx.dev/features/enhance-AI).
+You can also install the MCP server separately from the Nx Console extension via the `nx-mcp` NPM package. More about that [here](./apps/nx-mcp/README.md). Learn more in [the Nx docs](https://nx.dev/docs/features/enhance-ai).
 
 ### Project Details View
 
@@ -69,7 +69,7 @@ Nx Console provides seamless integration with the Project Details View (PDV). Yo
     </picture>
 </p>
 
-[Learn more about the Project Details view on nx.dev](https://nx.dev/recipes/nx-console/console-project-details#nx-console-project-details-view)
+[Learn more about the Project Details view on nx.dev](https://nx.dev/docs/guides/nx-console/console-project-details#nx-console-project-details-view)
 
 ### Generate UI
 
@@ -82,7 +82,7 @@ Nx Console makes it easier to run generators through our interactive Generate UI
     </picture>
 </p>
 
-You can launch the Generate UI via the `Nx: Generate (UI)` command or through the context menu in the file explorer. Paths will be automatically prefilled! [Learn more about the Generate UI on nx.dev](https://nx.dev/recipes/nx-console/console-generate-command)
+You can launch the Generate UI via the `Nx: Generate (UI)` command or through the context menu in the file explorer. Paths will be automatically prefilled! [Learn more about the Generate UI on nx.dev](https://nx.dev/docs/guides/nx-console/console-generate-command)
 
 ### Nx Cloud Integration
 
@@ -97,7 +97,7 @@ Nx Console improves the experience of using Nx Cloud by giving you an overview o
 
 Additionally, Nx Console helps by guiding you through the Nx Cloud onboarding process, right in your editor.
 
-[Learn more about the Nx Cloud Integration on nx.dev](https://nx.dev/recipes/nx-console/console-nx-cloud)
+[Learn more about the Nx Cloud Integration on nx.dev](https://nx.dev/docs/guides/nx-console/console-nx-cloud)
 
 ### Projects & Tasks Overview
 
@@ -123,15 +123,15 @@ Nx Console visualizes the Nx project & task graphs right in your editor. It know
 
 ## Requirements
 
-To use Nx Console, make sure you're in an Nx or Lerna workspace and have Node.js installed. If you're not using Nx yet, learn more here: [Intro to Nx](https://nx.dev/getting-started/intro)
+To use Nx Console, make sure you're in an Nx or Lerna workspace and have Node.js installed. If you're not using Nx yet, learn more here: [Intro to Nx](https://nx.dev/docs/getting-started/intro)
 
-You can [create an Nx workspace](https://nx.dev/getting-started/installation) by running the following command:
+You can [create an Nx workspace](https://nx.dev/docs/getting-started/installation) by running the following command:
 
 ```bash
 npx create-nx-workspace@latest my-workspace
 ```
 
-To [install Nx into an existing repository](https://nx.dev/getting-started/installation#installing-nx-into-an-existing-repository), simply run
+To [install Nx into an existing repository](https://nx.dev/docs/getting-started/installation#installing-nx-into-an-existing-repository), simply run
 
 ```bash
 npx nx init
@@ -142,7 +142,7 @@ npx nx init
 The latest version of Nx Console supports all Nx versions starting at Nx 15. For older versions, we cannot guarantee compatibility or full functionality. However, we welcome contributions! If you encounter specific issues with older versions, please consider submitting a PR. Of course, if you discover any problems with newer versions of Nx, please report these issues to help us improve Nx Console.
 
 If you're looking to upgrade your version of Nx easily, refer to the [Nx
-migrate documentation](https://nx.dev/features/automate-updating-dependencies).
+migrate documentation](https://nx.dev/docs/features/automate-updating-dependencies).
 
 # Contributing
 
@@ -153,7 +153,7 @@ list to get started.
 
 ## Learn More
 
-- [Documentation](https://nx.dev/getting-started/editor-setup) - Official documentation with video tutorials
+- [Documentation](https://nx.dev/docs/getting-started/editor-setup) - Official documentation with video tutorials
 - [nx.dev](http://nx.dev) - Documentation, Guides and Interactive Tutorials on Nx
 - [Join the community](http://go.nx.dev/community) - Chat about Nx & Nx Console on the official discord server
 - [Learn more about the team at Nx](https://nx.dev/company) - The team at Nx led the development of Nx Console,

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolMainComponents.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/NxToolMainComponents.kt
@@ -94,7 +94,7 @@ class NxToolMainComponents(private val project: Project) {
                         panel {
                             row {
                                 text(
-                                        " If you're just getting started with Nx, you can <a href='https://nx.dev/plugin-features/use-code-generators'>use generators</a> to quickly scaffold new projects or <a href='https://nx.dev/reference/project-configuration'>add them manually</a>.<br/> If your Nx workspace is not at the root of the opened project, make sure to set the <a href='open-setting'>workspace path setting</a>."
+                                        " If you're just getting started with Nx, you can <a href='https://nx.dev/docs/features/generate-code'>use generators</a> to quickly scaffold new projects or <a href='https://nx.dev/docs/reference/project-configuration'>add them manually</a>.<br/> If your Nx workspace is not at the root of the opened project, make sure to set the <a href='open-setting'>workspace path setting</a>."
                                     ) {
                                         if (it.description == "open-setting") {
                                             ShowSettingsUtil.getInstance()
@@ -204,7 +204,7 @@ class NxToolMainComponents(private val project: Project) {
                         panel {
                             row {
                                 text(
-                                        "New to Nx? <a href='https://nx.dev/plugin-features/use-code-generators'>Use generators</a> to scaffold projects or <a href='https://nx.dev/reference/project-configuration'>configure them manually</a>. " +
+                                        "New to Nx? <a href='https://nx.dev/docs/features/generate-code'>Use generators</a> to scaffold projects or <a href='https://nx.dev/docs/reference/project-configuration'>configure them manually</a>. " +
                                             "If your workspace isn't at the project root, set the <a href='open-setting'>workspace path</a>."
                                     ) {
                                         if (it.description == "open-setting") {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/tree/NxTreeStructure.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/tree/NxTreeStructure.kt
@@ -256,7 +256,8 @@ class NxTreeStructure(val tree: NxProjectsTree, val project: Project) : SimpleTr
         override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         override fun actionPerformed(e: AnActionEvent) {
-            val url = "https://nx.dev/docs/features/ci-features/split-e2e-tasks?utm_source=nx-console"
+            val url =
+                "https://nx.dev/docs/features/ci-features/split-e2e-tasks?utm_source=nx-console"
             BrowserLauncher.instance.browse(URI.create(url))
         }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/tree/NxTreeStructure.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nx_toolwindow/tree/NxTreeStructure.kt
@@ -256,7 +256,7 @@ class NxTreeStructure(val tree: NxProjectsTree, val project: Project) : SimpleTr
         override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         override fun actionPerformed(e: AnActionEvent) {
-            val url = "https://nx.dev/ci/features/split-e2e-tasks?utm_source=nx-console"
+            val url = "https://nx.dev/docs/features/ci-features/split-e2e-tasks?utm_source=nx-console"
             BrowserLauncher.instance.browse(URI.create(url))
         }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/settings/options/TelemetrySetting.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/settings/options/TelemetrySetting.kt
@@ -16,7 +16,7 @@ class TelemetrySetting() : NxConsoleSettingBase<Boolean> {
                 cell(checkbox)
                     .comment(
                         NxConsoleBundle.message("nx.telemetry.permission") +
-                            """ <a href="https://nx.dev/recipes/nx-console/console-telemetry#collected-data">Learn more.</a>""",
+                            """ <a href="https://nx.dev/docs/guides/nx-console/console-telemetry#collected-data">Learn more.</a>""",
                         MAX_LINE_LENGTH_WORD_WRAP,
                     )
             }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/Notifier.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/Notifier.kt
@@ -51,7 +51,7 @@ class Notifier {
                         object : AnAction("Learn more") {
                             override fun actionPerformed(e: AnActionEvent) {
                                 BrowserUtil.browse(
-                                    "https://nx.dev/recipes/nx-console/console-telemetry#collected-data"
+                                    "https://nx.dev/docs/guides/nx-console/console-telemetry#collected-data"
                                 )
                             }
                         },
@@ -213,7 +213,7 @@ class Notifier {
                 .addAction(
                     NotificationAction.createSimpleExpiring("Learn More") {
                         BrowserUtil.browse(
-                            "https://nx.dev/getting-started/ai-integration#manual-setup-for-other-ai-clients"
+                            "https://nx.dev/docs/getting-started/ai-setup#manual-setup-for-other-ai-clients"
                         )
                     }
                 )

--- a/apps/nx-mcp/README.md
+++ b/apps/nx-mcp/README.md
@@ -8,7 +8,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io/introduction) server 
 
 The Nx MCP server gives LLMs deep access to your monorepo’s structure: project relationships, file mappings, runnable tasks, ownership info, tech stacks, Nx generators, and even Nx documentation. With this context, LLMs can generate code tailored to your stack, understand the impact of a change, and apply modifications across connected files with precision. This is possible because Nx already understands the higher-level architecture of your workspace, and monorepos bring all relevant projects into one place.
 
-Read more in [our blog post](https://nx.dev/blog/nx-made-cursor-smarter) and [in our docs](https://nx.dev/features/enhance-AI).
+Read more in [our blog post](https://nx.dev/blog/nx-made-cursor-smarter) and [in our docs](https://nx.dev/docs/features/enhance-ai).
 
 ## Installation and Usage
 
@@ -80,8 +80,8 @@ If you're using Cursor you can directly install the Nx Console extension which a
 
 More info:
 
-- [Install Nx Console](https://nx.dev/getting-started/editor-setup)
-- [Configure Cursor to use the nx-mcp](https://nx.dev/features/enhance-AI#cursor)
+- [Install Nx Console](https://nx.dev/docs/getting-started/editor-setup)
+- [Configure Cursor to use the nx-mcp](https://nx.dev/docs/features/enhance-ai#cursor)
 
 ## Minimal Mode (Default)
 

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -50,9 +50,9 @@ Nx Console enhances your editors AI features by providing relevant context to th
     </picture>
 </p>
 
-In VSCode, access the enhancements via the `@nx` chat participant. Learn more [in our blog post](https://nx.dev/blog/nx-just-made-your-llm-smarter) or the [Nx docs](https://nx.dev/features/enhance-AI#vs-code-with-github-copilot)
+In VSCode, access the enhancements via the `@nx` chat participant. Learn more [in our blog post](https://nx.dev/blog/nx-just-made-your-llm-smarter) or the [Nx docs](https://nx.dev/docs/features/enhance-ai#vs-code-with-github-copilot)
 
-In Cursor or anywhere else, use the Nx MCP server. Learn more [in our Cursor blog](https://nx.dev/blog/nx-made-cursor-smarter) post or [the Nx docs](https://nx.dev/features/enhance-AI#cursor)
+In Cursor or anywhere else, use the Nx MCP server. Learn more [in our Cursor blog](https://nx.dev/blog/nx-made-cursor-smarter) post or [the Nx docs](https://nx.dev/docs/features/enhance-ai#cursor)
 
 ### Project Details View
 
@@ -65,7 +65,7 @@ Nx Console provides seamless integration with the Project Details View (PDV). Yo
     </picture>
 </p>
 
-[Learn more about the Project Details view on nx.dev](https://nx.dev/recipes/nx-console/console-project-details#nx-console-project-details-view)
+[Learn more about the Project Details view on nx.dev](https://nx.dev/docs/guides/nx-console/console-project-details#nx-console-project-details-view)
 
 ### Generate UI
 
@@ -78,7 +78,7 @@ Nx Console makes it easier to run generators through our interactive Generate UI
     </picture>
 </p>
 
-You can launch the Generate UI via the `Nx: Generate (UI)` command or through the context menu in the file explorer. Paths will be automatically prefilled! [Learn more about the Generate UI on nx.dev](https://nx.dev/recipes/nx-console/console-generate-command)
+You can launch the Generate UI via the `Nx: Generate (UI)` command or through the context menu in the file explorer. Paths will be automatically prefilled! [Learn more about the Generate UI on nx.dev](https://nx.dev/docs/guides/nx-console/console-generate-command)
 
 ### Nx Cloud Integration
 
@@ -93,7 +93,7 @@ Nx Console improves the experience of using Nx Cloud by giving you an overview o
 
 Additionally, Nx Console helps by guiding you through the Nx Cloud onboarding process, right in your editor.
 
-[Learn more about the Nx Cloud Integration on nx.dev](https://nx.dev/recipes/nx-console/console-nx-cloud)
+[Learn more about the Nx Cloud Integration on nx.dev](https://nx.dev/docs/guides/nx-console/console-nx-cloud)
 
 ### Projects & Tasks Overview
 
@@ -119,15 +119,15 @@ Nx Console visualizes the Nx project & task graphs right in your editor. It know
 
 ## Requirements
 
-To use Nx Console, make sure you're in an Nx or Lerna workspace and have Node.js installed. If you're not using Nx yet, learn more here: [Intro to Nx](https://nx.dev/getting-started/intro)
+To use Nx Console, make sure you're in an Nx or Lerna workspace and have Node.js installed. If you're not using Nx yet, learn more here: [Intro to Nx](https://nx.dev/docs/getting-started/intro)
 
-You can [create an Nx workspace](https://nx.dev/getting-started/installation) by running the following command:
+You can [create an Nx workspace](https://nx.dev/docs/getting-started/installation) by running the following command:
 
 ```bash
 npx create-nx-workspace@latest my-workspace
 ```
 
-To [install Nx into an existing repository](https://nx.dev/getting-started/installation#installing-nx-into-an-existing-repository), simply run
+To [install Nx into an existing repository](https://nx.dev/docs/getting-started/installation#installing-nx-into-an-existing-repository), simply run
 
 ```bash
 npx nx init
@@ -138,7 +138,7 @@ npx nx init
 The latest version of Nx Console supports all Nx versions starting at Nx 15. For older versions, we cannot guarantee compatibility or full functionality. However, we welcome contributions! If you encounter specific issues with older versions, please consider submitting a PR. Of course, if you discover any problems with newer versions of Nx, please report these issues to help us improve Nx Console.
 
 If you're looking to upgrade your version of Nx easily, refer to the [Nx
-migrate documentation](https://nx.dev/features/automate-updating-dependencies).
+migrate documentation](https://nx.dev/docs/features/automate-updating-dependencies).
 
 # Contributing
 
@@ -149,7 +149,7 @@ list to get started.
 
 ## Learn More
 
-- [Documentation](https://nx.dev/getting-started/editor-setup) - Official documentation with video tutorials
+- [Documentation](https://nx.dev/docs/getting-started/editor-setup) - Official documentation with video tutorials
 - [nx.dev](http://nx.dev) - Documentation, Guides and Interactive Tutorials on Nx
 - [Join the community](http://go.nx.dev/community) - Chat about Nx & Nx Console on the official discord server
 - [Learn more about the team at Nx](https://nx.dev/company) - The team at Nx led the development of Nx Console,

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -19,7 +19,7 @@
     "color": "#176BCC",
     "theme": "dark"
   },
-  "homepage": "https://nx.dev/using-nx/console#nx-console-for-vscode",
+  "homepage": "https://nx.dev/docs/getting-started/editor-setup#nx-console-for-vscode",
   "bugs": {
     "url": "https://github.com/nrwl/nx-console/issues"
   },
@@ -965,11 +965,11 @@
     "viewsWelcome": [
       {
         "view": "nxConsole.views.welcome",
-        "contents": "It looks like you're not inside an Nx workspace. Click the button below to add nx to your current workspace by running [nx init](https://nx.dev/recipes/adopting-nx/adding-to-existing-project). \n [Add Nx](command:nx.init)\n If your Nx workspace is in a different folder, you can manually select it below. \n[Select Workspace](command:nxConsole.selectWorkspaceManually)\nLearn more about Nx on [nx.dev](https://nx.dev) or check out the [Nx Console Documentation](https://nx.dev/getting-started/editor-setup)."
+        "contents": "It looks like you're not inside an Nx workspace. Click the button below to add nx to your current workspace by running [nx init](https://nx.dev/docs/guides/adopting-nx/adding-to-existing-project). \n [Add Nx](command:nx.init)\n If your Nx workspace is in a different folder, you can manually select it below. \n[Select Workspace](command:nxConsole.selectWorkspaceManually)\nLearn more about Nx on [nx.dev](https://nx.dev) or check out the [Nx Console Documentation](https://nx.dev/docs/getting-started/editor-setup)."
       },
       {
         "view": "nxConsole.views.angular-welcome",
-        "contents": "Nx Console no longer supports Angular CLI workspaces.\nHowever, Nx now supports a [Standalone App workspace](https://nx.dev/getting-started/angular-standalone-tutorial) setup aimed at non-monorepo scenarios. This setup is identical to a typical Angular CLI workspace and allows for leveraging all Nx features, including:\n- [Modularizing your codebase](https://nx.dev/more-concepts/applications-and-libraries) with local libraries\n- [Powerful generators and plugins](https://nx.dev/plugin-features/use-code-generators) from the team and the Nx community (Jest, Cypress, Tailwind, Storybook, NgRx, etc.)\n- [Visualizing your workspace structure](https://nx.dev/core-features/explore-graph)\n- [Task caching](https://nx.dev/core-features/cache-task-results) to speed up your runs and CI\nFurthermore, if you ever want to migrate to a monorepo, it can be done easily.\nMigrating from the Angular CLI to Nx is fully automated and won't change your workspace structure. Click the button below to run the migration and convert your workspace. Make sure to commit all changes first.\n[Migrate to Nx](command:nxConsole.migrateAngularCliToNx)"
+        "contents": "Nx Console no longer supports Angular CLI workspaces.\nHowever, Nx now supports a [Standalone App workspace](https://nx.dev/docs/getting-started/tutorials/angular-monorepo-tutorial) setup aimed at non-monorepo scenarios. This setup is identical to a typical Angular CLI workspace and allows for leveraging all Nx features, including:\n- [Modularizing your codebase](https://nx.dev/docs/concepts/decisions/project-size) with local libraries\n- [Powerful generators and plugins](https://nx.dev/docs/features/generate-code) from the team and the Nx community (Jest, Cypress, Tailwind, Storybook, NgRx, etc.)\n- [Visualizing your workspace structure](https://nx.dev/docs/features/explore-graph)\n- [Task caching](https://nx.dev/docs/features/cache-task-results) to speed up your runs and CI\nFurthermore, if you ever want to migrate to a monorepo, it can be done easily.\nMigrating from the Angular CLI to Nx is fully automated and won't change your workspace structure. Click the button below to run the migration and convert your workspace. Make sure to commit all changes first.\n[Migrate to Nx](command:nxConsole.migrateAngularCliToNx)"
       },
       {
         "view": "nxProjects",
@@ -998,7 +998,7 @@
       },
       {
         "view": "nxProjects",
-        "contents": "No projects found in this workspace.\n\n[Refresh Workspace](command:nxConsole.refreshWorkspace)\n\n[Use generators](https://nx.dev/plugin-features/use-code-generators) to scaffold new projects.",
+        "contents": "No projects found in this workspace.\n\n[Refresh Workspace](command:nxConsole.refreshWorkspace)\n\n[Use generators](https://nx.dev/docs/features/generate-code) to scaffold new projects.",
         "when": "nxProjectsView.state == no-projects"
       },
       {

--- a/libs/vscode/migrate-sidebar-webview/src/main.ts
+++ b/libs/vscode/migrate-sidebar-webview/src/main.ts
@@ -32,7 +32,7 @@ export class Root extends LitElement {
           A newer version of Nx is available:
           ${this.migrateViewData?.latestNxVersion.full} <br />
           Use the button below to start a guided migration using the Migrate UI.
-          <a href="https://nx.dev/latest/react/cli/migrate">Learn more</a>
+          <a href="https://nx.dev/docs/features/automate-updating-dependencies">Learn more</a>
         </p>
 
         ${this.migrateViewData?.hasPendingChanges

--- a/libs/vscode/migrate-sidebar-webview/src/main.ts
+++ b/libs/vscode/migrate-sidebar-webview/src/main.ts
@@ -32,7 +32,9 @@ export class Root extends LitElement {
           A newer version of Nx is available:
           ${this.migrateViewData?.latestNxVersion.full} <br />
           Use the button below to start a guided migration using the Migrate UI.
-          <a href="https://nx.dev/docs/features/automate-updating-dependencies">Learn more</a>
+          <a href="https://nx.dev/docs/features/automate-updating-dependencies"
+            >Learn more</a
+          >
         </p>
 
         ${this.migrateViewData?.hasPendingChanges

--- a/libs/vscode/nx-cloud-onboarding-webview/src/main.ts
+++ b/libs/vscode/nx-cloud-onboarding-webview/src/main.ts
@@ -92,7 +92,7 @@ export class Root extends LitElement {
     if (!this.cloudOnboardingInfo?.isConnectedToCloud) {
       return html`<p>
         Nx Cloud facilitates Remote Caching, Task Distribution and more.
-        <vscode-link href="https://nx.dev/ci/intro/why-nx-cloud"
+        <vscode-link href="https://nx.dev/docs/getting-started/nx-cloud"
           >Learn more about Nx Cloud</vscode-link
         >
       </p>`;
@@ -100,7 +100,7 @@ export class Root extends LitElement {
       return html`<p>
         Finish connecting your repository to Nx Cloud in the web application,
         gain access to the PR integration and more.
-        <vscode-link href="https://nx.dev/ci/intro/why-nx-cloud"
+        <vscode-link href="https://nx.dev/docs/getting-started/nx-cloud"
           >Learn more about Nx Cloud</vscode-link
         >
       </p>`;
@@ -108,7 +108,7 @@ export class Root extends LitElement {
       return html`<p>
         Use our generator to easily create a CI configuration for your CI
         provider of choice.
-        <vscode-link href="https://nx.dev/ci/intro/why-nx-cloud"
+        <vscode-link href="https://nx.dev/docs/getting-started/nx-cloud"
           >Learn more about Nx Cloud</vscode-link
         >
       </p>`;

--- a/libs/vscode/nx-conversion/src/lib/vscode-nx-conversion.ts
+++ b/libs/vscode/nx-conversion/src/lib/vscode-nx-conversion.ts
@@ -54,7 +54,7 @@ export async function initNxConversion(
   if (answer === 'Learn More') {
     commands.executeCommand(
       'vscode.open',
-      'https://nx.dev/technologies/angular/migration/angular#migrating-an-angular-cli-project-to-nx?utm_source=nx-console',
+      'https://nx.dev/docs/technologies/angular/migration/angular#migrating-an-angular-cli-project-to-nx?utm_source=nx-console',
     );
     return;
   }

--- a/libs/vscode/nx-project-view/src/lib/atomizer-decorations.ts
+++ b/libs/vscode/nx-project-view/src/lib/atomizer-decorations.ts
@@ -79,7 +79,7 @@ export class AtomizerDecorationProvider implements FileDecorationProvider {
                 if (selection === 'Learn More') {
                   commands.executeCommand(
                     'vscode.open',
-                    'https://nx.dev/ci/features/split-e2e-tasks#automatically-split-e2e-tasks-by-file-atomizer?utm_source=nxconsole',
+                    'https://nx.dev/docs/features/ci-features/split-e2e-tasks#automatically-split-e2e-tasks-by-file-atomizer?utm_source=nxconsole',
                   );
                 }
               });
@@ -101,7 +101,7 @@ export class AtomizerDecorationProvider implements FileDecorationProvider {
                 if (selection === 'Learn More') {
                   commands.executeCommand(
                     'vscode.open',
-                    'https://nx.dev/ci/features/split-e2e-tasks#automatically-split-e2e-tasks-by-file-atomizer?utm_source=nxconsole',
+                    'https://nx.dev/docs/features/ci-features/split-e2e-tasks#automatically-split-e2e-tasks-by-file-atomizer?utm_source=nxconsole',
                   );
                 }
               });


### PR DESCRIPTION
## Summary
- Updates all hardcoded `nx.dev` documentation links to use the canonical `/docs/` prefixed URLs
- Verified each URL by checking browser redirects against the live site
- Covers 12 files across IntelliJ plugin, VSCode extension, READMEs, and shared libs

## Test plan
- [x] Verify links open correctly in IntelliJ plugin (telemetry notice, tool window, error view)
- [x] Verify links open correctly in VSCode extension (welcome views, migrate sidebar, cloud onboarding, atomizer notifications)
- [x] Spot-check a few updated URLs in browser to confirm they resolve without redirect

closes: https://github.com/nrwl/nx/issues/34910