### PR TITLE
feat(intellij): forward IDE shortcuts from generate UI browser

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/file/V2NxGenerateUiFile.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/ui/file/V2NxGenerateUiFile.kt
@@ -13,6 +13,7 @@ import dev.nx.console.models.NxGenerator
 import dev.nx.console.nxls.NxlsService
 import dev.nx.console.settings.NxConsoleSettingsProvider
 import dev.nx.console.utils.executeJavascriptWithCatch
+import dev.nx.console.utils.jcef.IdeShortcutForwardingKeyboardHandler
 import dev.nx.console.utils.jcef.OpenDevToolsContextMenuHandler
 import dev.nx.console.utils.jcef.getHexColor
 import dev.nx.console.utils.jcef.onBrowserLoadEnd
@@ -37,6 +38,10 @@ class V2NxGenerateUiFile(
         browser.setPageBackgroundColor(getHexColor(UIUtil.getPanelBackground()))
         browser.jbCefClient.addContextMenuHandler(
             OpenDevToolsContextMenuHandler(),
+            browser.cefBrowser,
+        )
+        browser.jbCefClient.addKeyboardHandler(
+            IdeShortcutForwardingKeyboardHandler(project),
             browser.cefBrowser,
         )
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/jcef/IdeShortcutForwardingKeyboardHandler.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/jcef/IdeShortcutForwardingKeyboardHandler.kt
@@ -1,0 +1,89 @@
+package dev.nx.console.utils.jcef
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionUiKind
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.actionSystem.ex.ActionUtil
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.keymap.KeymapManager
+import com.intellij.openapi.project.Project
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+import org.cef.browser.CefBrowser
+import org.cef.handler.CefKeyboardHandler.CefKeyEvent
+import org.cef.handler.CefKeyboardHandlerAdapter
+
+/**
+ * Forwards IDE keyboard shortcuts from a JCEF browser back to the IntelliJ action system. Without
+ * this, native Chromium consumes the keystroke and IDE shortcuts (e.g. Cmd+4 to toggle the Run tool
+ * window) don't fire while the browser is focused.
+ *
+ * Only shortcuts that clearly target the IDE are forwarded: modifier+digit, modifier+function key,
+ * or two-or-more-modifier combinations. Simple editing shortcuts like Cmd+C / Cmd+V stay with the
+ * browser.
+ */
+class IdeShortcutForwardingKeyboardHandler(private val project: Project) :
+    CefKeyboardHandlerAdapter() {
+
+    override fun onKeyEvent(browser: CefBrowser?, event: CefKeyEvent): Boolean {
+        if (event.type != CefKeyEvent.EventType.KEYEVENT_RAWKEYDOWN) return false
+
+        val awtModifiers = toAwtModifiers(event.modifiers)
+        if (!shouldForward(event.windows_key_code, awtModifiers)) return false
+
+        val keyStroke = KeyStroke.getKeyStroke(event.windows_key_code, awtModifiers) ?: return false
+        val actionIds =
+            KeymapManager.getInstance().activeKeymap.getActionIds(KeyboardShortcut(keyStroke, null))
+        if (actionIds.isEmpty()) return false
+
+        val actionManager = ActionManager.getInstance()
+        val action = actionIds.firstNotNullOfOrNull { actionManager.getAction(it) } ?: return false
+
+        ApplicationManager.getApplication().invokeLater {
+            val dataContext = SimpleDataContext.getProjectContext(project)
+            val actionEvent =
+                AnActionEvent.createEvent(
+                    action,
+                    dataContext,
+                    null,
+                    ActionPlaces.UNKNOWN,
+                    ActionUiKind.NONE,
+                    null,
+                )
+            ActionUtil.performAction(action, actionEvent)
+        }
+        return true
+    }
+
+    private fun shouldForward(keyCode: Int, awtModifiers: Int): Boolean {
+        val nonShift =
+            InputEvent.CTRL_DOWN_MASK or InputEvent.META_DOWN_MASK or InputEvent.ALT_DOWN_MASK
+        if (awtModifiers and nonShift == 0) return false
+        val isDigit = keyCode in KeyEvent.VK_0..KeyEvent.VK_9
+        val isFunctionKey = keyCode in KeyEvent.VK_F1..KeyEvent.VK_F24
+        val nonShiftCount = Integer.bitCount(awtModifiers and nonShift)
+        val hasShift = awtModifiers and InputEvent.SHIFT_DOWN_MASK != 0
+        val hasMultipleModifiers = nonShiftCount > 1 || (hasShift && nonShiftCount >= 1)
+        return isDigit || isFunctionKey || hasMultipleModifiers
+    }
+
+    private fun toAwtModifiers(cefFlags: Int): Int {
+        var mods = 0
+        if (cefFlags and EVENTFLAG_SHIFT_DOWN != 0) mods = mods or InputEvent.SHIFT_DOWN_MASK
+        if (cefFlags and EVENTFLAG_CONTROL_DOWN != 0) mods = mods or InputEvent.CTRL_DOWN_MASK
+        if (cefFlags and EVENTFLAG_ALT_DOWN != 0) mods = mods or InputEvent.ALT_DOWN_MASK
+        if (cefFlags and EVENTFLAG_COMMAND_DOWN != 0) mods = mods or InputEvent.META_DOWN_MASK
+        return mods
+    }
+
+    private companion object {
+        const val EVENTFLAG_SHIFT_DOWN = 1 shl 1
+        const val EVENTFLAG_CONTROL_DOWN = 1 shl 2
+        const val EVENTFLAG_ALT_DOWN = 1 shl 3
+        const val EVENTFLAG_COMMAND_DOWN = 1 shl 7
+    }
+}


### PR DESCRIPTION
Register a CEF keyboard handler on the V2 generate UI so IDE shortcuts (Cmd+digit, modifier+F-key, multi-modifier combos) fire through the action system instead of being swallowed by Chromium.

- Add `IdeShortcutForwardingKeyboardHandler` that maps CEF key events to the active keymap and performs the matching action on the EDT.                                                                      
- Register it on the V2 generate UI JCEF browser alongside the existing context-menu handler.                                                                                                                  
- Heuristic: only forward modifier+digit, modifier+F1–F24, or combos with ≥2 non-shift modifiers — editing shortcuts (Cmd+C / Cmd+V / typing) stay with the browser.          