### PR TITLE
fix(nxls): debounce PassiveDaemonWatcher callback to prevent reconfigure flood

### DIFF
--- a/libs/language-server/watcher/src/lib/watcher.ts
+++ b/libs/language-server/watcher/src/lib/watcher.ts
@@ -128,11 +128,12 @@ async function registerPassiveDaemonWatcher(
     lspLogger.debug?.(
       `registerPassiveDaemonWatcher: start() completed, state: ${_passiveDaemonWatcher.state}`,
     );
+    const debouncedCallback = debounce(callback, 1000);
     _passiveDaemonWatcher.listen((error, projectGraphAndSourceMaps) => {
       lspLogger.debug?.(
         `registerPassiveDaemonWatcher: Listener callback triggered, error=${error}`,
       );
-      callback(error, projectGraphAndSourceMaps);
+      debouncedCallback(error, projectGraphAndSourceMaps);
     });
     lspLogger.debug?.('registerPassiveDaemonWatcher: Listener registered');
     return async () => {


### PR DESCRIPTION
## Summary
- Adds a 1-second debounce to the `PassiveDaemonWatcher` listener callback, matching the existing debounce on the old `DaemonWatcher` path
- Prevents the Nx daemon from flooding the language server with thousands of concurrent reconfigure cycles when it delivers a burst of project graph recomputation notifications

Fixes #3101

## Context
The Nx daemon can deliver bursts of project graph recomputation notifications (16k+ observed in the logs attached to #3101). The old `DaemonWatcher` path (used for Nx < 22.5.0) already wraps its callback with `debounce(callback, 1000)`, but the new `PassiveDaemonWatcher` path (Nx >= 22.5.0) passes the callback through directly. Each notification triggers a full `reconfigure()` cycle — and while `nxWorkspace()` deduplicates the project graph computation, the 16k concurrent reconfigure calls all proceed to re-register watchers and configure schemas simultaneously, freezing the language server.

## Test plan
- [ ] Verify existing e2e tests pass
- [ ] Manually test with a large Nx workspace (Nx >= 22.5.0) — file changes should still trigger workspace refresh, but rapid bursts should coalesce into a single refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)