### PR TITLE
feat(vscode): use minimal MCP tool set and add enableNxMcpServer setting

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -873,6 +873,12 @@
           "default": "all",
           "description": "Controls which notifications are shown for Nx Cloud."
         },
+        "nxConsole.enableNxMcpServer": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource",
+          "description": "Automatically register and run the Nx MCP server. Disable to opt out of the Nx MCP server registration."
+        },
         "nxConsole.mcpPort": {
           "type": "number",
           "scope": "resource",

--- a/libs/vscode/configuration/src/lib/configuration-keys.ts
+++ b/libs/vscode/configuration/src/lib/configuration-keys.ts
@@ -13,6 +13,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'nxCloudNotifications',
   'enableDebugLogging',
   'disableFileWatching',
+  'enableNxMcpServer',
   'mcpPort',
   'mcpToolsFilter',
   'refreshOnBranchSwitch',
@@ -33,6 +34,7 @@ export type GlobalConfig = {
   nxCloudNotifications: 'all' | 'errors' | 'none';
   enableDebugLogging: boolean;
   disableFileWatching: boolean;
+  enableNxMcpServer: boolean;
   mcpPort: number | undefined;
   mcpToolsFilter: string[] | undefined;
   refreshOnBranchSwitch: boolean;

--- a/libs/vscode/mcp/src/lib/init-mcp.ts
+++ b/libs/vscode/mcp/src/lib/init-mcp.ts
@@ -11,7 +11,6 @@ import {
 import {
   getMcpJsonPath,
   hasNxMcpEntry,
-  hasNxWorkspaceSkill,
   isInCursor,
   isInVSCode,
   isInWindsurf,
@@ -55,6 +54,13 @@ export async function initMcp(context: ExtensionContext) {
   commands.executeCommand('setContext', 'isInCursor', isInCursor());
   commands.executeCommand('setContext', 'isInWindsurf', isInWindsurf());
   commands.executeCommand('setContext', 'isInVSCode', isInVSCode());
+
+  if (!GlobalConfigurationStore.instance.get('enableNxMcpServer', true)) {
+    vscodeLogger.log(
+      'Nx MCP server is disabled via the nxConsole.enableNxMcpServer setting.',
+    );
+    return;
+  }
 
   if (initialized) {
     return;
@@ -229,15 +235,13 @@ async function initModernVSCodeMcp(context: ExtensionContext, mcpPort: number) {
   const { McpStreamableWebServer, NxMcpServerDefinitionProvider } =
     await import('./mcp-vscode-server.js');
 
-  const workspacePath = getNxWorkspacePath();
-  const minimal = workspacePath ? hasNxWorkspaceSkill(workspacePath) : false;
-  if (minimal) {
-    vscodeLogger.log(
-      'Nx workspace skill detected, enabling minimal MCP mode. Workspace analysis tools (nx_workspace, nx_project_details, nx_generators, etc.) have been disabled and replaced by skills.',
-    );
-  }
+  vscodeLogger.log(
+    'Minimal MCP mode enabled. Workspace analysis tools (nx_workspace, nx_project_details, nx_generators, etc.) are disabled and replaced by skills.',
+  );
 
-  mcpStreamableWebServer = new McpStreamableWebServer(mcpPort, { minimal });
+  mcpStreamableWebServer = new McpStreamableWebServer(mcpPort, {
+    minimal: true,
+  });
   context.subscriptions.push({
     dispose: () => {
       mcpStreamableWebServer?.stopMcpServer();
@@ -261,15 +265,11 @@ async function initCursorMcp(context: ExtensionContext, mcpPort: number) {
 
   // Register with Cursor's MCP API
   if ('cursor' in vscode && 'mcp' in (vscode as any).cursor) {
-    const workspacePath = getNxWorkspacePath();
-    const minimal = workspacePath ? hasNxWorkspaceSkill(workspacePath) : false;
-    if (minimal) {
-      vscodeLogger.log(
-        'Nx workspace skill detected, enabling minimal MCP mode. Workspace analysis tools (nx_workspace, nx_project_details, nx_generators, etc.) have been disabled and replaced by skills.',
-      );
-    }
+    vscodeLogger.log(
+      'Minimal MCP mode enabled. Workspace analysis tools (nx_workspace, nx_project_details, nx_generators, etc.) are disabled and replaced by skills.',
+    );
 
-    mcpCursorServer = new McpCursorServer(mcpPort, { minimal });
+    mcpCursorServer = new McpCursorServer(mcpPort, { minimal: true });
     context.subscriptions.push({
       dispose: () => {
         mcpCursorServer?.stopMcpServer();

--- a/libs/vscode/mcp/src/lib/mcp-http-server-core.ts
+++ b/libs/vscode/mcp/src/lib/mcp-http-server-core.ts
@@ -104,7 +104,7 @@ export class McpHttpServerCore {
 
           if (this.options.minimal) {
             vscodeLogger.log(
-              'Minimal mode enabled: The following MCP tools have been disabled because they have been replaced by skills: nx_available_plugins, nx_workspace_path, nx_workspace, nx_project_details, nx_generators, nx_generator_schema. To re-enable them, set nxConsole.mcpMinimalMode to false.',
+              'Minimal mode enabled: The following MCP tools have been disabled because they have been replaced by skills: nx_available_plugins, nx_workspace_path, nx_workspace, nx_project_details, nx_generators, nx_generator_schema.',
             );
             toolsFilter = toolsFilter
               ? [...toolsFilter, ...MINIMAL_EXCLUDED_TOOLS]


### PR DESCRIPTION
The Nx MCP server now always runs in minimal mode so it exposes the same reduced tool set as the standalone nx-mcp --minimal. Before, the full tool set leaked in unless an Nx workspace skill happened to be detected.

This also adds a new nxConsole.enableNxMcpServer setting so users who don't want the Nx MCP server can opt out of registering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)