### PR TITLE
fix(nxls): add debounce and reconfigure lock to prevent watcher flood

### DIFF
--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -417,6 +417,12 @@ async function reconfigureAndSendNotificationWithBackoff(
     return;
   }
 
+  if (retryTimeoutId) {
+    clearTimeout(retryTimeoutId);
+    retryTimeoutId = undefined;
+    reconfigureAttempts = 0;
+  }
+
   isReconfiguring = true;
   try {
     if (reconfigureAttempts === 0) {

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -115,6 +115,15 @@ const fileWatcherOperationalCallback = (status: WatcherStatus) => {
   });
 };
 let reconfigureAttempts = 0;
+let isReconfiguring = false;
+let pendingReconfigure: {
+  workingPath: string;
+  projectGraphAndSourceMaps?: {
+    projectGraph: ProjectGraph;
+    sourceMaps: ConfigurationSourceMaps;
+  } | null;
+} | null = null;
+let retryTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
 // Create a text document manager.
 const documents = new TextDocuments(TextDocument);
@@ -403,37 +412,65 @@ async function reconfigureAndSendNotificationWithBackoff(
     sourceMaps: ConfigurationSourceMaps;
   } | null,
 ) {
-  if (reconfigureAttempts === 0) {
-    safeSendNotification(NxWorkspaceRefreshStartedNotification.method);
-  }
-  const workspace = await reconfigure(workingPath, projectGraphAndSourceMaps);
-  await safeSendNotification(NxWorkspaceRefreshNotification.method);
-
-  if (
-    !workspace?.errors ||
-    (workspace.errors &&
-      workspace.isPartial &&
-      Object.keys(workspace.projectGraph.nodes ?? {}).length > 0)
-  ) {
-    reconfigureAttempts = 0;
+  if (isReconfiguring) {
+    pendingReconfigure = { workingPath, projectGraphAndSourceMaps };
     return;
   }
 
-  if (reconfigureAttempts < 3) {
-    reconfigureAttempts++;
-    lspLogger.log(
-      `reconfiguration failed, trying again in ${
-        reconfigureAttempts * reconfigureAttempts
-      } seconds`,
-    );
-    new Promise((resolve) =>
-      setTimeout(resolve, 1000 * reconfigureAttempts * reconfigureAttempts),
-    ).then(() => reconfigureAndSendNotificationWithBackoff(workingPath));
-  } else {
-    lspLogger.log(
-      `reconfiguration failed after ${reconfigureAttempts} attempts`,
-    );
-    reconfigureAttempts = 0;
+  isReconfiguring = true;
+  try {
+    if (reconfigureAttempts === 0) {
+      safeSendNotification(NxWorkspaceRefreshStartedNotification.method);
+    }
+    const workspace = await reconfigure(workingPath, projectGraphAndSourceMaps);
+    safeSendNotification(NxWorkspaceRefreshNotification.method);
+
+    if (
+      !workspace?.errors ||
+      (workspace.errors &&
+        workspace.isPartial &&
+        Object.keys(workspace.projectGraph.nodes ?? {}).length > 0)
+    ) {
+      reconfigureAttempts = 0;
+      return;
+    }
+
+    if (reconfigureAttempts < 3) {
+      reconfigureAttempts++;
+      lspLogger.log(
+        `reconfiguration failed, trying again in ${
+          reconfigureAttempts * reconfigureAttempts
+        } seconds`,
+      );
+      retryTimeoutId = setTimeout(
+        () => {
+          retryTimeoutId = undefined;
+          reconfigureAndSendNotificationWithBackoff(workingPath);
+        },
+        1000 * reconfigureAttempts * reconfigureAttempts,
+      );
+    } else {
+      lspLogger.log(
+        `reconfiguration failed after ${reconfigureAttempts} attempts`,
+      );
+      reconfigureAttempts = 0;
+    }
+  } finally {
+    isReconfiguring = false;
+
+    if (pendingReconfigure) {
+      const pending = pendingReconfigure;
+      pendingReconfigure = null;
+      if (retryTimeoutId) {
+        clearTimeout(retryTimeoutId);
+        retryTimeoutId = undefined;
+      }
+      reconfigureAttempts = 0;
+      reconfigureAndSendNotificationWithBackoff(
+        pending.workingPath,
+        pending.projectGraphAndSourceMaps,
+      );
+    }
   }
 }
 

--- a/libs/language-server/watcher/src/lib/watcher.ts
+++ b/libs/language-server/watcher/src/lib/watcher.ts
@@ -114,6 +114,12 @@ async function registerPassiveDaemonWatcher(
       lspLogger.debug?.(
         `registerPassiveDaemonWatcher: Existing watcher state: ${_passiveDaemonWatcher.state}`,
       );
+      try {
+        _passiveDaemonWatcher.dispose();
+      } catch (e) {
+        lspLogger.log('Error stopping previous passive daemon watcher: ' + e);
+      }
+      _passiveDaemonWatcher = undefined;
     }
     lspLogger.debug?.(
       'registerPassiveDaemonWatcher: Creating new PassiveDaemonWatcher...',
@@ -128,11 +134,12 @@ async function registerPassiveDaemonWatcher(
     lspLogger.debug?.(
       `registerPassiveDaemonWatcher: start() completed, state: ${_passiveDaemonWatcher.state}`,
     );
+    const debouncedCallback = debounce(callback, 1000);
     _passiveDaemonWatcher.listen((error, projectGraphAndSourceMaps) => {
       lspLogger.debug?.(
         `registerPassiveDaemonWatcher: Listener callback triggered, error=${error}`,
       );
-      callback(error, projectGraphAndSourceMaps);
+      debouncedCallback(error, projectGraphAndSourceMaps);
     });
     lspLogger.debug?.('registerPassiveDaemonWatcher: Listener registered');
     return async () => {


### PR DESCRIPTION
The `PassiveDaemonWatcher` (Nx >= 22.5.0-beta.3) passes daemon events to
`reconfigureAndSendNotificationWithBackoff` without debouncing. When the daemon
fires rapid events (builds, npm install, branch switches), this causes:

- N concurrent `reconfigure()` calls that race on watcher re-registration,
  leaking `PassiveDaemonWatcher` instances (each leaked watcher fires its own
  callbacks, amplifying the problem)
- A flood of `nx/refreshWorkspaceStarted` + `nx/refreshWorkspace` notifications
- Potential nxls crash under sustained load (OOM or mid-write crash producing
  truncated JSON-RPC responses)

The old `DaemonWatcher` path already debounces at 1000ms and properly disposes
previous watchers — these safeguards were missed when `PassiveDaemonWatcher` was
introduced in #2851.

PR #3001 partially addressed this by coalescing `nxWorkspace()` calls, but the
wrapping `reconfigure()` (schema config, watcher re-registration) still runs
concurrently.

## Changes

- **Add 1000ms debounce** to `PassiveDaemonWatcher` callback, matching old
  watcher path
- **Dispose old `PassiveDaemonWatcher`** before creating a new one, preventing
  watcher leaks on re-registration (matching old watcher cleanup pattern)
- **Add reconfigure lock** — when a reconfigure is in progress, new requests are
  coalesced into a single follow-up instead of running concurrently. Stale
  backoff retries are cancelled when fresh events arrive.

Should fix #2921. Potentially, should also fix #3101 since the codebase seems to be shared between both plugins.

## Repro of the bug

1. Pull https://github.com/gultyayev/nx-angular-mfe-repro
2. `npm i`
3. Checkout `test-branch` – it has a few libs generated

Observe multiple `Refresh workspace started called from nxls` logs. Checking out from branch to branch raises the number of `Refresh workspace started called from nxls` logs exponentially.