### PR TITLE
fix(intellij): show actionable notification when generator filter hides all generators

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/NxGenerateService.kt
@@ -70,7 +70,13 @@ class NxGenerateService(val project: Project, private val cs: CoroutineScope) {
             if (generators.isEmpty()) {
                 val hasErrors =
                     (NxlsService.getInstance(project).workspace()?.errors?.size ?: 0) > 0
-                Notifier.notifyNoGenerators(project, hasErrors)
+                val activeIncludeFilters =
+                    NxConsoleProjectSettingsProvider.getInstance(project)
+                        .generatorFilters
+                        ?.filter { it.include }
+                        ?.map { it.matcher }
+                        .orEmpty()
+                Notifier.notifyNoGenerators(project, hasErrors, activeIncludeFilters)
 
                 return@launch it.resume(null)
             }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/Notifier.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/Notifier.kt
@@ -8,11 +8,13 @@ import com.intellij.notification.*
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.util.ui.RestartDialogImpl
 import dev.nx.console.NxConsoleBundle
 import dev.nx.console.nxls.NxRefreshWorkspaceAction
+import dev.nx.console.settings.NxConsoleSettingsConfigurable
 import dev.nx.console.telemetry.actions.TelemetryOptInAction
 import dev.nx.console.telemetry.actions.TelemetryOptOutAction
 import kotlinx.coroutines.CoroutineScope
@@ -156,24 +158,40 @@ class Notifier {
             return notification
         }
 
-        fun notifyNoGenerators(project: Project, hasNxErrors: Boolean) {
+        fun notifyNoGenerators(
+            project: Project,
+            hasNxErrors: Boolean,
+            activeFilterMatchers: List<String> = emptyList(),
+        ) {
+            val message =
+                when {
+                    activeFilterMatchers.isNotEmpty() ->
+                        "No generators matched the active generator filter (${activeFilterMatchers.joinToString(", ")}). " +
+                            "Update or remove the filter in Nx Console settings."
+                    hasNxErrors -> "No generators found. View Nx Errors for more information."
+                    else -> "No generators found. View logs for more information."
+                }
+
             val notification =
                 getGroup()
-                    .createNotification(
-                        if (hasNxErrors) "No generators found. View Nx Errors for more information."
-                        else "No generators found. View logs for more information.",
-                        NotificationType.ERROR,
-                    )
+                    .createNotification(message, NotificationType.ERROR)
                     .setTitle("Nx Console")
 
-            if (hasNxErrors) {
+            if (activeFilterMatchers.isNotEmpty()) {
+                notification.addAction(
+                    NotificationAction.createSimpleExpiring("Open Nx Console Settings") {
+                        ShowSettingsUtil.getInstance()
+                            .showSettingsDialog(project, NxConsoleSettingsConfigurable::class.java)
+                    }
+                )
+            } else if (hasNxErrors) {
                 notification.addAction(
                     NotificationAction.createSimpleExpiring("View Nx Errors") {
                         ProblemsView.getToolWindow(project)?.show()
                     }
                 )
             } else {
-                notification.addAction(ActionManager.getInstance().getAction("OpenLog"))
+                ActionManager.getInstance().getAction("OpenLog")?.let { notification.addAction(it) }
             }
             notification.notify(project)
         }

--- a/apps/intellij/src/main/kotlin/dev/nx/console/utils/Notifier.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/utils/Notifier.kt
@@ -20,6 +20,7 @@ import dev.nx.console.telemetry.actions.TelemetryOptOutAction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.eclipse.lsp4j.jsonrpc.MessageIssueException
+import org.jetbrains.annotations.VisibleForTesting
 
 class Notifier {
     companion object {
@@ -158,19 +159,25 @@ class Notifier {
             return notification
         }
 
+        @VisibleForTesting
+        internal fun noGeneratorsMessage(
+            hasNxErrors: Boolean,
+            activeFilterMatchers: List<String>,
+        ): String =
+            when {
+                activeFilterMatchers.isNotEmpty() ->
+                    "No generators matched the active generator filter (${activeFilterMatchers.joinToString(", ")}). " +
+                        "Update or remove the filter in Nx Console settings."
+                hasNxErrors -> "No generators found. View Nx Errors for more information."
+                else -> "No generators found. View logs for more information."
+            }
+
         fun notifyNoGenerators(
             project: Project,
             hasNxErrors: Boolean,
             activeFilterMatchers: List<String> = emptyList(),
         ) {
-            val message =
-                when {
-                    activeFilterMatchers.isNotEmpty() ->
-                        "No generators matched the active generator filter (${activeFilterMatchers.joinToString(", ")}). " +
-                            "Update or remove the filter in Nx Console settings."
-                    hasNxErrors -> "No generators found. View Nx Errors for more information."
-                    else -> "No generators found. View logs for more information."
-                }
+            val message = noGeneratorsMessage(hasNxErrors, activeFilterMatchers)
 
             val notification =
                 getGroup()

--- a/apps/intellij/src/test/kotlin/dev/nx/console/utils/NoGeneratorsMessageTest.kt
+++ b/apps/intellij/src/test/kotlin/dev/nx/console/utils/NoGeneratorsMessageTest.kt
@@ -1,0 +1,49 @@
+package dev.nx.console.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NoGeneratorsMessageTest {
+
+    @Test
+    fun testNamesTheActiveIncludeFilters() {
+        val message = Notifier.noGeneratorsMessage(false, listOf("@nx/angular:*"))
+
+        assertTrue(
+            message.contains("@nx/angular:*"),
+            "the message must name the filter that hid the generators: $message",
+        )
+    }
+
+    @Test
+    fun testListsEveryActiveIncludeFilter() {
+        val message = Notifier.noGeneratorsMessage(false, listOf("@nx/angular:*", "@nx/react:*"))
+
+        assertTrue(message.contains("@nx/angular:*"), message)
+        assertTrue(message.contains("@nx/react:*"), message)
+    }
+
+    @Test
+    fun testFilterMessageWinsOverTheNxErrorMessage() {
+        val message = Notifier.noGeneratorsMessage(true, listOf("@nx/angular:*"))
+
+        assertTrue(message.contains("@nx/angular:*"), message)
+    }
+
+    @Test
+    fun testWithoutFiltersItKeepsTheNxErrorMessage() {
+        assertEquals(
+            "No generators found. View Nx Errors for more information.",
+            Notifier.noGeneratorsMessage(true, emptyList()),
+        )
+    }
+
+    @Test
+    fun testWithoutFiltersOrErrorsItPointsAtTheLogs() {
+        assertEquals(
+            "No generators found. View logs for more information.",
+            Notifier.noGeneratorsMessage(false, emptyList()),
+        )
+    }
+}


### PR DESCRIPTION
In WebStorm 2025.3 the `OpenLog` action ID is unregistered, so the non-null `addAction` call threw and the "no generators" notification never rendered, making Nx Generate (UI) appear to do nothing when a stale `generatorAllowlist` filtered everything out. The lookup is now null-guarded, and when an active include filter hides every generator the notification names the active pattern(s) and offers a shortcut to Nx Console settings so the user can fix the allowlist.

Closes #3128