### PR TITLE
fix(intellij): reuse HttpClient in NxGraphServer to prevent thread/selector leak

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphServer.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphServer.kt
@@ -57,6 +57,19 @@ open class NxGraphServer(
     private var isStarted = false
     private var isStarting = false
 
+    // Reuse a single HttpClient instead of creating one per request. Each JDK
+    // HttpClient owns a selector-manager thread and an executor that live until
+    // the client is closed, so allocating one per request leaked those
+    // resources. Recreated lazily after dispose() since dispose() is also used
+    // by restart().
+    private val httpClientLock = Any()
+    private var httpClient: HttpClient? = null
+
+    private fun obtainHttpClient(): HttpClient =
+        synchronized(httpClientLock) {
+            httpClient ?: HttpClient.newBuilder().build().also { httpClient = it }
+        }
+
     init {
         with(project.messageBus.connect()) {
             subscribe(
@@ -93,7 +106,7 @@ open class NxGraphServer(
                     else -> throw Exception("unknown request type ${request.type}")
                 }
 
-            val client = HttpClient.newBuilder().build()
+            val client = obtainHttpClient()
             val httpRequest =
                 HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -245,6 +258,10 @@ open class NxGraphServer(
         nxGraphProcess = null
         isStarted = false
         isStarting = false
+        synchronized(httpClientLock) {
+            httpClient?.shutdownNow()
+            httpClient = null
+        }
     }
 }
 

--- a/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphServer.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/graph/NxGraphServer.kt
@@ -17,6 +17,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import kotlinx.coroutines.*
 import kotlinx.coroutines.future.await
+import org.jetbrains.annotations.VisibleForTesting
 
 data class WebviewRequest(val type: String, val id: String) {}
 
@@ -65,7 +66,8 @@ open class NxGraphServer(
     private val httpClientLock = Any()
     private var httpClient: HttpClient? = null
 
-    private fun obtainHttpClient(): HttpClient =
+    @VisibleForTesting
+    internal fun obtainHttpClient(): HttpClient =
         synchronized(httpClientLock) {
             httpClient ?: HttpClient.newBuilder().build().also { httpClient = it }
         }

--- a/apps/intellij/src/test/kotlin/dev/nx/console/graph/NxGraphServerHttpClientTest.kt
+++ b/apps/intellij/src/test/kotlin/dev/nx/console/graph/NxGraphServerHttpClientTest.kt
@@ -1,0 +1,53 @@
+package dev.nx.console.graph
+
+import NxGraphServer
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.time.Duration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+class NxGraphServerHttpClientTest : BasePlatformTestCase() {
+
+    private lateinit var scope: CoroutineScope
+
+    override fun setUp() {
+        super.setUp()
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    override fun tearDown() {
+        try {
+            scope.cancel()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testGraphRequestsShareOneHttpClient() {
+        val server = NxGraphServer(project, 5580, false, scope)
+        try {
+            val client = server.obtainHttpClient()
+            assertSame(client, server.obtainHttpClient())
+            assertSame(client, server.obtainHttpClient())
+        } finally {
+            server.dispose()
+        }
+    }
+
+    fun testDisposeShutsTheClientDownAndTheNextRequestGetsAFreshOne() {
+        val server = NxGraphServer(project, 5580, false, scope)
+        val disposed = server.obtainHttpClient()
+
+        server.dispose()
+
+        assertTrue(
+            "dispose() must shut the shared client down",
+            disposed.awaitTermination(Duration.ofSeconds(10)),
+        )
+        val afterRestart = server.obtainHttpClient()
+        assertNotSame(disposed, afterRestart)
+        server.dispose()
+    }
+}


### PR DESCRIPTION
### Summary
`NxGraphServer.handleGraphRequest` created a new `java.net.http.HttpClient` on every graph request and never closed it. This change reuses a single client for the lifetime of the server and shuts it down on dispose.

### Problem
Every graph request (`requestProjectGraph`, `requestTaskGraph`, `requestExpandedTaskInputs`, `requestSourceMaps`) called `HttpClient.newBuilder().build()`. On JDK 21 an `HttpClient` is `AutoCloseable` and owns its own selector-manager thread and executor, which stay alive until the client is closed or garbage-collected. Allocating one per request leaks those threads and the associated resources, and they accumulate as the user interacts with the graph.

### Fix
- Hold a single, lazily-created `HttpClient` in the server and reuse it across requests.
- Shut it down via `shutdownNow()` in `dispose()`.
- The client lives in a lock-guarded nullable field (recreated on demand) rather than a `lazy val`, because `dispose()` is also called by `restart()`; this guarantees a restarted server transparently creates a fresh client on its next request.

### Behavior
Request semantics are unchanged — same URL, headers, async send/await, retry logic, and error handling. Only the lifecycle of the HTTP client changes.