### PR TITLE
fix(vscode): block lifecycle scripts in all dlx commands

### DIFF
--- a/apps/vscode/src/nx-init.ts
+++ b/apps/vscode/src/nx-init.ts
@@ -1,4 +1,8 @@
 import {
+  buildSafeDlxCommand,
+  getPackageManagerCommand,
+} from '@nx-console/shared-npm';
+import {
   noProvenanceError,
   nxLatestProvenanceCheck,
 } from '@nx-console/shared-utils';
@@ -34,16 +38,23 @@ export function initNxInit(context: ExtensionContext) {
           logAndShowError(noProvenanceError, provenanceResult);
           return;
         }
-        const command = 'nx@latest init --ignore-scripts';
+        const packageManagerCommand = await getPackageManagerCommand(
+          workspacePath ?? '',
+        );
+        const { prefix, env } = buildSafeDlxCommand(
+          packageManagerCommand.dlx,
+        );
+        const command = `${prefix} nx@latest init`;
         const task = new Task(
-          { type: 'nx' }, // definition
-          TaskScope.Workspace, // scope
-          command, // name
+          { type: 'nx' },
+          TaskScope.Workspace,
+          command,
           'nx',
-          // execution
-          new ShellExecution(`npx ${command}`, {
+          new ShellExecution(command, {
             cwd: workspacePath,
             env: {
+              ...process.env,
+              ...env,
               NX_CONSOLE: 'true',
             },
           }),

--- a/apps/vscode/src/nx-init.ts
+++ b/apps/vscode/src/nx-init.ts
@@ -41,9 +41,7 @@ export function initNxInit(context: ExtensionContext) {
         const packageManagerCommand = await getPackageManagerCommand(
           workspacePath ?? '',
         );
-        const { prefix, env } = buildSafeDlxCommand(
-          packageManagerCommand.dlx,
-        );
+        const { prefix, env } = buildSafeDlxCommand(packageManagerCommand.dlx);
         const command = `${prefix} nx@latest init`;
         const task = new Task(
           { type: 'nx' },

--- a/libs/shared/npm/src/index.ts
+++ b/libs/shared/npm/src/index.ts
@@ -4,6 +4,8 @@ export * from './lib/package-details';
 export * from './lib/pnp-dependencies';
 export { checkIsNxWorkspace } from './lib/check-is-nx-workspace';
 export { getNxExecutionCommand } from './lib/get-nx-execution-command';
+export { buildSafeDlxCommand } from './lib/safe-dlx-command';
+export type { SafeDlxCommand } from './lib/safe-dlx-command';
 
 export {
   detectPackageManager,

--- a/libs/shared/npm/src/lib/safe-dlx-command.ts
+++ b/libs/shared/npm/src/lib/safe-dlx-command.ts
@@ -1,0 +1,68 @@
+export interface SafeDlxCommand {
+  /** The dlx command prefix to place before the package name */
+  prefix: string;
+  /** Environment variables to set when spawning for lifecycle script safety */
+  env: Record<string, string>;
+}
+
+/**
+ * Builds a dlx command prefix that blocks lifecycle scripts during package
+ * installation. Returns both the command prefix and any environment variables
+ * needed for the spawn/exec call.
+ *
+ * Usage: `${prefix} <package>@latest <command> <flags>`
+ *
+ * @param dlx - The dlx command from getPackageManagerCommand().dlx
+ * @param options.npxCacheDir - Optional cache directory (only applies to npx)
+ */
+export function buildSafeDlxCommand(
+  dlx: string | undefined,
+  options?: { npxCacheDir?: string },
+): SafeDlxCommand {
+  const cacheParam = options?.npxCacheDir
+    ? `--cache=${options.npxCacheDir}`
+    : '';
+
+  // 'yarn' (without 'dlx') is an outdated config from old nx versions.
+  // undefined means detection failed. Both fall back to npx.
+  if (!dlx || dlx === 'npx' || dlx === 'yarn') {
+    return {
+      prefix: ['npx', '-y', '--ignore-scripts', cacheParam]
+        .filter(Boolean)
+        .join(' '),
+      env: {},
+    };
+  }
+
+  // yarn berry (v2+) removed --ignore-scripts from dlx; use env var instead
+  if (dlx === 'yarn dlx') {
+    return {
+      prefix: 'yarn dlx',
+      env: { YARN_ENABLE_SCRIPTS: 'false' },
+    };
+  }
+
+  // pnpm dlx doesn't support --ignore-scripts; use npm config env var
+  if (dlx === 'pnpm dlx' || dlx === 'pnpx') {
+    return {
+      prefix: dlx,
+      env: { npm_config_ignore_scripts: 'true' },
+    };
+  }
+
+  // bun doesn't run lifecycle scripts for bunx/bun dlx by default
+  if (dlx === 'bunx' || dlx === 'bun dlx' || dlx === 'bun x') {
+    return {
+      prefix: dlx,
+      env: {},
+    };
+  }
+
+  // Unknown dlx command - fall back to npx for safety
+  return {
+    prefix: ['npx', '-y', '--ignore-scripts', cacheParam]
+      .filter(Boolean)
+      .join(' '),
+    env: {},
+  };
+}

--- a/libs/vscode/mcp/src/lib/periodic-ai-check.ts
+++ b/libs/vscode/mcp/src/lib/periodic-ai-check.ts
@@ -141,8 +141,7 @@ async function constructCommand(
     : buildSafeDlxCommand(packageManagerCommands.dlx, { npxCacheDir });
 
   return {
-    command:
-      `${prefix} nx@latest configure-ai-agents ${flags}`.trim(),
+    command: `${prefix} nx@latest configure-ai-agents ${flags}`.trim(),
     env,
   };
 }
@@ -677,8 +676,7 @@ async function runAiAgentCheckLegacy() {
           source: 'notification',
         });
 
-        const { command: setupCmd, env: setupEnv } =
-          await constructCommand('');
+        const { command: setupCmd, env: setupEnv } = await constructCommand('');
         const task = new Task(
           { type: 'nx' },
           TaskScope.Workspace,

--- a/libs/vscode/mcp/src/lib/periodic-ai-check.ts
+++ b/libs/vscode/mcp/src/lib/periodic-ai-check.ts
@@ -1,5 +1,6 @@
 import { gte } from '@nx-console/nx-version';
 import {
+  buildSafeDlxCommand,
   checkIsNxWorkspace,
   detectPackageManager,
   getPackageManagerCommand,
@@ -64,32 +65,18 @@ const EXPECTED_ERRORS = [
 ];
 
 let checkTimer: NodeJS.Timeout | undefined;
-let intervalTimer: NodeJS.Timeout | undefined;
 
 export function setupPeriodicAiCheck(context: ExtensionContext) {
-  // Run first check after 3 minutes
-  checkTimer = setTimeout(
-    () => {
-      runAiAgentCheck();
-
-      // Then check every 3 hours
-      intervalTimer = setInterval(
-        () => {
-          runAiAgentCheck();
-        },
-        3 * 60 * 60 * 1000,
-      );
-    },
-    3 * 60 * 1000,
-  );
+  // Run once on startup with a randomized delay (1 to 5 minutes)
+  const delayMs = (60 + Math.floor(Math.random() * 240)) * 1000;
+  checkTimer = setTimeout(() => {
+    runAiAgentCheck();
+  }, delayMs);
 
   context.subscriptions.push(
     new Disposable(() => {
       if (checkTimer) {
         clearTimeout(checkTimer);
-      }
-      if (intervalTimer) {
-        clearInterval(intervalTimer);
       }
     }),
   );
@@ -102,7 +89,7 @@ export async function runConfigureAiAgentsCommand() {
     source: 'command',
   });
 
-  const command = await constructCommand('');
+  const { command, env: dlxEnv } = await constructCommand('');
   const task = new Task(
     { type: 'nx' },
     TaskScope.Workspace,
@@ -112,6 +99,7 @@ export async function runConfigureAiAgentsCommand() {
       cwd: workspacePath,
       env: {
         ...process.env,
+        ...dlxEnv,
         NX_CONSOLE: 'true',
         NX_AI_FILES_USE_LOCAL: 'true',
       },
@@ -121,7 +109,10 @@ export async function runConfigureAiAgentsCommand() {
   tasks.executeTask(task);
 }
 
-async function constructCommand(flags: string, forceNpx = false) {
+async function constructCommand(
+  flags: string,
+  forceNpx = false,
+): Promise<{ command: string; env: Record<string, string> }> {
   const workspacePath = getWorkspacePath();
 
   const hash = createHash('sha256')
@@ -131,11 +122,11 @@ async function constructCommand(flags: string, forceNpx = false) {
 
   const tmpDir = join(tmpdir(), 'nx-console-tmp', hash);
 
-  let cacheParam = '';
+  let npxCacheDir: string | undefined;
   try {
     rmSync(tmpDir, { recursive: true, force: true });
     mkdirSync(tmpDir, { recursive: true });
-    cacheParam = `--cache=${tmpDir}`;
+    npxCacheDir = tmpDir;
   } catch (e) {
     // No permissions or can't create tmpDir, skip cache parameter
   }
@@ -145,15 +136,15 @@ async function constructCommand(flags: string, forceNpx = false) {
     vscodeLogger,
   );
 
-  let dlx = packageManagerCommands.dlx;
+  const { prefix, env } = forceNpx
+    ? buildSafeDlxCommand(undefined, { npxCacheDir })
+    : buildSafeDlxCommand(packageManagerCommands.dlx, { npxCacheDir });
 
-  // there are older versions of nx that have this outdated config
-  // 'yarn' isn't actually a dlx command it's only for local packages
-  if (dlx === 'yarn' || dlx === 'npx' || dlx === undefined) {
-    dlx = `npx -y --ignore-scripts ${cacheParam}`;
-  }
-
-  return `${forceNpx ? `npx -y ${cacheParam} --ignore-scripts` : dlx} nx@latest configure-ai-agents ${flags}`.trim();
+  return {
+    command:
+      `${prefix} nx@latest configure-ai-agents ${flags}`.trim(),
+    env,
+  };
 }
 
 async function doRunAiAgentCheck(
@@ -171,13 +162,15 @@ async function doRunAiAgentCheck(
   const errors: [string, Error][] = [];
 
   try {
-    command = await constructCommand('--check', forceNpx);
+    const result = await constructCommand('--check', forceNpx);
+    command = result.command;
     await new Promise((resolve, reject) => {
       commandStartTime = Date.now();
       const childProcess = spawn(command, {
         cwd: workspacePath,
         env: {
           ...process.env,
+          ...result.env,
           NX_CONSOLE: 'true',
           // we're already executing from latest, we don't have to fetch latest again
           NX_AI_FILES_USE_LOCAL: 'true',
@@ -595,7 +588,7 @@ async function runAiAgentCheckLegacy() {
           });
 
           // Run the configure command
-          const command = await constructCommand('');
+          const { command, env: dlxEnv } = await constructCommand('');
           const task = new Task(
             { type: 'nx' },
             TaskScope.Workspace,
@@ -605,6 +598,7 @@ async function runAiAgentCheckLegacy() {
               cwd: workspacePath,
               env: {
                 ...process.env,
+                ...dlxEnv,
                 NX_CONSOLE: 'true',
                 NX_AI_FILES_USE_LOCAL: 'true',
               },
@@ -640,13 +634,14 @@ async function runAiAgentCheckLegacy() {
     }
 
     // Run the check=all command to see if configuration is needed
-    const checkAllCommand = await constructCommand('--check=all');
+    const checkAllResult = await constructCommand('--check=all');
     try {
-      await promisify(exec)(checkAllCommand, {
+      await promisify(exec)(checkAllResult.command, {
         cwd: workspacePath,
         timeout: 360000,
         env: {
           ...process.env,
+          ...checkAllResult.env,
           NX_CONSOLE: 'true',
           NX_AI_FILES_USE_LOCAL: 'true',
         },
@@ -682,16 +677,18 @@ async function runAiAgentCheckLegacy() {
           source: 'notification',
         });
 
-        const command = await constructCommand('');
+        const { command: setupCmd, env: setupEnv } =
+          await constructCommand('');
         const task = new Task(
           { type: 'nx' },
           TaskScope.Workspace,
-          command,
+          setupCmd,
           'nx',
-          new ShellExecution(command, {
+          new ShellExecution(setupCmd, {
             cwd: workspacePath,
             env: {
               ...process.env,
+              ...setupEnv,
               NX_CONSOLE: 'true',
               NX_AI_FILES_USE_LOCAL: 'true',
             },

--- a/libs/vscode/nx-cloud-view/src/get-cloud-onboarding-url.ts
+++ b/libs/vscode/nx-cloud-view/src/get-cloud-onboarding-url.ts
@@ -1,5 +1,5 @@
 import {
-  detectPackageManager,
+  buildSafeDlxCommand,
   getPackageManagerCommand,
 } from '@nx-console/shared-npm';
 import {
@@ -13,10 +13,6 @@ import { execSync } from 'child_process';
 
 export async function getCloudOnboardingUrl() {
   const workspacePath = getNxWorkspacePath();
-  const packageManager = await detectPackageManager(
-    workspacePath,
-    vscodeLogger,
-  );
   const packageManagerCommand = await getPackageManagerCommand(workspacePath);
   const provenanceResult = await nxLatestProvenanceCheck(workspacePath);
   if (provenanceResult !== true) {
@@ -25,14 +21,11 @@ export async function getCloudOnboardingUrl() {
     throw new Error(noProvenanceError);
   }
 
-  // newer versions of nx will add `--ignore-scripts` by default, but older versions may not
-  // yarn is not compatible with `--ignore-scripts` so we skip it for yarn
-  let command = `${packageManagerCommand.dlx} ${packageManagerCommand.dlx === 'npx' ? '-y' : ''} nx@latest connect --ignore-scripts`;
-  if (!command.includes('--ignore-scripts') && packageManager !== 'yarn') {
-    command += ' --ignore-scripts';
-  }
+  const { prefix, env } = buildSafeDlxCommand(packageManagerCommand.dlx);
+  const command = `${prefix} nx@latest connect`;
   const nxConnectOutput = execSync(command, {
     cwd: workspacePath,
+    env: { ...process.env, ...env },
   });
   const match = nxConnectOutput.toString().match(/(https:\/\/\S+)/);
   return match ? match[1] : undefined;

--- a/libs/vscode/nx-cloud-view/src/init-nx-cloud-view.ts
+++ b/libs/vscode/nx-cloud-view/src/init-nx-cloud-view.ts
@@ -1,4 +1,7 @@
-import { getPackageManagerCommand } from '@nx-console/shared-npm';
+import {
+  buildSafeDlxCommand,
+  getPackageManagerCommand,
+} from '@nx-console/shared-npm';
 import { TelemetryEventSource } from '@nx-console/shared-telemetry';
 import { CIPEInfo, CIPEInfoError } from '@nx-console/shared-types';
 import { throttle } from '@nx-console/shared-utils';
@@ -136,17 +139,21 @@ export function initNxCloudView(context: ExtensionContext) {
       const workspacePath = getWorkspacePath();
 
       const pkgManagerCommands = await getPackageManagerCommand(workspacePath);
+      const { prefix, env: dlxEnv } = buildSafeDlxCommand(
+        pkgManagerCommands.dlx,
+      );
 
-      const command = 'nx-cloud login';
+      const command = `${prefix} nx-cloud login`;
       const task = new Task(
         { type: 'nx' },
         TaskScope.Workspace,
         command,
         'nx',
-        new ShellExecution(`${pkgManagerCommands.dlx} ${command}`, {
+        new ShellExecution(command, {
           cwd: workspacePath,
           env: {
             ...process.env,
+            ...dlxEnv,
             NX_CONSOLE: 'true',
           },
         }),


### PR DESCRIPTION
## Summary
- Several `npx`/`yarn dlx`/`pnpm dlx` invocations either had no `--ignore-scripts` protection or placed the flag after the package name, where it gets passed to `nx` instead of `npx`. This is the primary supply chain attack vector — lifecycle scripts from transitive dependencies run during package fetch.
- Created a shared `buildSafeDlxCommand` helper (`libs/shared/npm/src/lib/safe-dlx-command.ts`) that returns the correct flag or env var for each package manager: `--ignore-scripts` for npx, `YARN_ENABLE_SCRIPTS=false` for yarn berry, `npm_config_ignore_scripts=true` for pnpm, and a no-op for bun.
- Fixed all four call sites: `nx-init.ts`, `periodic-ai-check.ts`, `get-cloud-onboarding-url.ts`, and `init-nx-cloud-view.ts`.
- Changed the periodic AI agent check from a 3-minute delay + 3-hour repeating interval to a single randomized startup delay (1–5 minutes).

## Key decisions
- The helper returns env vars instead of inlining `VAR=value command` syntax because that doesn't work on Windows.
- Yarn berry removed `--ignore-scripts` from `dlx`, and pnpm `dlx` doesn't support it either — both need env vars instead.
- `nx-init.ts` was hardcoded to `npx` regardless of the user's package manager. Now it detects the PM and uses the helper.
- The periodic check doesn't need to repeat every 3 hours — a one-time startup check is sufficient.