### PR TITLE
feat: handle prompt-bearing migration webview events

### DIFF
--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -67,6 +67,15 @@ export async function undoMigration(migration: MigrationDetailsWithId) {
   );
 }
 
+export async function acknowledgeMigration(migration: MigrationDetailsWithId) {
+  const workspacePath = getNxWorkspacePath();
+  const migrateUIApi = await importMigrateUIApi(workspacePath);
+  // This is safe to call since this code path only happens if the bundled or local version of Nx exposes the prompt-bearing migration UI (nx 23.0.0-beta.19+).
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  migrateUIApi.acknowledgeMigrationPrompt(workspacePath, migration);
+}
+
 export async function confirmPackageChanges() {
   window.withProgress(
     {

--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -4,6 +4,7 @@ import { logAndShowError } from '@nx-console/vscode-output-channels';
 import { getGitApi } from '@nx-console/vscode-utils';
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
+import { join } from 'path';
 import type { MigrationDetailsWithId } from 'nx/src/config/misc-interfaces';
 import {
   commands,
@@ -196,6 +197,22 @@ export async function viewImplementation(migration: MigrationDetailsWithId) {
       `Cannot find implementation file for ${migration.name}`,
     );
   }
+}
+
+export async function viewPrompt(migration: MigrationDetailsWithId) {
+  if (!migration.prompt) {
+    return;
+  }
+  // The prompt is recorded as a workspace-relative path in migrations.json,
+  // so it resolves without going through the migrate UI API.
+  const fullPath = join(getNxWorkspacePath(), migration.prompt);
+  if (!existsSync(fullPath)) {
+    window.showErrorMessage(`Cannot find prompt file at ${fullPath}`);
+    return;
+  }
+  workspace.openTextDocument(fullPath).then((doc) => {
+    window.showTextDocument(doc);
+  });
 }
 
 export async function viewDocumentation(migration: MigrationDetailsWithId) {

--- a/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
+++ b/libs/vscode/migrate/src/lib/commands/migrate-commands.ts
@@ -70,7 +70,8 @@ export async function undoMigration(migration: MigrationDetailsWithId) {
 export async function acknowledgeMigration(migration: MigrationDetailsWithId) {
   const workspacePath = getNxWorkspacePath();
   const migrateUIApi = await importMigrateUIApi(workspacePath);
-  // This is safe to call since this code path only happens if the bundled or local version of Nx exposes the prompt-bearing migration UI (nx 23.0.0-beta.19+).
+  // TODO: Once Nx is updated with the `acknowledgeMigrationPrompt` API we can remove the ts-ignore.
+  // This is safe to call, since this code path only happens if the bundled or local version of Nx exposes the prompt-bearing migration UI.
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   migrateUIApi.acknowledgeMigrationPrompt(workspacePath, migration);

--- a/libs/vscode/migrate/src/lib/migrate-webview.ts
+++ b/libs/vscode/migrate/src/lib/migrate-webview.ts
@@ -24,6 +24,7 @@ import {
   undoMigration,
   viewDocumentation,
   viewImplementation,
+  viewPrompt,
 } from './commands/migrate-commands';
 import { getTelemetry } from '@nx-console/vscode-telemetry';
 import { watchFile } from '@nx-console/vscode-utils';
@@ -134,6 +135,9 @@ export class MigrateWebview {
           break;
         case 'acknowledge-prompt':
           acknowledgeMigration(message.payload.migration);
+          break;
+        case 'view-prompt':
+          viewPrompt(message.payload.migration);
           break;
       }
     });

--- a/libs/vscode/migrate/src/lib/migrate-webview.ts
+++ b/libs/vscode/migrate/src/lib/migrate-webview.ts
@@ -17,6 +17,7 @@ import {
   window,
 } from 'vscode';
 import {
+  acknowledgeMigration,
   cancelMigration,
   skipMigration,
   stopMigration,
@@ -130,6 +131,9 @@ export class MigrateWebview {
           break;
         case 'stop-migration':
           stopMigration(message.payload.migration);
+          break;
+        case 'acknowledge-prompt':
+          acknowledgeMigration(message.payload.migration);
           break;
       }
     });


### PR DESCRIPTION
Adds the `acknowledge-prompt` and `view-prompt` webview message handlers, completing the nx-console side of prompt-only and hybrid migration shape support.

> [!IMPORTANT]
> Depends on nrwl/nx#35822 being merged; `acknowledgeMigrationPrompt` and the `view-prompt` event only exist in nx versions that include it. Workspaces on older nx silently no-op: the prompt-bearing migration UI (which renders the Approve/Mark as Run buttons and the clickable prompt path) only ships with the same nx version that introduces the API, so the `acknowledge-prompt` and `view-prompt` events are never posted from an older workspace.

## What changed

- **`libs/vscode/migrate/src/lib/commands/migrate-commands.ts`** - adds `acknowledgeMigration()`, which calls `migrateUIApi.acknowledgeMigrationPrompt(workspacePath, migration)` (same `@ts-ignore` pattern as `undoMigration` for the not-yet-typed API symbol), and `viewPrompt()`, which resolves `migration.prompt` against the workspace root and opens it in the editor.
- **`libs/vscode/migrate/src/lib/migrate-webview.ts`** - adds `case 'acknowledge-prompt':` and `case 'view-prompt':` to the `onDidReceiveMessage` switch.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4477-03fa3f4b)
<!-- polygraph-session-end -->
