### PR TITLE
fix(intellij): read the nx version fallback under a read action and stop swapping major/minor

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/sync_services/NxVersionUtil.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/sync_services/NxVersionUtil.kt
@@ -49,7 +49,10 @@ class NxVersionUtil(private val project: Project, private val cs: CoroutineScope
         return if (ApplicationManager.getApplication().isDispatchThread) {
             nxVersion
         } else {
-            nxVersion ?: tryGetNxVersionFromNodeModules() ?: tryGetNxVersionFromPackageJson()
+            nxVersion
+                ?: ApplicationManager.getApplication().runReadAction<NxVersion?> {
+                    tryGetNxVersionFromNodeModules() ?: tryGetNxVersionFromPackageJson()
+                }
         }
     }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/sync_services/NxVersionUtil.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/sync_services/NxVersionUtil.kt
@@ -45,6 +45,11 @@ class NxVersionUtil(private val project: Project, private val cs: CoroutineScope
         mutex.withLock { nxVersion = newVersion }
     }
 
+    /**
+     * The fallbacks parse package.json through the PSI, so they need a read action and they touch
+     * the disk. On the EDT we deliberately skip them and return whatever the language server has
+     * already reported rather than freeze the UI on file I/O.
+     */
     fun getNxVersionSynchronously(): NxVersion? {
         return if (ApplicationManager.getApplication().isDispatchThread) {
             nxVersion
@@ -77,7 +82,9 @@ class NxVersionUtil(private val project: Project, private val cs: CoroutineScope
 
             val version = versionProperty?.let { it.value?.text } ?: return null
 
-            return SemVer.parseFromText(version)?.let { NxVersion(it.major, it.minor, version) }
+            return SemVer.parseFromText(version)?.let {
+                NxVersion(major = it.major, minor = it.minor, full = version)
+            }
         } catch (e: Throwable) {
             return null
         }
@@ -117,7 +124,9 @@ class NxVersionUtil(private val project: Project, private val cs: CoroutineScope
                     ?: devDependenciesProperty?.let { getDependencyVersionFromProperty(it, "nx") }
                     ?: return null
 
-            return SemVer.parseFromText(version)?.let { NxVersion(it.major, it.minor, version) }
+            return SemVer.parseFromText(version)?.let {
+                NxVersion(major = it.major, minor = it.minor, full = version)
+            }
         } catch (e: Throwable) {
             return null
         }

--- a/apps/intellij/src/test/kotlin/dev/nx/console/utils/sync_services/NxVersionUtilTest.kt
+++ b/apps/intellij/src/test/kotlin/dev/nx/console/utils/sync_services/NxVersionUtilTest.kt
@@ -1,0 +1,69 @@
+package dev.nx.console.utils.sync_services
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import dev.nx.console.models.NxVersion
+import dev.nx.console.settings.NxConsoleProjectSettingsProvider
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+class NxVersionUtilTest : BasePlatformTestCase() {
+
+    private lateinit var workspace: Path
+
+    private data class Probe(
+        val onDispatchThread: Boolean,
+        val readAccessAllowed: Boolean,
+        val version: NxVersion?,
+    )
+
+    override fun setUp() {
+        super.setUp()
+        workspace = Files.createTempDirectory("nx-version-util-test")
+        Files.writeString(
+            workspace.resolve("package.json"),
+            """{ "devDependencies": { "nx": "22.6.3" } }""",
+        )
+        LocalFileSystem.getInstance().refreshAndFindFileByNioFile(workspace)
+        NxConsoleProjectSettingsProvider.getInstance(project).workspacePath = workspace.toString()
+    }
+
+    override fun tearDown() {
+        try {
+            NxConsoleProjectSettingsProvider.getInstance(project).workspacePath = null
+            workspace.toFile().deleteRecursively()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun probeFromBackgroundThread(): Probe =
+        ApplicationManager.getApplication()
+            .executeOnPooledThread<Probe> {
+                val application = ApplicationManager.getApplication()
+                Probe(
+                    onDispatchThread = application.isDispatchThread,
+                    readAccessAllowed = application.isReadAccessAllowed,
+                    version = NxVersionUtil.getInstance(project).getNxVersionSynchronously(),
+                )
+            }
+            .get(60, TimeUnit.SECONDS)
+
+    fun testFallbackParsesPackageJsonOffTheDispatchThread() {
+        val probe = probeFromBackgroundThread()
+
+        assertFalse("must exercise the non-dispatch branch", probe.onDispatchThread)
+        assertFalse("must start without an ambient read action", probe.readAccessAllowed)
+        assertEquals("22.6.3", probe.version?.full)
+    }
+
+    fun testFallbackReportsMajorAndMinorTheRightWayAround() {
+        val version = probeFromBackgroundThread().version
+
+        assertNotNull(version)
+        assertEquals(22, version!!.major)
+        assertEquals(6, version.minor)
+    }
+}


### PR DESCRIPTION
`NxVersionUtil.getNxVersionSynchronously()` is called from `PeriodicAiCheckService`, which runs on a background coroutine with no ambient read action. Two things were wrong on that path.

**1. The fallback never returned anything off the EDT.** `tryGetNxVersionFromNodeModules()` / `tryGetNxVersionFromPackageJson()` go through `PsiManager.findFile`, which asserts read access. The assertion was swallowed by the surrounding `catch (e: Throwable) { return null }`, so the caller silently saw "no nx version" and the IDE logged an internal error. Fixed by wrapping the fallback in a read action.

**2. `major` and `minor` were swapped.** `NxVersion`'s primary constructor is `(minor, major, full)` and both fallbacks passed it positionally as `NxVersion(it.major, it.minor, version)`. nx `22.6.3` therefore came back as `major = 6`, so `PeriodicAiCheckService`'s `major >= 22` gate never matched and the AI agent check always fell back to spawning `nx configure-ai-agents --check` instead of asking the daemon. Fixed by naming the arguments. This only becomes reachable once (1) is fixed, so both belong in the same change.

The EDT branch still deliberately skips the fallback — it does disk I/O and PSI parsing — and that is now documented on the method instead of being implicit.

Adds `NxVersionUtilTest`, which drives `getNxVersionSynchronously()` from a pooled thread and asserts up front that it is genuinely off the dispatch thread with no read access. Before/after table and raw test output in the comment below.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AkE7irXfqsmXtntFZUAmM
