### PR TITLE
fix(vscode): keep target-less root project expandable in projects view

### DIFF
--- a/libs/vscode/nx-project-view/jest.config.cts
+++ b/libs/vscode/nx-project-view/jest.config.cts
@@ -1,0 +1,5 @@
+module.exports = {
+  displayName: 'vscode-nx-project-view',
+  preset: '../../../jest.preset.js',
+  coverageDirectory: 'test-output/jest/coverage',
+};

--- a/libs/vscode/nx-project-view/src/lib/views/nx-project-tree-view.spec.ts
+++ b/libs/vscode/nx-project-view/src/lib/views/nx-project-tree-view.spec.ts
@@ -1,0 +1,82 @@
+import type { ProjectGraphProjectNode } from 'nx/src/devkit-exports';
+
+// vscode is not available in the test runner; provide the enum used by the view.
+jest.mock('vscode', () => ({
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+}));
+jest.mock('@nx-console/vscode-utils', () => ({
+  getWorkspacePath: () => '/workspace',
+}));
+jest.mock('@nx-console/vscode-output-channels', () => ({
+  vscodeLogger: { log: jest.fn() },
+}));
+jest.mock('@nx-console/vscode-nx-workspace', () => ({
+  getNxWorkspaceProjects: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('@nx-console/vscode-lsp-client', () => ({
+  WatcherRunningService: { INSTANCE: { status: 'running' } },
+}));
+
+import { TreeItemCollapsibleState } from 'vscode';
+import { TreeView } from './nx-project-tree-view';
+
+function projectNode(
+  name: string,
+  root: string,
+  targets: Record<string, unknown>,
+): ProjectGraphProjectNode {
+  return {
+    name,
+    type: 'lib',
+    data: { root, name, targets },
+  } as unknown as ProjectGraphProjectNode;
+}
+
+describe('TreeView root rendering', () => {
+  it('keeps a target-less root project expandable when it has children', async () => {
+    // Mirrors a workspace whose root package.json is an inferred project at
+    // `.` with no targets, which becomes the singular tree root with the rest
+    // of the workspace nested beneath it. Regression test for the projects
+    // view rendering it as a non-expandable leaf under Nx 23.
+    const rootNode = {
+      dir: '.',
+      projectName: 'root',
+      projectConfiguration: projectNode('root', '.', {}),
+      children: ['libs'],
+    };
+    const libsNode = { dir: 'libs', children: [] as string[] };
+
+    const view = new TreeView();
+    view.workspaceData = {} as never;
+    view.treeMap = new Map([
+      ['.', rootNode],
+      ['libs', libsNode],
+    ]);
+    view.roots = [rootNode];
+
+    const items = await view.getChildren();
+
+    expect(items).toHaveLength(1);
+    expect(items![0].contextValue).toBe('project');
+    expect(items![0].collapsible).not.toBe(TreeItemCollapsibleState.None);
+  });
+
+  it('still renders a target-less project without children as a leaf', async () => {
+    const leafNode = {
+      dir: '.',
+      projectName: 'root',
+      projectConfiguration: projectNode('root', '.', {}),
+      children: [] as string[],
+    };
+
+    const view = new TreeView();
+    view.workspaceData = {} as never;
+    view.treeMap = new Map([['.', leafNode]]);
+    view.roots = [leafNode];
+
+    const items = await view.getChildren();
+
+    expect(items).toHaveLength(1);
+    expect(items![0].collapsible).toBe(TreeItemCollapsibleState.None);
+  });
+});

--- a/libs/vscode/nx-project-view/src/lib/views/nx-project-tree-view.ts
+++ b/libs/vscode/nx-project-view/src/lib/views/nx-project-tree-view.ts
@@ -142,11 +142,30 @@ export class TreeView extends BaseView {
     collapsible = TreeItemCollapsibleState.Collapsed,
   ): ProjectViewItem | FolderViewItem {
     const config = node.projectConfiguration;
-    return config
-      ? this.createProjectViewItem(
-          [config.name ?? node.projectName ?? '', config],
-          collapsible,
-        )
-      : this.createFolderTreeItem(node.dir, collapsible);
+    if (!config) {
+      return this.createFolderTreeItem(node.dir, collapsible);
+    }
+
+    const item = this.createProjectViewItem(
+      [config.name ?? node.projectName ?? '', config],
+      collapsible,
+    );
+
+    // A project node can also have nested folder/project children in the tree
+    // (e.g. the workspace-root project at '.'). createProjectViewItem decides
+    // collapsibility from the project's targets alone, so a target-less project
+    // that still has children would render as a non-expandable leaf and hide
+    // everything beneath it. Keep it expandable when it has children.
+    if (
+      node.children.length > 0 &&
+      item.collapsible === TreeItemCollapsibleState.None
+    ) {
+      item.collapsible =
+        collapsible === TreeItemCollapsibleState.None
+          ? TreeItemCollapsibleState.Collapsed
+          : collapsible;
+    }
+
+    return item;
   }
 }

--- a/libs/vscode/nx-project-view/tsconfig.json
+++ b/libs/vscode/nx-project-view/tsconfig.json
@@ -5,6 +5,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/libs/vscode/nx-project-view/tsconfig.lib.json
+++ b/libs/vscode/nx-project-view/tsconfig.lib.json
@@ -6,7 +6,15 @@
     "noImplicitReturns": false,
     "strict": false
   },
-  "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts", "out-tsc"],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "jest.config.ts",
+    "out-tsc",
+    "jest.config.cts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ],
   "include": ["**/*.ts"],
   "references": [
     {

--- a/libs/vscode/nx-project-view/tsconfig.spec.json
+++ b/libs/vscode/nx-project-view/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/jest",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/vscode/nx-project-view/tsconfig.spec.json
+++ b/libs/vscode/nx-project-view/tsconfig.spec.json
@@ -12,5 +12,6 @@
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
-  ]
+  ],
+  "references": [{ "path": "./tsconfig.lib.json" }]
 }


