### PR TITLE
fix(repo): make importNxPackagePath src/ check platform-agnostic

### DIFF
--- a/libs/shared/npm/src/lib/workspace-dependencies.spec.ts
+++ b/libs/shared/npm/src/lib/workspace-dependencies.spec.ts
@@ -133,5 +133,24 @@ describe('workspace-dependencies', () => {
         importNxPackagePath('/workspace', 'package.json'),
       ).rejects.toBeDefined();
     });
+
+    it('should fall back to dist/src/... on Windows when callers pass forward-slash paths', async () => {
+      jest.mock(
+        '/workspace/node_modules/nx/dist/src/utils/package-manager',
+        () => ({ detectPackageManager: jest.fn() }),
+        { virtual: true },
+      );
+      jest.mocked(os.platform).mockReturnValue('win32');
+
+      try {
+        const result = await importNxPackagePath<{
+          detectPackageManager: unknown;
+        }>('/workspace', 'src/utils/package-manager');
+
+        expect(result.detectPackageManager).toBeDefined();
+      } finally {
+        jest.mocked(os.platform).mockReturnValue('darwin');
+      }
+    });
   });
 });

--- a/libs/shared/npm/src/lib/workspace-dependencies.ts
+++ b/libs/shared/npm/src/lib/workspace-dependencies.ts
@@ -109,9 +109,14 @@ export async function importNxPackagePath<T>(
 
   // Nx 22.7+ moved files from `nx/src/...` to `nx/dist/src/...`. Try the
   // pre-22.7 layout first, then fall back to the dist/ variant for src-prefixed paths.
-  const srcPrefix = `src${platform() === 'win32' ? '\\' : '/'}`;
+  // Callers pass forward-slash literals (e.g. 'src/utils/package-manager'), so the
+  // prefix check must not depend on the OS path separator.
   const candidates = [join(nxWorkspaceDepPath, nestedPath)];
-  if (nestedPath === 'src' || nestedPath.startsWith(srcPrefix)) {
+  if (
+    nestedPath === 'src' ||
+    nestedPath.startsWith('src/') ||
+    nestedPath.startsWith('src\\')
+  ) {
     candidates.push(join(nxWorkspaceDepPath, 'dist', nestedPath));
   }
 


### PR DESCRIPTION
The Nx 22.7 dist/ fallback added in #3125 picked its prefix from the host OS separator, but every caller passes forward-slash literals like `src/utils/package-manager`. On Windows the `startsWith` check never matched, so the dist/ candidate was skipped and pnpm workspaces silently fell back to npm/npx.

Fixes #3132