### PR TITLE
fix(intellij): resolve new nx graph asset paths

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowser.kt
@@ -195,11 +195,12 @@ class NxGraphBrowser(project: Project) : NxGraphBrowserBase(project) {
             if (browser.isDisposed) return@executeWhenLoaded
             val js =
                 """
+                window.externalApi = window.externalApi ?? {};
                 window.externalApi.graphInteractionEventListener = (message) => {
                     ${interactionEventHandler.inject("JSON.stringify(message)")}
                 }
                 """
-            browser.executeJavaScript(js)
+            withContext(Dispatchers.EDT) { browser.executeJavascriptWithCatch(js) }
         }
     }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowserBase.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphBrowserBase.kt
@@ -115,12 +115,18 @@ abstract class NxGraphBrowserBase(protected val project: Project) : Disposable {
     protected fun loadGraphHtmlBase(): String {
 
         val nxPackagePath = getNxPackagePath(project, project.nxBasePath)
-        val graphBasePath = Paths.get(nxPackagePath, "src", "core", "graph").toString() + "/"
+        val graphBasePath =
+            resolveGraphBasePath(nxPackagePath)
+                ?: return getErrorHtml(
+                    arrayOf(NxError("Unable to find Nx graph assets in $nxPackagePath"))
+                )
 
         val graphIndexHtmlPath = Paths.get(graphBasePath, "index.html").toString()
-
         val file =
-            LocalFileSystem.getInstance().refreshAndFindFileByPath(graphIndexHtmlPath) ?: return ""
+            LocalFileSystem.getInstance().refreshAndFindFileByPath(graphIndexHtmlPath)
+                ?: return getErrorHtml(
+                    arrayOf(NxError("Unable to find Nx graph index.html at $graphIndexHtmlPath"))
+                )
 
         var htmlText = file.readText()
 
@@ -228,6 +234,18 @@ abstract class NxGraphBrowserBase(protected val project: Project) : Disposable {
 
         setColors()
         return htmlText
+    }
+
+    private fun resolveGraphBasePath(nxPackagePath: String): String? {
+        return listOf(
+                Paths.get(nxPackagePath, "src", "core", "graph").toString(),
+                Paths.get(nxPackagePath, "dist", "src", "core", "graph").toString(),
+            )
+            .firstOrNull {
+                LocalFileSystem.getInstance()
+                    .refreshAndFindFileByPath(Paths.get(it, "index.html").toString()) != null
+            }
+            ?.let { if (it.endsWith("/")) it else "$it/" }
     }
 
     protected fun setErrorsAndRefresh(errors: Array<NxError>?) {

--- a/apps/intellij/src/main/kotlin/dev/nx/console/project_details/browsers/NewProjectDetailsBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/project_details/browsers/NewProjectDetailsBrowser.kt
@@ -474,6 +474,7 @@ class NewProjectDetailsBrowser(private val project: Project, private val file: V
         <script>
           const data = $pdvData
 
+           window.externalApi = window.externalApi ?? {};
            window.externalApi.graphInteractionEventListener = (message) => {
                     ${interactionEventQuery.inject("JSON.stringify(message)")}
                 }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/project_details/browsers/OldProjectDetailsBrowser.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/project_details/browsers/OldProjectDetailsBrowser.kt
@@ -153,6 +153,7 @@ class OldProjectDetailsBrowser(project: Project, private val file: VirtualFile) 
 
             val js =
                 """
+                window.externalApi = window.externalApi ?? {};
                 window.externalApi.graphInteractionEventListener = (message) => {
                     ${interactionEventQuery.inject("JSON.stringify(message)")}
                 }


### PR DESCRIPTION
Nx 22 can publish graph assets under dist/src/core/graph instead of src/core/graph. Resolve both locations in IntelliJ and guard graph interaction hookup when the page is still initializing.