### PR TITLE
fix(nxls-e2e): pin @nx/plugin to the workspace version in local-plugin test

### DIFF
--- a/apps/nxls-e2e/src/generators/generator-local-plugin.test.ts
+++ b/apps/nxls-e2e/src/generators/generator-local-plugin.test.ts
@@ -37,8 +37,9 @@ describe('generator local plugin', () => {
 
     console.log('creating local plugin');
 
-    // Install @nx/plugin and create a local plugin using nx generators
-    execSync('npm install -D @nx/plugin --force', {
+    // Pin to the workspace's nx version; unversioned pulls @nx/plugin@latest,
+    // whose @nx/devkit peer-requires a newer nx than defaultVersion (npm ERESOLVE).
+    execSync(`npm install -D @nx/plugin@${defaultVersion} --force`, {
       cwd: workspacePath,
       stdio: 'pipe',
     });


### PR DESCRIPTION
## Current Behavior

`apps/nxls-e2e/src/generators/generator-local-plugin.test.ts` fails on CI (Main Linux has been red on `master` for several days). The test creates a throwaway workspace at `defaultVersion` (currently `21.3.0`), then installs `@nx/plugin` **unversioned**:

```ts
execSync('npm install -D @nx/plugin --force', { cwd: workspacePath, ... });
```

That pulls `@nx/plugin@latest` (23.x). When the subsequent `nx g @nx/plugin:plugin` scaffolds the plugin, its `@nx/devkit@23.x` dependency peer-requires `nx@">= 22 …"`, which the `21.3.0` workspace root doesn't satisfy — so the generator's npm install fails with `ERESOLVE`, the plugin is never created, and the suite fails (`Cannot read properties of undefined (reading 'stopNxls')` in teardown).

This is version drift: it started failing when `@nx/plugin@latest` dropped `nx < 22` from its peer range, independent of anything in the workspace.

## Expected Behavior

Install `@nx/plugin` at the workspace's own version so the plugin and core stay aligned and no peer conflict arises:

```ts
execSync(`npm install -D @nx/plugin@${defaultVersion} --force`, { cwd: workspacePath, ... });
```

`defaultVersion` is already imported in the test, and this also holds under the `future_compat.yml` override (`NXLS_E2E_DEFAULT_VERSION=canary` installs `@nx/plugin@canary` against a canary workspace).

Verified locally: a `21.3.0` workspace + `npm install -D @nx/plugin@21.3.0 --force` + `nx g @nx/plugin:plugin` scaffolds the plugin with **no ERESOLVE** (the unversioned install reproduces the CI failure).

## Related Issue(s)

Pre-existing `master` failure surfaced while migrating nx-console to nx 23.1.0-rc.1 (this is unrelated to that migration — it reproduces on `master`).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Migrate-nrwl-repos-to-nx-23.1.0-rc.0-b8c94700)
<!-- polygraph-session-end -->