### PR TITLE
feat(nx-mcp): rework ci tools, add ci_task_output

### DIFF
--- a/apps/nx-mcp/README.md
+++ b/apps/nx-mcp/README.md
@@ -126,19 +126,9 @@ The Nx MCP server provides a comprehensive set of tools for interacting with you
 
 These tools provide insights and interactions with your Nx Cloud CI/CD data:
 
-- **ci_information**: Retrieves CI pipeline execution information for the current branch or a specific Nx Cloud CIPE URL. Supports a `select` parameter for field selection with pagination, making it easy to access specific data like task outputs or suggested fixes.
+- **ci_information**: Retrieves CI pipeline execution information for the current branch or a specific Nx Cloud URL. Returns failed tasks with `runId` metadata and supports a `select` parameter for field selection with pagination.
+- **ci_task_output**: Retrieves terminal output for a specific failed CI task, using a `runId` from `ci_information` or resolving it from the branch / URL context.
 - **update_self_healing_fix**: Apply, reject, or request a rerun for a self-healing CI fix from Nx Cloud
-
-### Nx Cloud Analytics Tools (only available w/ Nx Cloud enabled)
-
-These tools provide analytics and insights into your Nx Cloud CI/CD data, helping you track performance trends and team productivity:
-
-- **cloud_analytics_pipeline_executions_search**: Analyzes historical pipeline execution data to identify trends and patterns
-- **cloud_analytics_pipeline_execution_details**: Analyzes detailed data for a specific pipeline execution to investigate performance
-- **cloud_analytics_runs_search**: Analyzes historical run data to track performance trends and productivity patterns
-- **cloud_analytics_run_details**: Analyzes detailed data for a specific run to investigate command execution performance
-- **cloud_analytics_tasks_search**: Analyzes aggregated task performance statistics including success rates and cache hit rates
-- **cloud_analytics_task_executions_search**: Analyzes individual task execution data to investigate performance trends
 
 When no workspace path is specified, only the `nx_docs` and `nx_available_plugins` tools will be available.
 

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.spec.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.spec.ts
@@ -1,131 +1,120 @@
+jest.mock('@nx-console/shared-nx-cloud', () => ({
+  getNxCloudTerminalOutput: jest.fn(),
+  getPipelineExecutionDetails: jest.fn(),
+  getRecentCIPEData: jest.fn(),
+  getRunDetails: jest.fn(),
+  parseNxCloudUrl: jest.fn(),
+  retrieveFixDiff: jest.fn(),
+  updateSuggestedFix: jest.fn(),
+}));
+
+import { CI_TASK_OUTPUT } from '@nx-console/shared-llm-context';
+import { getNxCloudTerminalOutput } from '@nx-console/shared-nx-cloud';
+
 import { CIInformationOutput } from './output-schemas';
-import { __testing__, SELF_HEALING_CHUNK_SIZE } from './nx-cloud';
+import {
+  __testing__,
+  registerNxCloudTools,
+  SELF_HEALING_CHUNK_SIZE,
+} from './nx-cloud';
 import { getValueByPath } from './nx-workspace';
 
+const mockedGetNxCloudTerminalOutput = jest.mocked(getNxCloudTerminalOutput);
 const { parseShortLink, formatCIInformationOverview, chunkContentReverse } =
   __testing__;
 
