### PR TITLE
fix(repo): support Nx 22.7 dist/ layout in importNxPackagePath

### DIFF
--- a/libs/shared/npm/src/lib/workspace-dependencies.spec.ts
+++ b/libs/shared/npm/src/lib/workspace-dependencies.spec.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import { mocked } from 'jest-mock';
 import {
+  importNxPackagePath,
   importWorkspaceDependency,
   workspaceDependencyPath,
 } from './workspace-dependencies';
@@ -109,6 +110,28 @@ describe('workspace-dependencies', () => {
       expect(logMock).toHaveBeenCalledWith(
         'Using local Nx package at node_modules/nx/src/utils.js',
       );
+    });
+  });
+
+  describe('importNxPackagePath', () => {
+    it('should fall back to dist/src/... when src/... is not present (Nx 22.7+ layout)', async () => {
+      jest.mock(
+        '/workspace/node_modules/nx/dist/src/command-line/migrate/migrate-ui-api',
+        () => ({ recordInitialMigrationMetadata: jest.fn() }),
+        { virtual: true },
+      );
+
+      const result = await importNxPackagePath<{
+        recordInitialMigrationMetadata: unknown;
+      }>('/workspace', 'src/command-line/migrate/migrate-ui-api');
+
+      expect(result.recordInitialMigrationMetadata).toBeDefined();
+    });
+
+    it('should not try the dist/ fallback for non-src paths', async () => {
+      await expect(
+        importNxPackagePath('/workspace', 'package.json'),
+      ).rejects.toBeDefined();
     });
   });
 });

--- a/libs/shared/npm/src/lib/workspace-dependencies.ts
+++ b/libs/shared/npm/src/lib/workspace-dependencies.ts
@@ -107,10 +107,23 @@ export async function importNxPackagePath<T>(
     throw 'local Nx dependency not found';
   }
 
-  return importWorkspaceDependency(
-    join(nxWorkspaceDepPath, nestedPath),
-    logger,
-  );
+  // Nx 22.7+ moved files from `nx/src/...` to `nx/dist/src/...`. Try the
+  // pre-22.7 layout first, then fall back to the dist/ variant for src-prefixed paths.
+  const srcPrefix = `src${platform() === 'win32' ? '\\' : '/'}`;
+  const candidates = [join(nxWorkspaceDepPath, nestedPath)];
+  if (nestedPath === 'src' || nestedPath.startsWith(srcPrefix)) {
+    candidates.push(join(nxWorkspaceDepPath, 'dist', nestedPath));
+  }
+
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    try {
+      return await importWorkspaceDependency(candidate, logger);
+    } catch (e) {
+      lastError = e;
+    }
+  }
+  throw lastError;
 }
 
 export async function localDependencyPath(


### PR DESCRIPTION
Nx 22.7 moved package internals from `nx/src/...` to `nx/dist/src/...`. The earlier path-fix commit added a `dist/` fallback to `findNxPackagePath` but missed `importNxPackagePath`, which is what the migrate UI and ~7 other callers use. This unblocks `nx migrate` through the migrate UI and other dynamic Nx imports on 22.7+.