### PR DESCRIPTION
## What

Fixes the Projects view rendering only a single, **non-expandable root node** when the workspace has a **target-less project at the root** (`root: "."`) — e.g. the root `package.json` inferred as a project under Nx 23. All other projects (apps/libs/tools) become unreachable from the Projects view.

Fixes #3169.

## Why

A root project (`root: "."`) becomes the singular tree root via the `.`-root special case in `get-project-folder-tree.ts`, with every other root nested under it. It is then rendered as a **project** item, and `createProjectViewItem` (`nx-project-base-view.ts`) derives collapsibility from the project's **targets only**:

```ts
const hasChildren =
  !targets ||
  Object.keys(targets).length !== 0 ||
  Object.getPrototypeOf(targets) !== Object.prototype;
...
collapsible: hasChildren ? collapsible : TreeItemCollapsibleState.None,
```

For a project with empty `targets: {}`, `hasChildren` is `false` → `collapsible: None` → the node is a **leaf with no expand arrow**, hiding all of its folder/project children. This is general: any target-less project that has nested child projects/folders is wrongly non-expandable.

## How

In `nx-project-tree-view.ts`'s `createFolderOrProjectTreeItemFromNode`, after building the project item, keep it expandable when the folder tree gives it children, regardless of targets. Expanding then resolves through the existing `'project'` branch of `getChildren` (targets + nested folder/project children).

## Testing

- `nx typecheck vscode-nx-project-view` passes.
- Packaged a vsix and verified on a real ~662-project Nx 23 workspace whose root `package.json` is a target-less `.` project. **Before:** Projects view showed only a single non-expandable root node. **After:** it expands to apps/libs/tools and the full tree.
- Confirmed (by driving the bundled nxls directly over LSP) that the language server already returns the complete data — `nx/workspace` (662 nodes), `nx/workspaceSerialized` (~8.9 MB → 662), `nx/projectFolderTree` (root `.` with children, 768 entries). The regression was purely in the tree item's collapsible state.