+function createOutput(
+  overrides: Partial<CIInformationOutput> = {},
+): CIInformationOutput {
+  return {
+    cipeStatus: 'FAILED',
+    cipeUrl: 'https://cloud.nx.app/cipes/123',
+    branch: 'feature-branch',
+    commitSha: 'abc123',
+    failedTasks: [
+      {
+        taskId: 'app:build',
+        runId: 'run-1',
+        runUrl: 'https://cloud.nx.app/runs/run-1',
+      },
+      {
+        taskId: 'lib:test',
+        runId: 'run-2',
+        runUrl: 'https://cloud.nx.app/runs/run-2',
+      },
+    ],
+    verifiedTaskIds: ['app:build'],
+    selfHealingEnabled: true,
+    selfHealingStatus: 'COMPLETED',
+    verificationStatus: 'COMPLETED',
+    userAction: 'NONE',
+    failureClassification: 'build_error',
+    suggestedFixReasoning: 'The variable was undefined',
+    suggestedFixDescription: 'Fix the bug',
+    suggestedFix: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+    shortLink: 'abc-def',
+    couldAutoApplyTasks: true,
+    autoApplySkipped: null,
+    autoApplySkipReason: null,
+    confidence: 0.85,
+    confidenceReasoning:
+      'High confidence because the fix directly addresses the reported error',
+    selfHealingSkippedReason: null,
+    selfHealingSkipMessage: null,
+    error: null,
+    ...overrides,
+  };
+}
+
 describe('parseShortLink', () => {
   it('should parse valid shortlink with two parts', () => {
-    const result = parseShortLink('abc123-def456');
-    expect(result).toEqual({
+    expect(parseShortLink('abc123-def456')).toEqual({
       fixShortLink: 'abc123',
       suggestionShortLink: 'def456',
     });
   });
 
-  it('should return null for shortlink with one part', () => {
+  it('should reject invalid shortlinks', () => {
     expect(parseShortLink('abc123')).toBeNull();
-  });
-
-  it('should return null for empty string', () => {
     expect(parseShortLink('')).toBeNull();
-  });
-
-  it('should return null for shortlink with more than two parts', () => {
     expect(parseShortLink('abc-def-ghi')).toBeNull();
-  });
-
-  it('should return null for shortlink ending with dash', () => {
     expect(parseShortLink('abc123-')).toBeNull();
-  });
-
-  it('should return null for shortlink starting with dash', () => {
     expect(parseShortLink('-abc123')).toBeNull();
-  });
-
-  it('should return null for undefined input', () => {
     expect(parseShortLink(undefined as unknown as string)).toBeNull();
-  });
-
-  it('should return null for null input', () => {
     expect(parseShortLink(null as unknown as string)).toBeNull();
-  });
-
-  it('should return null for non-string input', () => {
     expect(parseShortLink(123 as unknown as string)).toBeNull();
   });
 });
 
 describe('formatCIInformationOverview', () => {
-  it('should format overview with all fields (new API with remote/local)', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'feature-branch',
-      commitSha: 'abc123',
-      failedTaskIds: ['app:build', 'lib:test'],
-      verifiedTaskIds: ['app:build'],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: 'COMPLETED',
-      userAction: 'NONE',
-      failureClassification: 'build_error',
-      taskOutputSummary: null,
-      remoteTaskSummary: 'TypeError: undefined is not a function (remote)',
-      localTaskSummary: 'Local build output here',
-      suggestedFixReasoning: 'The variable was undefined',
-      suggestedFixDescription: 'Fix the bug',
-      suggestedFix: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
-      shortLink: 'abc-def',
-      couldAutoApplyTasks: true,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: 0.85,
-      confidenceReasoning:
-        'High confidence because the fix directly addresses the reported error',
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
+  it('should format overview with failed tasks and fix metadata', () => {
+    const result = formatCIInformationOverview(createOutput());
 
-    const result = formatCIInformationOverview(output);
-
-    // Overview includes select hint
     expect(result).toContain('## CI Pipeline Information');
-    expect(result).toContain('`select` parameter');
-
-    // Overview includes pipeline status with property names in heading
     expect(result).toContain('### Pipeline Status');
-    expect(result).toContain('`cipeStatus`');
     expect(result).toContain('**Status:** FAILED');
     expect(result).toContain('**Branch:** feature-branch');
-    expect(result).toContain('**URL:** https://cloud.nx.app/cipes/123');
     expect(result).toContain('**Commit:** abc123');
 
-    // Overview includes failed tasks with property name
     expect(result).toContain('### Failed Tasks');
-    expect(result).toContain('`failedTaskIds`');
-    expect(result).toContain('app:build, lib:test');
+    expect(result).toContain('`failedTasks`');
+    expect(result).toContain(
+      '- app:build (runId: run-1, url: https://cloud.nx.app/runs/run-1)',
+    );
+    expect(result).toContain(
+      '- lib:test (runId: run-2, url: https://cloud.nx.app/runs/run-2)',
+    );
 
-    // Overview includes self-healing info with property names
     expect(result).toContain('### Self-Healing');
-    expect(result).toContain('`selfHealingEnabled`');
     expect(result).toContain('**Enabled:** Yes');
     expect(result).toContain('**Status:** COMPLETED');
     expect(result).toContain('**Verification:** COMPLETED');
     expect(result).toContain('**Failure Classification:** build_error');
     expect(result).toContain('**Could Auto-Apply:** Yes');
     expect(result).toContain('**Confidence:** 0.85');
-    expect(result).toContain(
-      '**Confidence Reasoning:** High confidence because the fix directly addresses the reported error',
-    );
+    expect(result).toContain('**Confidence Reasoning:**');
 
-    // Overview includes truncated task output (shown from the end)
-    expect(result).toContain('### Task Output');
-    expect(result).toContain(
-      '**Task Summary (`remoteTaskSummary`) - tasks ran on other machines:**',
-    );
-    expect(result).toContain('TypeError: undefined is not a function (remote)');
-    expect(result).toContain(
-      '**Task Output (`localTaskSummary`) - tasks ran on self-healing agent machine:**',
-    );
-    expect(result).toContain('Local build output here');
-    expect(result).toContain("select='remoteTaskSummary'");
-
-    // Overview includes fix description and truncated diff preview
     expect(result).toContain('### Suggested Fix');
-    expect(result).toContain('`suggestedFixDescription`');
     expect(result).toContain('**Description:** Fix the bug');
     expect(result).toContain('**Reasoning:** The variable was undefined');
     expect(result).toContain('#### Diff Preview');
@@ -134,502 +123,116 @@ describe('formatCIInformationOverview', () => {
     expect(result).toContain('+new');
     expect(result).toContain("select='suggestedFix'");
 
-    // Overview includes shortlink for apply tool
     expect(result).toContain('### Apply Fix');
-    expect(result).toContain('`shortLink`');
     expect(result).toContain('`abc-def`');
   });
 
-  it('should show legacy task_output when only taskOutputSummary is populated (old API)', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'feature-branch',
-      commitSha: 'abc123',
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: ['app:build'],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: 'COMPLETED',
-      userAction: 'NONE',
-      failureClassification: 'build_error',
-      taskOutputSummary: 'TypeError: undefined is not a function',
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: 'The variable was undefined',
-      suggestedFixDescription: 'Fix the bug',
-      suggestedFix: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
-      shortLink: 'abc-def',
-      couldAutoApplyTasks: true,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: 0.85,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const result = formatCIInformationOverview(output);
-
-    // Shows truncated task output from legacy field
-    expect(result).toContain('### Task Output');
-    expect(result).toContain('**Output:**');
-    expect(result).toContain('TypeError: undefined is not a function');
-    // New labels should NOT appear since remote/local are null
-    expect(result).not.toContain(
-      '**Task Summary (`remoteTaskSummary`) - tasks ran on other machines:**',
+  it('should omit optional sections when data is missing', () => {
+    const result = formatCIInformationOverview(
+      createOutput({
+        cipeStatus: 'IN_PROGRESS',
+        commitSha: null,
+        failedTasks: [],
+        suggestedFixReasoning: null,
+        suggestedFixDescription: null,
+        suggestedFix: null,
+        shortLink: null,
+      }),
     );
-    expect(result).not.toContain(
-      '**Task Output (`localTaskSummary`) - tasks ran on self-healing agent machine:**',
-    );
-  });
-
-  it('should show self-healing disabled when not enabled', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'SUCCEEDED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: [],
-      verifiedTaskIds: [],
-      selfHealingEnabled: false,
-      selfHealingStatus: null,
-      verificationStatus: null,
-      userAction: null,
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const result = formatCIInformationOverview(output);
-    expect(result).toContain('**Enabled:** No');
-    expect(result).not.toContain('**Status:** COMPLETED');
-    expect(result).not.toContain('**Confidence:**');
-  });
-
-  it('should omit optional sections when data is null', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'IN_PROGRESS',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: [],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: null,
-      verificationStatus: null,
-      userAction: null,
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const result = formatCIInformationOverview(output);
 
     expect(result).not.toContain('### Failed Tasks');
     expect(result).not.toContain('### Suggested Fix');
-    expect(result).not.toContain('### Task Output');
     expect(result).not.toContain('### Apply Fix');
     expect(result).not.toContain('**Commit:**');
   });
 
-  it('should not show user action when it is NONE', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: null,
-      userAction: 'NONE',
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
+  it('should hide user action when it is NONE and show skip details', () => {
+    const hiddenUserAction = formatCIInformationOverview(
+      createOutput({ userAction: 'NONE' }),
+    );
+    expect(hiddenUserAction).not.toContain('**User Action:**');
 
-    const result = formatCIInformationOverview(output);
-    expect(result).not.toContain('**User Action:**');
-  });
-
-  it('should show skipped reason and message when self-healing is throttled', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: null,
-      verificationStatus: null,
-      userAction: null,
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: 'THROTTLED',
-      selfHealingSkipMessage:
-        'Too many unapplied fixes. See https://cloud.nx.app/cipes/abc/self-healing',
-      error: null,
-    };
-
-    const result = formatCIInformationOverview(output);
-    expect(result).toContain('**Skipped:** THROTTLED');
-    expect(result).toContain(
+    const skipped = formatCIInformationOverview(
+      createOutput({
+        selfHealingStatus: null,
+        verificationStatus: null,
+        userAction: null,
+        selfHealingSkippedReason: 'THROTTLED',
+        selfHealingSkipMessage:
+          'Too many unapplied fixes. See https://cloud.nx.app/cipes/abc/self-healing',
+      }),
+    );
+    expect(skipped).toContain('**Skipped:** THROTTLED');
+    expect(skipped).toContain(
       '**Skip Message:** Too many unapplied fixes. See https://cloud.nx.app/cipes/abc/self-healing',
     );
   });
 
   it('should show user action when it is not NONE', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: null,
-      userAction: 'APPLIED_LOCALLY',
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
+    const result = formatCIInformationOverview(
+      createOutput({ userAction: 'APPLIED_LOCALLY' }),
+    );
 
-    const result = formatCIInformationOverview(output);
     expect(result).toContain('**User Action:** APPLIED_LOCALLY');
   });
 
-  it('should show only remote task output when only remote is available', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: null,
-      userAction: 'NONE',
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: 'Remote output here',
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const result = formatCIInformationOverview(output);
-    expect(result).toContain('### Task Output');
-    expect(result).toContain(
-      '**Task Summary (`remoteTaskSummary`) - tasks ran on other machines:**',
-    );
-    expect(result).toContain('Remote output here');
-    expect(result).not.toContain(
-      '**Task Output (`localTaskSummary`) - tasks ran on self-healing agent machine:**',
-    );
-    expect(result).not.toContain('**Output:**');
-  });
-
-  it('should show only local task output when only local is available', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: null,
-      userAction: 'NONE',
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: 'Local output here',
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const result = formatCIInformationOverview(output);
-    expect(result).toContain('### Task Output');
-    expect(result).not.toContain(
-      '**Task Summary (`remoteTaskSummary`) - tasks ran on other machines:**',
-    );
-    expect(result).toContain(
-      '**Task Output (`localTaskSummary`) - tasks ran on self-healing agent machine:**',
-    );
-    expect(result).toContain('Local output here');
-    expect(result).not.toContain('**Output:**');
-  });
-
-  it('should truncate long task output from the end', () => {
-    // Create string longer than TRUNCATION_LENGTH (1000)
-    // A's at start should be truncated, B's at end should be kept
-    // Last 1000 chars must not include any A's, so B section needs to be > 1000
-    const longOutput = 'A'.repeat(500) + 'B'.repeat(1200);
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: null,
-      userAction: 'NONE',
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: longOutput,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const result = formatCIInformationOverview(output);
-    // Should show end of output (B's), not beginning (A's)
-    expect(result).toContain('BBBBB');
-    expect(result).not.toContain('AAAAA');
-    // Should have truncation indicator at the beginning
-    expect(result).toContain('...');
-  });
-
-  it('should truncate long diff from the beginning', () => {
+  it('should truncate long diff previews from the beginning', () => {
     const longDiff =
       '--- a/file.ts\n+++ b/file.ts\n' + '+line\n'.repeat(500) + '-lastline';
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'main',
-      commitSha: null,
-      failedTaskIds: ['app:build'],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: null,
-      userAction: 'NONE',
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: 'Fix the bug',
-      suggestedFix: longDiff,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
+    const result = formatCIInformationOverview(
+      createOutput({
+        suggestedFixDescription: 'Fix the bug',
+        suggestedFix: longDiff,
+      }),
+    );
 
-    const result = formatCIInformationOverview(output);
-    // Diff is truncated from the beginning (shows start of diff)
     expect(result).toContain('--- a/file.ts');
-    // Should have truncation indicator at the end
     expect(result).toContain('...');
   });
 });
 
 describe('chunkContentReverse', () => {
   it('should return entire content when smaller than chunk size', () => {
-    const content = 'Hello World';
-    const result = chunkContentReverse(content, 0, 1000);
-    expect(result.chunk).toBe('Hello World');
-    expect(result.hasMore).toBe(false);
+    expect(chunkContentReverse('Hello World', 0, 1000)).toEqual({
+      chunk: 'Hello World',
+      hasMore: false,
+      totalPages: 1,
+    });
   });
 
-  it('should return empty string for empty content', () => {
-    const result = chunkContentReverse('', 0, 1000);
-    expect(result.chunk).toBe('');
-    expect(result.hasMore).toBe(false);
+  it('should paginate from the end of the content', () => {
+    expect(chunkContentReverse('1234567890', 0, 5)).toEqual({
+      chunk: '...[older output on page 1]\n67890',
+      hasMore: true,
+      totalPages: 2,
+    });
+    expect(chunkContentReverse('1234567890', 1, 5)).toEqual({
+      chunk: '12345',
+      hasMore: false,
+      totalPages: 2,
+    });
   });
 
-  it('should return end of content on page 0', () => {
-    const content = '1234567890';
-    const result = chunkContentReverse(content, 0, 5);
-    expect(result.chunk).toContain('67890');
-    expect(result.hasMore).toBe(true);
-  });
-
-  it('should return earlier content on page 1', () => {
-    const content = '1234567890';
-    const result = chunkContentReverse(content, 1, 5);
-    expect(result.chunk).toContain('12345');
-    expect(result.hasMore).toBe(false);
-  });
-
-  it('should add hint about older output when more content exists', () => {
-    const content = '1234567890';
-    const result = chunkContentReverse(content, 0, 5);
-    expect(result.chunk).toContain('...[older output on page 1]');
-  });
-
-  it('should handle page beyond content', () => {
-    const content = 'short';
-    const result = chunkContentReverse(content, 10, 5);
-    expect(result.chunk).toContain('no more content');
-    expect(result.hasMore).toBe(false);
+  it('should handle empty content and pages past the end', () => {
+    expect(chunkContentReverse('', 0, 1000)).toEqual({
+      chunk: '',
+      hasMore: false,
+      totalPages: 0,
+    });
+    expect(chunkContentReverse('short', 10, 5)).toEqual({
+      chunk: 'no more content on page 10',
+      hasMore: false,
+      totalPages: 1,
+    });
   });
 });
 
 describe('multi-field select parsing', () => {
-  it('should parse single field correctly', () => {
-    const select = 'suggestedFix';
-    const fields = select.split(',').map((s) => s.trim());
-    expect(fields).toEqual(['suggestedFix']);
-    expect(fields.length).toBe(1);
-  });
-
-  it('should parse multiple comma-separated fields', () => {
-    const select = 'suggestedFix,localTaskSummary';
-    const fields = select.split(',').map((s) => s.trim());
-    expect(fields).toEqual(['suggestedFix', 'localTaskSummary']);
-    expect(fields.length).toBe(2);
-  });
-
-  it('should trim whitespace from field names', () => {
-    const select = ' suggestedFix , localTaskSummary , remoteTaskSummary ';
-    const fields = select.split(',').map((s) => s.trim());
-    expect(fields).toEqual([
-      'suggestedFix',
-      'localTaskSummary',
-      'remoteTaskSummary',
-    ]);
-  });
-
-  it('should handle multiple fields with getValueByPath', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'feature-branch',
-      commitSha: 'abc123',
-      failedTaskIds: ['app:build', 'lib:test'],
-      verifiedTaskIds: ['app:build'],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: 'COMPLETED',
-      userAction: 'NONE',
-      failureClassification: 'build_error',
-      taskOutputSummary: null,
-      remoteTaskSummary: 'Remote task output',
-      localTaskSummary: 'Local task output',
-      suggestedFixReasoning: 'Reasoning here',
-      suggestedFixDescription: 'Fix description',
-      suggestedFix: '--- a/file.ts\n+++ b/file.ts',
-      shortLink: 'abc-def',
-      couldAutoApplyTasks: true,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: 0.85,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const fields = ['suggestedFix', 'localTaskSummary', 'cipeStatus'];
+  it('should parse and retrieve multiple fields', () => {
+    const output = createOutput();
+    const fields = 'suggestedFix, failedTasks, cipeStatus'
+      .split(',')
+      .map((s) => s.trim());
     const result: Record<string, unknown> = {};
 
     for (const field of fields) {
@@ -640,111 +243,45 @@ describe('multi-field select parsing', () => {
     }
 
     expect(result).toEqual({
-      suggestedFix: '--- a/file.ts\n+++ b/file.ts',
-      localTaskSummary: 'Local task output',
+      suggestedFix: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      failedTasks: output.failedTasks,
       cipeStatus: 'FAILED',
     });
   });
 
-  it('should skip non-existent fields in multi-field select', () => {
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'feature-branch',
-      commitSha: null,
-      failedTaskIds: [],
-      verifiedTaskIds: [],
-      selfHealingEnabled: false,
-      selfHealingStatus: null,
-      verificationStatus: null,
-      userAction: null,
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
+  it('should skip non-existent fields', () => {
+    const output = createOutput();
     const fields = ['cipeStatus', 'nonExistentField'];
     const result: Record<string, unknown> = {};
 
     for (const field of fields) {
-      // Skip fields that don't exist as keys in output
       if (!(field in output)) {
         continue;
       }
-      const value = getValueByPath(
+      result[field] = getValueByPath(
         output as unknown as Record<string, unknown>,
         field,
       );
-      result[field] = value;
     }
 
-    // nonExistentField should be skipped, not included with error message
     expect(result).toEqual({
       cipeStatus: 'FAILED',
     });
-    expect(result).not.toHaveProperty('nonExistentField');
   });
 
-  it('should truncate long strings in multi-field select', () => {
-    // Create a string longer than SELF_HEALING_CHUNK_SIZE
+  it('should truncate long strings in multi-field select from the start', () => {
     const longString = 'A'.repeat(SELF_HEALING_CHUNK_SIZE + 500);
-    const output: CIInformationOutput = {
-      cipeStatus: 'FAILED',
-      cipeUrl: 'https://cloud.nx.app/cipes/123',
-      branch: 'feature-branch',
-      commitSha: null,
-      failedTaskIds: [],
-      verifiedTaskIds: [],
-      selfHealingEnabled: true,
-      selfHealingStatus: 'COMPLETED',
-      verificationStatus: null,
-      userAction: null,
-      failureClassification: null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: longString,
-      suggestedFixReasoning: null,
-      suggestedFixDescription: null,
-      suggestedFix: null,
-      shortLink: null,
-      couldAutoApplyTasks: null,
-      autoApplySkipped: null,
-      autoApplySkipReason: null,
-      confidence: null,
-      confidenceReasoning: null,
-      selfHealingSkippedReason: null,
-      selfHealingSkipMessage: null,
-      error: null,
-    };
-
-    const fields = ['cipeStatus', 'localTaskSummary'];
+    const output = createOutput({
+      suggestedFix: longString,
+    });
     const result: Record<string, unknown> = {};
 
-    for (const field of fields) {
+    for (const field of ['cipeStatus', 'suggestedFix']) {
       const value = getValueByPath(
         output as unknown as Record<string, unknown>,
         field,
       );
-      if (value === undefined) {
-        result[field] = '[Field not found]';
-      } else if (
-        typeof value === 'string' &&
-        value.length > SELF_HEALING_CHUNK_SIZE
-      ) {
-        // Truncate long strings
+      if (typeof value === 'string' && value.length > SELF_HEALING_CHUNK_SIZE) {
         result[field] =
           value.slice(0, SELF_HEALING_CHUNK_SIZE) +
           `...\n\n[Truncated - use select="${field}" alone for full paginated content]`;
@@ -754,13 +291,90 @@ describe('multi-field select parsing', () => {
     }
 
     expect(result['cipeStatus']).toBe('FAILED');
-    expect(typeof result['localTaskSummary']).toBe('string');
-    expect((result['localTaskSummary'] as string).length).toBeLessThan(
-      longString.length,
+    expect(result['suggestedFix']).toContain('[Truncated');
+    expect(result['suggestedFix']).toContain(
+      'use select="suggestedFix" alone for full paginated content',
     );
-    expect(result['localTaskSummary']).toContain('[Truncated');
-    expect(result['localTaskSummary']).toContain(
-      'use select="localTaskSummary" alone for full paginated content',
+  });
+});
+
+describe('registerNxCloudTools', () => {
+  it('should register ci_task_output and return paginated output', async () => {
+    const terminalOutput = 'A'.repeat(5000) + 'B'.repeat(6000);
+    mockedGetNxCloudTerminalOutput.mockResolvedValue({
+      terminalOutput,
+    });
+
+    const registeredTools = new Map<
+      string,
+      {
+        name: string;
+        handler: (args: Record<string, unknown>) => Promise<unknown>;
+      }
+    >();
+    const registry = {
+      registerTool: jest.fn((tool) => {
+        registeredTools.set(tool.name, tool);
+      }),
+    };
+    const logger = {
+      debug: jest.fn(),
+      log: jest.fn(),
+    };
+
+    registerNxCloudTools(
+      '/workspace',
+      registry as any,
+      logger as any,
+      undefined,
     );
+
+    const tool = registeredTools.get(CI_TASK_OUTPUT);
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error('Expected ci_task_output to be registered');
+    }
+
+    const result = (await tool.handler({
+      taskId: 'app:build',
+      runId: 'run-1',
+      pageToken: 0,
+    })) as {
+      content: Array<{ type: string; text: string }>;
+      structuredContent: {
+        taskId: string;
+        terminalOutput: string | null;
+        error: string | null;
+        currentPage?: number;
+        totalPages?: number;
+      };
+    };
+
+    expect(mockedGetNxCloudTerminalOutput).toHaveBeenCalledWith(
+      { taskId: 'app:build', runId: 'run-1' },
+      '/workspace',
+      logger,
+    );
+    expect(result.structuredContent).toEqual({
+      taskId: 'app:build',
+      terminalOutput: `...[older output on page 1]\n${terminalOutput.slice(-SELF_HEALING_CHUNK_SIZE)}`,
+      error: null,
+      currentPage: 0,
+      totalPages: 2,
+    });
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: 'Showing page 1 of 2 (most recent output first).',
+      },
+      {
+        type: 'text',
+        text: `...[older output on page 1]\n${terminalOutput.slice(-SELF_HEALING_CHUNK_SIZE)}`,
+      },
+      {
+        type: 'text',
+        text: 'Next page token: 1. Call this tool again with the next page token to view older output (1 page(s) remaining).',
+      },
+    ]);
   });
 });

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.spec.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.spec.ts
@@ -455,11 +455,10 @@ describe('resolveSucceededTasks', () => {
       },
     );
 
-    const succeeded = await resolveSucceededTasks(
-      createCipe(),
-      '/workspace',
-      { log: jest.fn(), debug: jest.fn() } as any,
-    );
+    const succeeded = await resolveSucceededTasks(createCipe(), '/workspace', {
+      log: jest.fn(),
+      debug: jest.fn(),
+    } as any);
 
     expect(succeeded).toEqual([
       {
@@ -495,11 +494,10 @@ describe('resolveSucceededTasks', () => {
       },
     );
 
-    const succeeded = await resolveSucceededTasks(
-      createCipe(),
-      '/workspace',
-      { log: jest.fn(), debug: jest.fn() } as any,
-    );
+    const succeeded = await resolveSucceededTasks(createCipe(), '/workspace', {
+      log: jest.fn(),
+      debug: jest.fn(),
+    } as any);
 
     expect(succeeded).toEqual([
       {

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.spec.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.spec.ts
@@ -9,7 +9,11 @@ jest.mock('@nx-console/shared-nx-cloud', () => ({
 }));
 
 import { CI_TASK_OUTPUT } from '@nx-console/shared-llm-context';
-import { getNxCloudTerminalOutput } from '@nx-console/shared-nx-cloud';
+import {
+  getNxCloudTerminalOutput,
+  getRunDetails,
+} from '@nx-console/shared-nx-cloud';
+import { CIPEInfo } from '@nx-console/shared-types';
 
 import { CIInformationOutput } from './output-schemas';
 import {
@@ -20,8 +24,13 @@ import {
 import { getValueByPath } from './nx-workspace';
 
 const mockedGetNxCloudTerminalOutput = jest.mocked(getNxCloudTerminalOutput);
-const { parseShortLink, formatCIInformationOverview, chunkContentReverse } =
-  __testing__;
+const mockedGetRunDetails = jest.mocked(getRunDetails);
+const {
+  parseShortLink,
+  formatCIInformationOverview,
+  chunkContentReverse,
+  resolveSucceededTasks,
+} = __testing__;
 
 function createOutput(
   overrides: Partial<CIInformationOutput> = {},
@@ -374,6 +383,129 @@ describe('registerNxCloudTools', () => {
       {
         type: 'text',
         text: 'Next page token: 1. Call this tool again with the next page token to view older output (1 page(s) remaining).',
+      },
+    ]);
+  });
+});
+
+describe('resolveSucceededTasks', () => {
+  beforeEach(() => {
+    mockedGetRunDetails.mockReset();
+  });
+
+  function createCipe(): CIPEInfo {
+    return {
+      ciPipelineExecutionId: 'cipe-1',
+      branch: 'feature',
+      status: 'FAILED',
+      createdAt: 0,
+      completedAt: null,
+      commitTitle: null,
+      commitUrl: null,
+      cipeUrl: 'https://cloud.nx.app/cipes/cipe-1',
+      runGroups: [
+        {
+          ciExecutionEnv: 'env',
+          runGroup: 'rg-1',
+          createdAt: 0,
+          completedAt: null,
+          status: 'FAILED',
+          runs: [
+            {
+              linkId: 'run-1',
+              command: 'nx run-many -t build',
+              runUrl: 'https://cloud.nx.app/runs/run-1',
+              failedTasks: ['app:build'],
+            },
+            {
+              linkId: 'run-2',
+              command: 'nx run-many -t test',
+              runUrl: 'https://cloud.nx.app/runs/run-2',
+              failedTasks: [],
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it('returns tasks across runs excluding failed ones', async () => {
+    mockedGetRunDetails.mockImplementation(
+      async (_workspacePath, _logger, runId) => {
+        if (runId === 'run-1') {
+          return {
+            data: {
+              id: 'run-1',
+              tasks: [
+                { taskId: 'app:build', status: 'failed' },
+                { taskId: 'app:lint', status: 'success' },
+              ],
+            } as any,
+          };
+        }
+        return {
+          data: {
+            id: 'run-2',
+            tasks: [
+              { taskId: 'lib:test', status: 'success' },
+              { taskId: 'lib:build', status: 'cached' },
+            ],
+          } as any,
+        };
+      },
+    );
+
+    const succeeded = await resolveSucceededTasks(
+      createCipe(),
+      '/workspace',
+      { log: jest.fn(), debug: jest.fn() } as any,
+    );
+
+    expect(succeeded).toEqual([
+      {
+        taskId: 'app:lint',
+        runId: 'run-1',
+        runUrl: 'https://cloud.nx.app/runs/run-1',
+      },
+      {
+        taskId: 'lib:test',
+        runId: 'run-2',
+        runUrl: 'https://cloud.nx.app/runs/run-2',
+      },
+      {
+        taskId: 'lib:build',
+        runId: 'run-2',
+        runUrl: 'https://cloud.nx.app/runs/run-2',
+      },
+    ]);
+  });
+
+  it('skips runs whose getRunDetails errored', async () => {
+    mockedGetRunDetails.mockImplementation(
+      async (_workspacePath, _logger, runId) => {
+        if (runId === 'run-1') {
+          return { error: { type: 'other', message: 'boom' } };
+        }
+        return {
+          data: {
+            id: 'run-2',
+            tasks: [{ taskId: 'lib:test', status: 'success' }],
+          } as any,
+        };
+      },
+    );
+
+    const succeeded = await resolveSucceededTasks(
+      createCipe(),
+      '/workspace',
+      { log: jest.fn(), debug: jest.fn() } as any,
+    );
+
+    expect(succeeded).toEqual([
+      {
+        taskId: 'lib:test',
+        runId: 'run-2',
+        runUrl: 'https://cloud.nx.app/runs/run-2',
       },
     ]);
   });

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -27,7 +27,7 @@ import {
   ciInformationOutputSchema,
   CITaskOutputOutput,
   ciTaskOutputOutputSchema,
-  FailedTaskInfo,
+  TaskInfo,
   UpdateSelfHealingFixOutput,
   updateSelfHealingFixOutputSchema,
 } from './output-schemas';
@@ -399,7 +399,7 @@ async function resolveSucceededTasks(
   cipe: CIPEInfo,
   workspacePath: string,
   logger: Logger,
-): Promise<FailedTaskInfo[]> {
+): Promise<TaskInfo[]> {
   const failedTaskIdSet = new Set<string>();
   const runRefs: { runId: string; runUrl: string }[] = [];
 
@@ -419,7 +419,7 @@ async function resolveSucceededTasks(
     runRefs.map(({ runId }) => getRunDetails(workspacePath, logger, runId)),
   );
 
-  const succeeded: FailedTaskInfo[] = [];
+  const succeeded: TaskInfo[] = [];
   detailsResults.forEach((result, idx) => {
     if (result.error || !result.data) return;
     const { runId, runUrl } = runRefs[idx];
@@ -758,7 +758,7 @@ const getCIInformation =
     const retrievedDifferentCipe =
       cipeIdFromUrl && cipeForBranch.ciPipelineExecutionId !== cipeIdFromUrl;
 
-    const failedTasks: FailedTaskInfo[] = [];
+    const failedTasks: TaskInfo[] = [];
     for (const runGroup of cipeForBranch.runGroups) {
       for (const run of runGroup.runs) {
         if (!run.failedTasks) continue;

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -850,9 +850,7 @@ const getCIInformation =
     hints.push(
       'Use the ci_task_output tool to retrieve full terminal output for any task (pass a runId from failedTasks for direct lookup, or just a taskId to search the CIPE).',
     );
-    hints.push(
-      'Use select="succeededTasks" to list successful tasks (incurs extra API calls).',
-    );
+    hints.push('Use select="succeededTasks" to list successful tasks.');
     output.hints = hints;
 
     const selectedFields = params.select?.split(',').map((s) => s.trim()) ?? [];

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -855,8 +855,7 @@ const getCIInformation =
     );
     output.hints = hints;
 
-    const selectedFields =
-      params.select?.split(',').map((s) => s.trim()) ?? [];
+    const selectedFields = params.select?.split(',').map((s) => s.trim()) ?? [];
     if (selectedFields.includes('succeededTasks')) {
       output.succeededTasks = await resolveSucceededTasks(
         cipeForBranch,

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -395,6 +395,47 @@ function getDisplayTaskId(taskId: string, run: CIPERun): string {
     : taskId;
 }
 
+async function resolveSucceededTasks(
+  cipe: CIPEInfo,
+  workspacePath: string,
+  logger: Logger,
+): Promise<FailedTaskInfo[]> {
+  const failedTaskIdSet = new Set<string>();
+  const runRefs: { runId: string; runUrl: string }[] = [];
+
+  for (const runGroup of cipe.runGroups) {
+    for (const run of runGroup.runs) {
+      for (const taskId of run.failedTasks ?? []) {
+        failedTaskIdSet.add(taskId);
+      }
+      const runId = getRunIdFromRun(run);
+      if (runId) {
+        runRefs.push({ runId, runUrl: run.runUrl });
+      }
+    }
+  }
+
+  const detailsResults = await Promise.all(
+    runRefs.map(({ runId }) => getRunDetails(workspacePath, logger, runId)),
+  );
+
+  const succeeded: FailedTaskInfo[] = [];
+  detailsResults.forEach((result, idx) => {
+    if (result.error || !result.data) return;
+    const { runId, runUrl } = runRefs[idx];
+    for (const task of result.data.tasks ?? []) {
+      if (failedTaskIdSet.has(task.taskId)) continue;
+      succeeded.push({
+        taskId: task.taskId,
+        runId,
+        runUrl,
+      });
+    }
+  });
+
+  return succeeded;
+}
+
 async function resolveCandidateRunIds(
   workspacePath: string,
   logger: Logger,
@@ -809,7 +850,20 @@ const getCIInformation =
     hints.push(
       'Use the ci_task_output tool to retrieve full terminal output for any task (pass a runId from failedTasks for direct lookup, or just a taskId to search the CIPE).',
     );
+    hints.push(
+      'Use select="succeededTasks" to list successful tasks (incurs extra API calls).',
+    );
     output.hints = hints;
+
+    const selectedFields =
+      params.select?.split(',').map((s) => s.trim()) ?? [];
+    if (selectedFields.includes('succeededTasks')) {
+      output.succeededTasks = await resolveSucceededTasks(
+        cipeForBranch,
+        workspacePath,
+        logger,
+      );
+    }
 
     // Branch based on select parameter
     if (!params.select) {
@@ -1245,4 +1299,5 @@ export const __testing__ = {
   parseShortLink,
   formatCIInformationOverview,
   chunkContentReverse,
+  resolveSucceededTasks,
 };

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/nx-cloud.ts
@@ -1,35 +1,21 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
   CI_INFORMATION,
-  CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
-  CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
-  CLOUD_ANALYTICS_RUN_DETAILS,
-  CLOUD_ANALYTICS_RUNS_SEARCH,
-  CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
-  CLOUD_ANALYTICS_TASKS_SEARCH,
+  CI_TASK_OUTPUT,
   UPDATE_SELF_HEALING_FIX,
 } from '@nx-console/shared-llm-context';
 import {
-  formatPipelineExecutionDetailsContent,
-  formatPipelineExecutionsSearchContent,
-  formatRunDetailsContent,
-  formatRunsSearchContent,
-  formatTasksDetailsSearchContent,
-  formatTasksSearchContent,
   getRecentCIPEData,
   getPipelineExecutionDetails,
-  getPipelineExecutionsSearch,
+  getNxCloudTerminalOutput,
   getRunDetails,
-  getRunsSearch,
-  getTasksDetailsSearch,
-  getTasksSearch,
   parseNxCloudUrl,
   ParsedNxCloudUrl,
   retrieveFixDiff,
   updateSuggestedFix,
 } from '@nx-console/shared-nx-cloud';
 import { NxConsoleTelemetryLogger } from '@nx-console/shared-telemetry';
-import { CIPEInfo, NxAiFix } from '@nx-console/shared-types';
+import { CIPEInfo, CIPERun, NxAiFix } from '@nx-console/shared-types';
 import { Logger } from '@nx-console/shared-utils';
 import { execSync } from 'child_process';
 import { z } from 'zod';
@@ -39,13 +25,15 @@ import { chunkContent, getValueByPath } from './nx-workspace';
 import {
   CIInformationOutput,
   ciInformationOutputSchema,
+  CITaskOutputOutput,
+  ciTaskOutputOutputSchema,
+  FailedTaskInfo,
   UpdateSelfHealingFixOutput,
   updateSelfHealingFixOutputSchema,
 } from './output-schemas';
 
 export const SELF_HEALING_CHUNK_SIZE = 10000;
 
-const TRUNCATION_LENGTH = 1000;
 const DIFF_PREVIEW_LENGTH = 3000;
 
 /**
@@ -67,15 +55,6 @@ function truncateString(
 }
 
 /**
- * Fields that should use reverse pagination (task outputs - most recent first).
- */
-const REVERSE_PAGINATION_FIELDS = [
-  'remoteTaskSummary',
-  'localTaskSummary',
-  'taskOutputSummary',
-];
-
-/**
  * Chunk content from the end (reverse pagination).
  * Page 0 returns the most recent content (end of string).
  * Higher page numbers return progressively older content.
@@ -84,17 +63,22 @@ export function chunkContentReverse(
   content: string,
   pageNumber: number,
   chunkSize: number,
-): { chunk: string; hasMore: boolean } {
+): { chunk: string; hasMore: boolean; totalPages: number } {
   if (!content || content.length === 0) {
-    return { chunk: '', hasMore: false };
+    return { chunk: '', hasMore: false, totalPages: 0 };
   }
 
   const len = content.length;
+  const totalPages = Math.max(1, Math.ceil(len / chunkSize));
   const endIndex = len - pageNumber * chunkSize;
   const startIndex = Math.max(0, endIndex - chunkSize);
 
   if (endIndex <= 0) {
-    return { chunk: `no more content on page ${pageNumber}`, hasMore: false };
+    return {
+      chunk: `no more content on page ${pageNumber}`,
+      hasMore: false,
+      totalPages,
+    };
   }
 
   let chunk = content.slice(startIndex, endIndex);
@@ -104,7 +88,7 @@ export function chunkContentReverse(
     chunk = `...[older output on page ${pageNumber + 1}]\n${chunk}`;
   }
 
-  return { chunk, hasMore };
+  return { chunk, hasMore, totalPages };
 }
 
 export function registerNxCloudTools(
@@ -114,150 +98,6 @@ export function registerNxCloudTools(
   telemetry?: NxConsoleTelemetryLogger,
   toolsFilter?: string[],
 ): void {
-  if (!isToolEnabled(CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH, toolsFilter)) {
-    logger.debug?.(
-      `Skipping ${CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH} - disabled by tools filter`,
-    );
-  } else {
-    registry.registerTool({
-      name: CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
-      description:
-        'Analyze historical pipeline execution data from Nx Cloud to identify trends and patterns in CI/CD workflows. Use this analytics tool to track pipeline success rates over time, investigate performance patterns across branches or authors, and gain insights into team productivity. Filter by branch, status, author, or time range to analyze specific segments of your CI/CD history. Pipeline executions are the top-level containers in the hierarchy. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
-      inputSchema: pipelineExecutionSearchSchema.shape,
-      annotations: {
-        destructiveHint: false,
-        readOnlyHint: true,
-        openWorldHint: true,
-      },
-      handler: async (args) =>
-        nxCloudPipelineExecutionsSearch(
-          workspacePath,
-          logger,
-          telemetry,
-        )(args as z.infer<typeof pipelineExecutionSearchSchema>),
-    });
-  }
-
-  if (!isToolEnabled(CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS, toolsFilter)) {
-    logger.debug?.(
-      `Skipping ${CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS} - disabled by tools filter`,
-    );
-  } else {
-    registry.registerTool({
-      name: CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
-      description:
-        'Analyze detailed historical data for a specific pipeline execution in Nx Cloud. Use this analytics tool to investigate the complete structure of a past CI/CD run, understand performance bottlenecks, and identify optimization opportunities. Returns the full hierarchy including run groups and their associated runs, helping you gain insights into how the pipeline was executed and where improvements can be made.',
-      inputSchema: pipelineExecutionDetailsSchema.shape,
-      annotations: {
-        destructiveHint: false,
-        readOnlyHint: true,
-        openWorldHint: true,
-      },
-      handler: async (args) =>
-        nxCloudPipelineExecutionDetails(
-          workspacePath,
-          logger,
-          telemetry,
-        )(args as z.infer<typeof pipelineExecutionDetailsSchema>),
-    });
-  }
-
-  if (!isToolEnabled(CLOUD_ANALYTICS_RUNS_SEARCH, toolsFilter)) {
-    logger.debug?.(
-      `Skipping ${CLOUD_ANALYTICS_RUNS_SEARCH} - disabled by tools filter`,
-    );
-  } else {
-    registry.registerTool({
-      name: CLOUD_ANALYTICS_RUNS_SEARCH,
-      description:
-        'Analyze historical run data from Nx Cloud to track performance trends and team productivity patterns. Runs are mid-level containers within pipeline executions, each representing execution of a specific command (like "nx affected:build"). Use this analytics tool to identify which commands are taking the longest, track success rates across different run groups, and understand how your team\'s build patterns have evolved over time. Filter by pipeline execution, branch, run group, or status to analyze specific segments. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
-      inputSchema: runSearchSchema.shape,
-      annotations: {
-        destructiveHint: false,
-        readOnlyHint: true,
-        openWorldHint: true,
-      },
-      handler: async (args) =>
-        nxCloudRunsSearch(
-          workspacePath,
-          logger,
-          telemetry,
-        )(args as z.infer<typeof runSearchSchema>),
-    });
-  }
-
-  if (!isToolEnabled(CLOUD_ANALYTICS_RUN_DETAILS, toolsFilter)) {
-    logger.debug?.(
-      `Skipping ${CLOUD_ANALYTICS_RUN_DETAILS} - disabled by tools filter`,
-    );
-  } else {
-    registry.registerTool({
-      name: CLOUD_ANALYTICS_RUN_DETAILS,
-      description:
-        'Analyze detailed historical data for a specific run in Nx Cloud. Use this analytics tool to investigate command execution performance, understand task distribution patterns, and identify optimization opportunities. Returns comprehensive information including the command executed, duration, status, and all tasks that were part of this run, helping you gain insights into where time is being spent and how to improve build efficiency.',
-      inputSchema: runDetailsSchema.shape,
-      annotations: {
-        destructiveHint: false,
-        readOnlyHint: true,
-        openWorldHint: true,
-      },
-      handler: async (args) =>
-        nxCloudRunDetails(
-          workspacePath,
-          logger,
-          telemetry,
-        )(args as z.infer<typeof runDetailsSchema>),
-    });
-  }
-
-  if (!isToolEnabled(CLOUD_ANALYTICS_TASKS_SEARCH, toolsFilter)) {
-    logger.debug?.(
-      `Skipping ${CLOUD_ANALYTICS_TASKS_SEARCH} - disabled by tools filter`,
-    );
-  } else {
-    registry.registerTool({
-      name: CLOUD_ANALYTICS_TASKS_SEARCH,
-      description:
-        'Analyze aggregated task performance statistics from Nx Cloud to identify optimization opportunities and track trends over time. Returns performance metrics including success rates, cache hit rates, and average durations for each task (project + target combination). Use this analytics tool to understand which tasks are the slowest, track cache effectiveness trends, identify projects with low success rates, and gain insights into overall team productivity patterns. Filter by project, target, or time range to analyze specific segments. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
-      inputSchema: taskSearchSchema.shape,
-      annotations: {
-        destructiveHint: false,
-        readOnlyHint: true,
-        openWorldHint: true,
-      },
-      handler: async (args) =>
-        nxCloudTasksSearch(
-          workspacePath,
-          logger,
-          telemetry,
-        )(args as z.infer<typeof taskSearchSchema>),
-    });
-  }
-
-  if (!isToolEnabled(CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH, toolsFilter)) {
-    logger.debug?.(
-      `Skipping ${CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH} - disabled by tools filter`,
-    );
-  } else {
-    registry.registerTool({
-      name: CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
-      description:
-        'Analyze individual task execution data from Nx Cloud to investigate performance trends and understand task behavior over time. Returns detailed information for each task execution including project, target, duration, cache status, and parameters. Use this analytics tool to track how specific tasks perform across different runs, identify patterns in cache misses, and gain insights into which task configurations are most efficient. Filter by project, target, or time range to analyze specific execution patterns. If a pagination token is returned, call this tool again with the token to retrieve additional results and ensure all data is collected.',
-      inputSchema: taskDetailsSchema.shape,
-      annotations: {
-        destructiveHint: false,
-        readOnlyHint: true,
-        openWorldHint: true,
-      },
-      handler: async (args) =>
-        nxCloudTaskDetails(
-          workspacePath,
-          logger,
-          telemetry,
-        )(args as z.infer<typeof taskDetailsSchema>),
-    });
-  }
-
   if (!isToolEnabled(CI_INFORMATION, toolsFilter)) {
     logger.debug?.(`Skipping ${CI_INFORMATION} - disabled by tools filter`);
   } else {
@@ -266,7 +106,7 @@ export function registerNxCloudTools(
       description:
         'Retrieve CI pipeline execution information from Nx Cloud for the current branch. ' +
         'Supports Nx Cloud URLs: CIPE URLs (/cipes/{id}), run URLs (/runs/{id}), and task URLs (/runs/{id}/task/{taskId}). ' +
-        'Without select parameter: Returns formatted overview (CIPE status, failed task IDs, self-healing status). ' +
+        'Without select parameter: Returns formatted overview (CIPE status, failed tasks, self-healing status). ' +
         'With select parameter: Returns raw JSON value at specified path. ' +
         'Includes selfHealingSkippedReason/selfHealingSkipMessage when self-healing was skipped (e.g. THROTTLED). ' +
         'Includes autoApplySkipped/autoApplySkipReason when a fix could have been auto-applied but was skipped. ' +
@@ -284,6 +124,32 @@ export function registerNxCloudTools(
           logger,
           telemetry,
         )(args as z.infer<typeof ciInformationSchema>),
+    });
+  }
+
+  if (!isToolEnabled(CI_TASK_OUTPUT, toolsFilter)) {
+    logger.debug?.(`Skipping ${CI_TASK_OUTPUT} - disabled by tools filter`);
+  } else {
+    registry.registerTool({
+      name: CI_TASK_OUTPUT,
+      description:
+        'Retrieve the terminal output (logs) for any CI task (failed or successful). ' +
+        'If runId is provided, fetches logs directly from that run. ' +
+        'If only taskId is provided, iterates through the runs of the matching CIPE (current branch by default) until the task is found. ' +
+        'Supports Nx Cloud URLs for cross-branch lookups.',
+      inputSchema: ciTaskOutputSchema.shape,
+      outputSchema: ciTaskOutputOutputSchema,
+      annotations: {
+        destructiveHint: false,
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      handler: async (args) =>
+        handleCITaskOutput(
+          workspacePath,
+          logger,
+          telemetry,
+        )(args as z.infer<typeof ciTaskOutputSchema>),
     });
   }
 
@@ -354,173 +220,6 @@ export const renderCipeDetails = (cipe: CIPEInfo): string => {
 };
 
 // Schemas for the new tools
-const pipelineExecutionSearchSchema = z.object({
-  branches: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by specific branches'),
-  statuses: z
-    .array(z.string())
-    .optional()
-    .describe(
-      'Filter by execution statuses (e.g., "NOT_STARTED", "IN_PROGRESS", "SUCCEEDED", "FAILED", "CANCELED", "TIMED_OUT")',
-    ),
-  authors: z.array(z.string()).optional().describe('Filter by commit authors'),
-  repositoryUrl: z.string().optional().describe('Filter by repository URL'),
-  minCreatedAt: z
-    .string()
-    .optional()
-    .describe(
-      'Minimum creation time. Can be an exact date or relative to today in natural language (e.g., "2024-01-01", "yesterday", "3 days ago", "last week")',
-    ),
-  maxCreatedAt: z
-    .string()
-    .optional()
-    .describe(
-      'Maximum creation time. Can be an exact date or relative to today in natural language (e.g., "2024-12-31", "today", "2 hours ago", "last month")',
-    ),
-  vcsTitleContains: z
-    .string()
-    .optional()
-    .describe('Filter by VCS title containing this text'),
-  limit: z
-    .number()
-    .optional()
-    .default(50)
-    .describe('Maximum number of results to return'),
-  pageToken: z.string().optional().describe('Token for pagination'),
-});
-
-const pipelineExecutionDetailsSchema = z.object({
-  pipelineExecutionId: z
-    .string()
-    .describe('The ID of the pipeline execution to retrieve'),
-});
-
-const runSearchSchema = z.object({
-  pipelineExecutionId: z
-    .string()
-    .optional()
-    .describe('Filter by pipeline execution ID'),
-  branches: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by specific branches'),
-  runGroups: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by run group names'),
-  commitShas: z.array(z.string()).optional().describe('Filter by commit SHAs'),
-  statuses: z
-    .array(z.string())
-    .optional()
-    .describe(
-      'Filter by run statuses (e.g., "NOT_STARTED", "IN_PROGRESS", "SUCCEEDED", "FAILED", "CANCELED", "TIMED_OUT")',
-    ),
-  minStartTime: z
-    .string()
-    .optional()
-    .describe(
-      'Minimum start time. Can be an exact date or relative to today in natural language (e.g., "2024-01-01", "yesterday", "3 days ago", "last week")',
-    ),
-  maxStartTime: z
-    .string()
-    .optional()
-    .describe(
-      'Maximum start time. Can be an exact date or relative to today in natural language (e.g., "2024-12-31", "today", "2 hours ago", "last month")',
-    ),
-  limit: z
-    .number()
-    .optional()
-    .default(50)
-    .describe('Maximum number of results to return'),
-  pageToken: z.string().optional().describe('Token for pagination'),
-});
-
-const runDetailsSchema = z.object({
-  runId: z.string().describe('The ID of the run to retrieve'),
-});
-
-const taskSearchSchema = z.object({
-  taskIds: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by specific task IDs'),
-  projectNames: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by project names'),
-  targets: z.array(z.string()).optional().describe('Filter by target names'),
-  configurations: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by configurations'),
-  minStartTime: z
-    .string()
-    .optional()
-    .describe(
-      'Minimum start time. Can be an exact date or relative to today in natural language (e.g., "2024-01-01", "yesterday", "3 days ago", "last week")',
-    ),
-  maxStartTime: z
-    .string()
-    .optional()
-    .describe(
-      'Maximum start time. Can be an exact date or relative to today in natural language (e.g., "2024-12-31", "today", "2 hours ago", "last month")',
-    ),
-  limit: z
-    .number()
-    .optional()
-    .default(100)
-    .describe('Maximum number of results to return'),
-  pageToken: z.string().optional().describe('Token for pagination'),
-  includeLocal: z
-    .boolean()
-    .optional()
-    .describe(
-      'Include data from local machine runs in addition to CI data. If false or omitted, only CI data is included.',
-    ),
-});
-
-const taskDetailsSchema = z.object({
-  taskIds: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by specific task IDs'),
-  projectNames: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by project names'),
-  targets: z.array(z.string()).optional().describe('Filter by target names'),
-  configurations: z
-    .array(z.string())
-    .optional()
-    .describe('Filter by configurations'),
-  minStartTime: z
-    .string()
-    .optional()
-    .describe(
-      'Minimum start time. Can be an exact date or relative to today in natural language (e.g., "2024-01-01", "yesterday", "3 days ago", "last week")',
-    ),
-  maxStartTime: z
-    .string()
-    .optional()
-    .describe(
-      'Maximum start time. Can be an exact date or relative to today in natural language (e.g., "2024-12-31", "today", "2 hours ago", "last month")',
-    ),
-  limit: z
-    .number()
-    .optional()
-    .default(100)
-    .describe('Maximum number of results to return'),
-  pageToken: z.string().optional().describe('Token for pagination'),
-  includeLocal: z
-    .boolean()
-    .optional()
-    .describe(
-      'Include data from local machine runs in addition to CI data. If false or omitted, only CI data is included.',
-    ),
-});
-
 const ciInformationSchema = z.object({
   url: z
     .string()
@@ -547,9 +246,39 @@ const ciInformationSchema = z.object({
     .number()
     .optional()
     .describe(
-      'Pagination token (0-based). Only used when select returns a long string value. ' +
-        'Task summaries use reverse pagination (page 0 = most recent output). ' +
-        'Other strings use forward pagination (page 0 = start).',
+      'Pagination token (0-based). Only used when select returns a long string value.',
+    ),
+});
+
+const ciTaskOutputSchema = z.object({
+  taskId: z
+    .string()
+    .describe('The task ID to get output for (e.g., "myapp:build")'),
+  runId: z
+    .string()
+    .optional()
+    .describe(
+      'The run ID containing the task. If provided, fetches logs directly without CIPE resolution. Can be obtained from ci_information failedTasks or from any Nx Cloud run URL.',
+    ),
+  url: z
+    .string()
+    .optional()
+    .describe(
+      'An Nx Cloud URL to resolve the CIPE from. Supports CIPE URLs (/cipes/{id}), ' +
+        'run URLs (/runs/{id}), and task URLs (/runs/{id}/task/{taskId}). ' +
+        'Only used when runId is not provided.',
+    ),
+  branch: z
+    .string()
+    .optional()
+    .describe(
+      'Branch name to find the CIPE. Defaults to current git branch. Only used when runId is not provided.',
+    ),
+  pageToken: z
+    .number()
+    .optional()
+    .describe(
+      'Pagination token (0-based). Terminal output uses reverse pagination (page 0 = most recent output).',
     ),
 });
 
@@ -576,184 +305,6 @@ const updateSelfHealingFixSchema = z.object({
       'Action to perform on the fix: APPLY to accept, REJECT to decline, RERUN_ENVIRONMENT_STATE to request a CI rerun (only available for pipeline executions that failed due to an environment issue).',
     ),
 });
-
-// Implementation functions
-const nxCloudPipelineExecutionsSearch =
-  (
-    workspacePath: string,
-    logger: Logger,
-    telemetry: NxConsoleTelemetryLogger | undefined,
-  ) =>
-  async (
-    params: z.infer<typeof pipelineExecutionSearchSchema>,
-  ): Promise<CallToolResult> => {
-    telemetry?.logUsage('ai.tool-call', {
-      tool: CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH,
-    });
-
-    const result = await getPipelineExecutionsSearch(
-      workspacePath,
-      logger,
-      params,
-    );
-
-    if (result.error) {
-      throw new Error(
-        `Error searching pipeline executions: ${result.error.message}`,
-      );
-    }
-
-    const textContent = formatPipelineExecutionsSearchContent(result.data!);
-    const content: CallToolResult['content'] = textContent.map((text) => ({
-      type: 'text',
-      text,
-    }));
-
-    return { content };
-  };
-
-const nxCloudPipelineExecutionDetails =
-  (
-    workspacePath: string,
-    logger: Logger,
-    telemetry: NxConsoleTelemetryLogger | undefined,
-  ) =>
-  async (
-    params: z.infer<typeof pipelineExecutionDetailsSchema>,
-  ): Promise<CallToolResult> => {
-    telemetry?.logUsage('ai.tool-call', {
-      tool: CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS,
-    });
-
-    const result = await getPipelineExecutionDetails(
-      workspacePath,
-      logger,
-      params.pipelineExecutionId,
-    );
-
-    if (result.error) {
-      throw new Error(
-        `Error getting pipeline execution details: ${result.error.message}`,
-      );
-    }
-
-    const textContent = formatPipelineExecutionDetailsContent(result.data!);
-    const content: CallToolResult['content'] = textContent.map((text) => ({
-      type: 'text',
-      text,
-    }));
-
-    return { content };
-  };
-
-// In Progress
-const nxCloudRunsSearch =
-  (
-    workspacePath: string,
-    logger: Logger,
-    telemetry: NxConsoleTelemetryLogger | undefined,
-  ) =>
-  async (params: z.infer<typeof runSearchSchema>): Promise<CallToolResult> => {
-    telemetry?.logUsage('ai.tool-call', {
-      tool: CLOUD_ANALYTICS_RUNS_SEARCH,
-    });
-
-    const result = await getRunsSearch(workspacePath, logger, params);
-
-    if (result.error) {
-      throw new Error(`Error searching runs: ${result.error.message}`);
-    }
-
-    const textContent = formatRunsSearchContent(result.data!);
-    const content: CallToolResult['content'] = textContent.map((text) => ({
-      type: 'text',
-      text,
-    }));
-
-    return { content };
-  };
-
-const nxCloudRunDetails =
-  (
-    workspacePath: string,
-    logger: Logger,
-    telemetry: NxConsoleTelemetryLogger | undefined,
-  ) =>
-  async (params: z.infer<typeof runDetailsSchema>): Promise<CallToolResult> => {
-    telemetry?.logUsage('ai.tool-call', {
-      tool: CLOUD_ANALYTICS_RUN_DETAILS,
-    });
-
-    const result = await getRunDetails(workspacePath, logger, params.runId);
-
-    if (result.error) {
-      throw new Error(`Error getting run details: ${result.error.message}`);
-    }
-
-    const textContent = formatRunDetailsContent(result.data!);
-    const content: CallToolResult['content'] = textContent.map((text) => ({
-      type: 'text',
-      text,
-    }));
-
-    return { content };
-  };
-
-const nxCloudTasksSearch =
-  (
-    workspacePath: string,
-    logger: Logger,
-    telemetry: NxConsoleTelemetryLogger | undefined,
-  ) =>
-  async (params: z.infer<typeof taskSearchSchema>): Promise<CallToolResult> => {
-    telemetry?.logUsage('ai.tool-call', {
-      tool: CLOUD_ANALYTICS_TASKS_SEARCH,
-    });
-
-    const result = await getTasksSearch(workspacePath, logger, params);
-
-    if (result.error) {
-      throw new Error(`Error searching tasks: ${result.error.message}`);
-    }
-
-    const textContent = formatTasksSearchContent(result.data!);
-    const content: CallToolResult['content'] = textContent.map((text) => ({
-      type: 'text',
-      text,
-    }));
-
-    return { content };
-  };
-
-const nxCloudTaskDetails =
-  (
-    workspacePath: string,
-    logger: Logger,
-    telemetry: NxConsoleTelemetryLogger | undefined,
-  ) =>
-  async (
-    params: z.infer<typeof taskDetailsSchema>,
-  ): Promise<CallToolResult> => {
-    telemetry?.logUsage('ai.tool-call', {
-      tool: CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH,
-    });
-
-    const result = await getTasksDetailsSearch(workspacePath, logger, params);
-
-    if (result.error) {
-      throw new Error(`Error searching task details: ${result.error.message}`);
-    }
-
-    const textContent = formatTasksDetailsSearchContent(result.data!);
-    const content: CallToolResult['content'] = textContent.map(
-      (text: string) => ({
-        type: 'text',
-        text,
-      }),
-    );
-
-    return { content };
-  };
 
 function getCurrentGitBranch(workspacePath: string): string | null {
   try {
@@ -832,6 +383,221 @@ async function resolveUrlToBranch(
     cipeId: runResult.data.distributedExecutionId,
   };
 }
+
+function getRunIdFromRun(run: CIPERun): string | undefined {
+  return run.linkId ?? run.executionId;
+}
+
+function getDisplayTaskId(taskId: string, run: CIPERun): string {
+  return taskId === 'upload-run-result:record-command' ||
+    taskId === 'nx-cloud-tasks-runner:record-command'
+    ? run.command
+    : taskId;
+}
+
+async function resolveCandidateRunIds(
+  workspacePath: string,
+  logger: Logger,
+  url?: string,
+  branch?: string,
+): Promise<{ runIds?: string[]; branch?: string; error?: string }> {
+  let resolvedBranch: string | undefined;
+
+  if (url) {
+    const parsed = parseNxCloudUrl(url);
+    if (!parsed) {
+      return {
+        error:
+          'Invalid Nx Cloud URL. Supported patterns: /cipes/{id}, /runs/{id}, /runs/{id}/task/{taskId}',
+      };
+    }
+
+    const urlResolution = await resolveUrlToBranch(
+      parsed,
+      workspacePath,
+      logger,
+    );
+    if (urlResolution.error) {
+      return { error: urlResolution.error };
+    }
+    resolvedBranch = urlResolution.branch;
+  } else {
+    resolvedBranch = branch ?? getCurrentGitBranch(workspacePath) ?? undefined;
+    if (!resolvedBranch) {
+      return {
+        error:
+          'Could not determine the current git branch. Please provide a branch name, URL, or runId explicitly.',
+      };
+    }
+  }
+
+  const cipeResult = await getRecentCIPEData(workspacePath, logger, {
+    branch: resolvedBranch,
+  });
+
+  if (cipeResult.error) {
+    return {
+      error: `Failed to retrieve CI information: ${cipeResult.error.message}`,
+    };
+  }
+
+  const cipeForBranch = cipeResult.info?.find(
+    (cipe) => cipe.branch === resolvedBranch,
+  );
+
+  if (!cipeForBranch) {
+    return {
+      error: `No CI pipeline execution found for branch "${resolvedBranch}".`,
+    };
+  }
+
+  const runIds: string[] = [];
+  for (const runGroup of cipeForBranch.runGroups) {
+    for (const run of runGroup.runs) {
+      const runId = getRunIdFromRun(run);
+      if (runId && !runIds.includes(runId)) {
+        runIds.push(runId);
+      }
+    }
+  }
+
+  if (runIds.length === 0) {
+    return {
+      error: `No runs found in the CI pipeline execution for branch "${resolvedBranch}".`,
+      branch: resolvedBranch,
+    };
+  }
+
+  return { runIds, branch: resolvedBranch };
+}
+
+const handleCITaskOutput =
+  (
+    workspacePath: string,
+    logger: Logger,
+    telemetry: NxConsoleTelemetryLogger | undefined,
+  ) =>
+  async (
+    params: z.infer<typeof ciTaskOutputSchema>,
+  ): Promise<CallToolResult> => {
+    telemetry?.logUsage('ai.tool-call', {
+      tool: CI_TASK_OUTPUT,
+    });
+
+    let candidateRunIds: string[];
+    let branchForError: string | undefined;
+
+    const parsedUrl = params.url ? parseNxCloudUrl(params.url) : null;
+    if (params.url && !parsedUrl) {
+      const errorMessage =
+        'Invalid Nx Cloud URL. Supported patterns: /cipes/{id}, /runs/{id}, /runs/{id}/task/{taskId}';
+      const output: CITaskOutputOutput = {
+        taskId: params.taskId,
+        terminalOutput: null,
+        error: errorMessage,
+      };
+      return {
+        content: [{ type: 'text', text: errorMessage }],
+        structuredContent: output,
+        isError: true,
+      };
+    }
+
+    if (params.runId) {
+      candidateRunIds = [params.runId];
+    } else if (parsedUrl?.type === 'run' || parsedUrl?.type === 'task') {
+      candidateRunIds = [parsedUrl.runId];
+    } else {
+      const resolved = await resolveCandidateRunIds(
+        workspacePath,
+        logger,
+        params.url,
+        params.branch,
+      );
+      if (resolved.error) {
+        const output: CITaskOutputOutput = {
+          taskId: params.taskId,
+          terminalOutput: null,
+          error: resolved.error,
+        };
+        return {
+          content: [{ type: 'text', text: resolved.error }],
+          structuredContent: output,
+          isError: true,
+        };
+      }
+      candidateRunIds = resolved.runIds ?? [];
+      branchForError = resolved.branch;
+    }
+
+    let result: { terminalOutput?: string; error?: string } | undefined;
+    let lastError: string | undefined;
+    for (const runId of candidateRunIds) {
+      const attempt = await getNxCloudTerminalOutput(
+        { taskId: params.taskId, runId },
+        workspacePath,
+        logger,
+      );
+      if (attempt.terminalOutput !== undefined) {
+        result = attempt;
+        break;
+      }
+      lastError = attempt.error;
+    }
+
+    if (!result) {
+      const errorMessage =
+        candidateRunIds.length === 1
+          ? `Error: ${lastError ?? `No terminal output found for task "${params.taskId}" in run "${candidateRunIds[0]}".`}`
+          : `Task "${params.taskId}" not found in any run for branch "${branchForError ?? 'unknown'}". Last error: ${lastError ?? 'unknown'}`;
+      const output: CITaskOutputOutput = {
+        taskId: params.taskId,
+        terminalOutput: null,
+        error: errorMessage,
+      };
+      return {
+        content: [{ type: 'text', text: errorMessage }],
+        structuredContent: output,
+        isError: true,
+      };
+    }
+
+    const terminalOutput = result.terminalOutput ?? '';
+    const pageNumber = params.pageToken ?? 0;
+    const { chunk, hasMore, totalPages } = chunkContentReverse(
+      terminalOutput,
+      pageNumber,
+      SELF_HEALING_CHUNK_SIZE,
+    );
+
+    const output: CITaskOutputOutput = {
+      taskId: params.taskId,
+      terminalOutput: chunk,
+      error: null,
+      currentPage: pageNumber,
+      totalPages,
+    };
+
+    const content: CallToolResult['content'] = [];
+
+    if (totalPages > 1) {
+      content.push({
+        type: 'text',
+        text: `Showing page ${pageNumber + 1} of ${totalPages} (most recent output first).`,
+      });
+    }
+
+    content.push({ type: 'text', text: chunk });
+
+    if (hasMore) {
+      content.push({
+        type: 'text',
+        text: `Next page token: ${pageNumber + 1}. Call this tool again with the next page token to view older output (${totalPages - pageNumber - 1} page(s) remaining).`,
+      });
+    }
+
+    return { content, structuredContent: output };
+  };
 
 const getCIInformation =
   (
@@ -923,16 +689,13 @@ const getCIInformation =
           cipeUrl: null,
           branch: branch ?? null,
           commitSha: null,
-          failedTaskIds: [],
+          failedTasks: [],
           verifiedTaskIds: [],
           selfHealingEnabled: false,
           selfHealingStatus: null,
           verificationStatus: null,
           userAction: null,
           failureClassification: null,
-          taskOutputSummary: null,
-          remoteTaskSummary: null,
-          localTaskSummary: null,
           suggestedFixReasoning: null,
           suggestedFixDescription: null,
           suggestedFix: null,
@@ -954,23 +717,18 @@ const getCIInformation =
     const retrievedDifferentCipe =
       cipeIdFromUrl && cipeForBranch.ciPipelineExecutionId !== cipeIdFromUrl;
 
-    // Collect all failed task IDs from all runs
-    const failedTaskIds: string[] = [];
+    const failedTasks: FailedTaskInfo[] = [];
     for (const runGroup of cipeForBranch.runGroups) {
       for (const run of runGroup.runs) {
-        if (run.failedTasks) {
-          for (const taskId of run.failedTasks) {
-            // Transform record-command tasks to use the actual command for better agent understanding
-            // These taskIds are internal placeholders - the real command is in run.command
-            if (
-              taskId === 'upload-run-result:record-command' ||
-              taskId === 'nx-cloud-tasks-runner:record-command'
-            ) {
-              failedTaskIds.push(run.command);
-            } else {
-              failedTaskIds.push(taskId);
-            }
-          }
+        if (!run.failedTasks) continue;
+
+        const runId = getRunIdFromRun(run) ?? '';
+        for (const taskId of run.failedTasks) {
+          failedTasks.push({
+            taskId: getDisplayTaskId(taskId, run),
+            runId,
+            runUrl: run.runUrl,
+          });
         }
       }
     }
@@ -992,16 +750,13 @@ const getCIInformation =
       cipeUrl: cipeForBranch.cipeUrl,
       branch: cipeForBranch.branch,
       commitSha: null,
-      failedTaskIds,
+      failedTasks,
       verifiedTaskIds: aiFix?.verificationTasksExecuted ?? [],
       selfHealingEnabled,
       selfHealingStatus: aiFix?.suggestedFixStatus ?? null,
       verificationStatus: aiFix?.verificationStatus ?? null,
       userAction: aiFix?.userAction ?? null,
       failureClassification: aiFix?.failureClassification ?? null,
-      taskOutputSummary: null,
-      remoteTaskSummary: null,
-      localTaskSummary: null,
       suggestedFixReasoning: aiFix?.suggestedFixReasoning ?? null,
       suggestedFixDescription: aiFix?.suggestedFixDescription ?? null,
       suggestedFix: aiFix?.suggestedFix ?? null,
@@ -1030,18 +785,6 @@ const getCIInformation =
         );
         if (fixResult.data) {
           output.commitSha = fixResult.data.commitSha;
-          // Prefer new API fields (remoteTaskSummary and localTaskSummary) over old taskOutputSummary
-          output.remoteTaskSummary = fixResult.data.remoteTaskSummary ?? null;
-          output.localTaskSummary = fixResult.data.localTaskSummary ?? null;
-          // Backwards compatibility for taskOutputSummary:
-          // - If new fields available, combine them
-          // - Otherwise fall back to old API field
-          output.taskOutputSummary =
-            output.remoteTaskSummary || output.localTaskSummary
-              ? [output.remoteTaskSummary, output.localTaskSummary]
-                  .filter(Boolean)
-                  .join('\n\n---\n\n')
-              : (fixResult.data.taskOutputSummary ?? null);
           output.suggestedFixReasoning = fixResult.data.suggestedFixReasoning;
           output.suggestedFixDescription =
             fixResult.data.suggestedFixDescription;
@@ -1064,7 +807,7 @@ const getCIInformation =
       hints.push(retrievedDifferentCipeDisclaimer);
     }
     hints.push(
-      'remoteTaskSummary contains output from tasks that ran on CI machines. localTaskSummary contains output from the self-healing agent machine.',
+      'Use the ci_task_output tool to retrieve full terminal output for any task (pass a runId from failedTasks for direct lookup, or just a taskId to search the CIPE).',
     );
     output.hints = hints;
 
@@ -1118,16 +861,11 @@ const getCIInformation =
       // Handle string values with pagination
       if (typeof selectedValue === 'string') {
         const pageNumber = params.pageToken ?? 0;
-        const useReversePagination =
-          REVERSE_PAGINATION_FIELDS.includes(fieldName);
-
-        const { chunk, hasMore } = useReversePagination
-          ? chunkContentReverse(
-              selectedValue,
-              pageNumber,
-              SELF_HEALING_CHUNK_SIZE,
-            )
-          : chunkContent(selectedValue, pageNumber, SELF_HEALING_CHUNK_SIZE);
+        const { chunk, hasMore } = chunkContent(
+          selectedValue,
+          pageNumber,
+          SELF_HEALING_CHUNK_SIZE,
+        );
 
         // Format diff content with code block
         const isDiff = fieldName === 'suggestedFix';
@@ -1138,12 +876,9 @@ const getCIInformation =
         ];
 
         if (hasMore) {
-          const paginationHint = useReversePagination
-            ? 'to view older output'
-            : 'to continue';
           content.push({
             type: 'text',
-            text: `Next page token: ${pageNumber + 1}. Call this tool again with the next page token ${paginationHint}.`,
+            text: `Next page token: ${pageNumber + 1}. Call this tool again with the next page token to continue.`,
           });
         }
 
@@ -1174,10 +909,8 @@ const getCIInformation =
         field,
       );
       if (typeof value === 'string' && value.length > SELF_HEALING_CHUNK_SIZE) {
-        // Truncate long strings, indicate more available
-        const fromEnd = REVERSE_PAGINATION_FIELDS.includes(field);
         result[field] =
-          truncateString(value, SELF_HEALING_CHUNK_SIZE, fromEnd) +
+          truncateString(value, SELF_HEALING_CHUNK_SIZE) +
           `\n\n[Truncated - use select="${field}" alone for full paginated content]`;
       } else {
         result[field] = value;
@@ -1215,9 +948,13 @@ function formatCIInformationOverview(output: CIInformationOutput): string {
   lines.push('');
 
   // Failed Tasks
-  if (output.failedTaskIds.length > 0) {
-    lines.push('### Failed Tasks (`failedTaskIds`)');
-    lines.push(output.failedTaskIds.join(', '));
+  if (output.failedTasks.length > 0) {
+    lines.push('### Failed Tasks (`failedTasks`)');
+    for (const task of output.failedTasks) {
+      lines.push(
+        `- ${task.taskId} (runId: ${task.runId}, url: ${task.runUrl})`,
+      );
+    }
     lines.push('');
   }
 
@@ -1268,53 +1005,6 @@ function formatCIInformationOverview(output: CIInformationOutput): string {
     }
   }
   lines.push('');
-
-  // Task output section with truncated previews (show end of logs)
-  const hasTaskOutput =
-    output.remoteTaskSummary ||
-    output.localTaskSummary ||
-    output.taskOutputSummary;
-  if (hasTaskOutput) {
-    lines.push(
-      '### Task Output (`remoteTaskSummary`, `localTaskSummary`, `taskOutputSummary`)',
-    );
-    if (output.remoteTaskSummary) {
-      lines.push(
-        '**Task Summary (`remoteTaskSummary`) - tasks ran on other machines:**',
-      );
-      lines.push('```');
-      lines.push(
-        truncateString(output.remoteTaskSummary, TRUNCATION_LENGTH, true),
-      );
-      lines.push('```');
-    }
-    if (output.localTaskSummary) {
-      lines.push(
-        '**Task Output (`localTaskSummary`) - tasks ran on self-healing agent machine:**',
-      );
-      lines.push('```');
-      lines.push(
-        truncateString(output.localTaskSummary, TRUNCATION_LENGTH, true),
-      );
-      lines.push('```');
-    }
-    if (
-      output.taskOutputSummary &&
-      !output.remoteTaskSummary &&
-      !output.localTaskSummary
-    ) {
-      lines.push('**Output:**');
-      lines.push('```');
-      lines.push(
-        truncateString(output.taskOutputSummary, TRUNCATION_LENGTH, true),
-      );
-      lines.push('```');
-    }
-    lines.push(
-      "_Full output available via `select='remoteTaskSummary'` or `select='localTaskSummary'`_",
-    );
-    lines.push('');
-  }
 
   // Suggested Fix with truncated diff preview
   if (output.suggestedFixDescription || output.suggestedFix) {

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
@@ -39,6 +39,7 @@ export interface CIInformationOutput {
   branch: string;
   commitSha: string | null;
   failedTasks: FailedTaskInfo[];
+  succeededTasks?: FailedTaskInfo[];
   verifiedTaskIds: string[];
   selfHealingEnabled: boolean;
   selfHealingStatus: AITaskFixStatus | null;
@@ -114,6 +115,17 @@ export const ciInformationOutputSchema = {
     branch: { type: 'string' },
     commitSha: { type: ['string', 'null'] },
     failedTasks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          taskId: { type: 'string' },
+          runId: { type: 'string' },
+          runUrl: { type: 'string' },
+        },
+      },
+    },
+    succeededTasks: {
       type: 'array',
       items: {
         type: 'object',

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
@@ -27,7 +27,7 @@ export interface NxProjectDetailsOutput {
   [key: string]: unknown;
 }
 
-export interface FailedTaskInfo {
+export interface TaskInfo {
   taskId: string;
   runId: string;
   runUrl: string;
@@ -38,8 +38,8 @@ export interface CIInformationOutput {
   cipeUrl: string;
   branch: string;
   commitSha: string | null;
-  failedTasks: FailedTaskInfo[];
-  succeededTasks?: FailedTaskInfo[];
+  failedTasks: TaskInfo[];
+  succeededTasks?: TaskInfo[];
   verifiedTaskIds: string[];
   selfHealingEnabled: boolean;
   selfHealingStatus: AITaskFixStatus | null;

--- a/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
+++ b/libs/nx-mcp/nx-mcp-server/src/lib/tools/output-schemas.ts
@@ -27,24 +27,24 @@ export interface NxProjectDetailsOutput {
   [key: string]: unknown;
 }
 
+export interface FailedTaskInfo {
+  taskId: string;
+  runId: string;
+  runUrl: string;
+}
+
 export interface CIInformationOutput {
   cipeStatus: CIPEExecutionStatus;
   cipeUrl: string;
   branch: string;
   commitSha: string | null;
-  failedTaskIds: string[];
+  failedTasks: FailedTaskInfo[];
   verifiedTaskIds: string[];
   selfHealingEnabled: boolean;
   selfHealingStatus: AITaskFixStatus | null;
   verificationStatus: AITaskFixStatus | null;
   userAction: AITaskFixUserAction | null;
   failureClassification: string | null;
-  /** @deprecated Use remoteTaskSummary and localTaskSummary instead */
-  taskOutputSummary: string | null;
-  /** Task output from CI/remote execution */
-  remoteTaskSummary: string | null;
-  /** Task output from local execution */
-  localTaskSummary: string | null;
   suggestedFixReasoning: string | null;
   suggestedFixDescription: string | null;
   suggestedFix: string | null;
@@ -58,6 +58,15 @@ export interface CIInformationOutput {
   selfHealingSkipMessage: string | null;
   error: string | null;
   hints?: string[];
+  [key: string]: unknown;
+}
+
+export interface CITaskOutputOutput {
+  taskId: string;
+  terminalOutput: string | null;
+  error: string | null;
+  currentPage?: number;
+  totalPages?: number;
   [key: string]: unknown;
 }
 
@@ -104,9 +113,16 @@ export const ciInformationOutputSchema = {
     cipeUrl: { type: 'string' },
     branch: { type: 'string' },
     commitSha: { type: ['string', 'null'] },
-    failedTaskIds: {
+    failedTasks: {
       type: 'array',
-      items: { type: 'string' },
+      items: {
+        type: 'object',
+        properties: {
+          taskId: { type: 'string' },
+          runId: { type: 'string' },
+          runUrl: { type: 'string' },
+        },
+      },
     },
     verifiedTaskIds: {
       type: 'array',
@@ -147,9 +163,6 @@ export const ciInformationOutputSchema = {
       ],
     },
     failureClassification: { type: ['string', 'null'] },
-    taskOutputSummary: { type: ['string', 'null'] },
-    remoteTaskSummary: { type: ['string', 'null'] },
-    localTaskSummary: { type: ['string', 'null'] },
     suggestedFixReasoning: { type: ['string', 'null'] },
     suggestedFixDescription: { type: ['string', 'null'] },
     suggestedFix: { type: ['string', 'null'] },
@@ -163,6 +176,17 @@ export const ciInformationOutputSchema = {
     selfHealingSkipMessage: { type: ['string', 'null'] },
     error: { type: ['string', 'null'] },
     hints: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+export const ciTaskOutputOutputSchema = {
+  type: 'object',
+  properties: {
+    taskId: { type: 'string' },
+    terminalOutput: { type: ['string', 'null'] },
+    error: { type: ['string', 'null'] },
+    currentPage: { type: 'number' },
+    totalPages: { type: 'number' },
   },
 };
 

--- a/libs/shared/llm-context/src/lib/tool-names.ts
+++ b/libs/shared/llm-context/src/lib/tool-names.ts
@@ -18,16 +18,7 @@ export const NX_CURRENT_RUNNING_TASKS_DETAILS =
   'nx_current_running_tasks_details';
 export const NX_CURRENT_RUNNING_TASK_OUTPUT = 'nx_current_running_task_output';
 
-export const CLOUD_ANALYTICS_PIPELINE_EXECUTIONS_SEARCH =
-  'cloud_analytics_pipeline_executions_search';
-export const CLOUD_ANALYTICS_PIPELINE_EXECUTION_DETAILS =
-  'cloud_analytics_pipeline_execution_details';
-export const CLOUD_ANALYTICS_RUNS_SEARCH = 'cloud_analytics_runs_search';
-export const CLOUD_ANALYTICS_RUN_DETAILS = 'cloud_analytics_run_details';
-export const CLOUD_ANALYTICS_TASKS_SEARCH = 'cloud_analytics_tasks_search';
-export const CLOUD_ANALYTICS_TASK_EXECUTIONS_SEARCH =
-  'cloud_analytics_task_executions_search';
-
 export const CI_INFORMATION = 'ci_information';
+export const CI_TASK_OUTPUT = 'ci_task_output';
 
 export const UPDATE_SELF_HEALING_FIX = 'update_self_healing_fix';

--- a/libs/shared/nx-cloud/src/lib/get-nx-cloud-terminal-output.ts
+++ b/libs/shared/nx-cloud/src/lib/get-nx-cloud-terminal-output.ts
@@ -3,8 +3,67 @@ import { pipeline } from 'stream/promises';
 import { extract } from 'tar-stream';
 import * as zlib from 'zlib';
 
+import { getNxCloudUrl } from './cloud-ids';
+import { isNxCloudUsed } from './is-nx-cloud-used';
 import { Logger } from '@nx-console/shared-utils';
-import { sanitizeNxCloudError } from './nx-cloud-request';
+import { nxCloudAuthHeaders } from './nx-cloud-auth-headers';
+import { nxCloudRequest, sanitizeNxCloudError } from './nx-cloud-request';
+
+export async function getNxCloudTerminalOutput(
+  request: {
+    taskId: string;
+    runId: string;
+  },
+  workspacePath: string,
+  logger: Logger,
+): Promise<{ terminalOutput?: string; error?: string }> {
+  if (!(await isNxCloudUsed(workspacePath, logger))) {
+    return { error: 'Nx Cloud is not used in this workspace.' };
+  }
+
+  const nxCloudUrl = await getNxCloudUrl(workspacePath);
+  const url = `${nxCloudUrl}/nx-cloud/nx-console/ci-pipeline-executions/terminal-outputs`;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(await nxCloudAuthHeaders(workspacePath)),
+  };
+
+  const taskId = request.taskId.trim();
+  const runId = request.runId.trim();
+
+  try {
+    const response = await nxCloudRequest('TERMINAL_OUTPUT', {
+      type: 'POST',
+      url,
+      headers,
+      data: JSON.stringify({
+        taskId,
+        linkId: runId,
+        executionId: runId,
+      }),
+    });
+    const responseData = JSON.parse(response.responseText) as {
+      artifactUrl: string;
+    };
+
+    const terminalOutput = await downloadAndExtractArtifact(
+      responseData.artifactUrl,
+      logger,
+    );
+    const strippedOutput = terminalOutput.replace(
+      /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g,
+      '',
+    );
+
+    return { terminalOutput: strippedOutput };
+  } catch (e: any) {
+    logger.log(`Error fetching terminal output: ${JSON.stringify(e)}`);
+    return {
+      error: e.responseText ?? e.message ?? String(e),
+    };
+  }
+}
 
 export async function downloadAndExtractArtifact(
   artifactUrl: string,


### PR DESCRIPTION
NXA-1206. Drops log summaries from ci_information in favor of a new ci_task_output tool that fetches terminal output for any task by taskId (with optional runId/url/branch). Removes the six unused cloud_analytics_* tools.