### PR TITLE
fix(intellij): always trigger exit handler and throttle post-crash logs

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsProcess.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsProcess.kt
@@ -46,16 +46,11 @@ class NxlsProcess(private val project: Project, private val cs: CoroutineScope) 
                 exitJob =
                     cs.launch {
                         it.awaitExit()
-                        it.errorStream.readAllBytes().decodeToString().run {
-                            if (this.isEmpty()) {
-                                return@run
-                            }
-
-                            if (project.isDisposed) {
-                                return@run
-                            }
-
-                            logger.error("Nxls early exit: $this")
+                        val stderr = it.errorStream.readAllBytes().decodeToString()
+                        if (stderr.isNotEmpty() && !project.isDisposed) {
+                            logger.error("Nxls early exit: $stderr")
+                        }
+                        if (!project.isDisposed) {
                             onExit?.invoke()
                         }
                     }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
@@ -50,6 +50,7 @@ class NxlsWrapper(val project: Project, private val cs: CoroutineScope) {
     private var connectedEditors = ConcurrentHashMap<String, DocumentManager>()
 
     private var status = NxlsState.STOPPED
+    private var loggedProcessExited = false
 
     fun getServerCapabilities(): ServerCapabilities? {
         log.log("Getting language server capabilities")
@@ -58,6 +59,7 @@ class NxlsWrapper(val project: Project, private val cs: CoroutineScope) {
 
     suspend fun start() {
         try {
+            loggedProcessExited = false
             status = NxlsState.STARTING
             val nxlsProcess = NxlsProcess(project, cs)
             this.nxlsProcess = nxlsProcess
@@ -115,9 +117,12 @@ class NxlsWrapper(val project: Project, private val cs: CoroutineScope) {
                                         if (this) {
                                             consume.consume(message)
                                         } else {
-                                            log.log(
-                                                "Unable to send messages to the nxls, the process has exited"
-                                            )
+                                            if (!loggedProcessExited) {
+                                                loggedProcessExited = true
+                                                log.log(
+                                                    "Unable to send messages to the nxls, the process has exited"
+                                                )
+                                            }
                                             status = NxlsState.STOPPED
                                         }
                                     }


### PR DESCRIPTION
When the nxls process crashes at runtime (as opposed to a startup failure), two
IntelliJ-specific issues compound the problem:

1. **`NxlsProcess.onExit` only fires when stderr has content.** If the process
   is killed by SIGKILL (OOM killer) or exits without writing to stderr, the
   callback never fires, so `NxlsWrapper.stop()` is never triggered and
   resources are not cleaned up. This was originally designed for startup error
   detection (#1649) but doesn't cover runtime crashes.

2. **"Unable to send messages to the nxls" is logged for every buffered message
   after process death** — hundreds of times from the OS pipe buffer — with no
   throttle.

## Changes

- **Always call `onExit`** when the process exits, regardless of stderr content.
  Stderr is still logged when present. Safe because `NxlsProcess.stop()` cancels
  `exitJob` in the intentional-stop path, and `NxlsWrapper.stop()` has a
  re-entrancy guard (`STOPPING` state check).
- **Add log-once guard** for the "Unable to send" message. Flag is reset on
  `start()`.

Addresses side effects of #2921. Specifically, those tons of messages that occur when the process gets killed.

## Repro of the bug

1. Pull https://github.com/gultyayev/nx-angular-mfe-repro
2. `npm i`
3. `nx sync & kill -9 <nxls pid>`

No logs when the process is killed.

After the fix

```
[L][2026-04-04 16:46:07.172] Stopping nxls
[L][2026-04-04 16:46:07.175] Unable to send messages to the nxls, the process has exited
[L][2026-04-04 16:46:07.175] Sending request to nxls: shutdown (null)
[L][2026-04-04 16:46:08.177] stopping nxls process
[L][2026-04-04 16:46:08.177] process is not alive
[L][2026-04-04 16:46:08.178] Process exited: true
```

I struggle to find "proper" reproduction for the real flood, but this small repro seems to still prove the point.