### PR TITLE
fix(nx-mcp): resolve nx internals through the dist/src fallback

### DIFF
--- a/apps/nx-mcp-e2e/src/nx-project-details-modern-nx-layout.test.ts
+++ b/apps/nx-mcp-e2e/src/nx-project-details-modern-nx-layout.test.ts
@@ -1,0 +1,87 @@
+import {
+  cleanupNxWorkspace,
+  createInvokeMCPInspectorCLI,
+  e2eCwd,
+  newWorkspace,
+  simpleReactWorkspaceOptions,
+  uniq,
+} from '@nx-console/shared-e2e-utils';
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Nx 22.7+ publishes its internals under `nx/dist/src/**` instead of `nx/src/**`.
+// The rest of the e2e suite pins the older default version, so this file exists to
+// exercise the newer layout end-to-end.
+const nxVersion = '22.7.0';
+
+describe(`nx_project_details - nx ${nxVersion} (dist/src layout)`, () => {
+  let invokeMCPInspectorCLI: Awaited<
+    ReturnType<typeof createInvokeMCPInspectorCLI>
+  >;
+  const workspaceName = uniq('nx-mcp-project-details-dist-layout');
+  const testWorkspacePath = join(e2eCwd, workspaceName);
+
+  beforeAll(async () => {
+    newWorkspace({
+      name: workspaceName,
+      options: simpleReactWorkspaceOptions,
+      version: nxVersion,
+    });
+    invokeMCPInspectorCLI = await createInvokeMCPInspectorCLI(
+      e2eCwd,
+      workspaceName,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupNxWorkspace(testWorkspacePath, nxVersion);
+    rmSync(testWorkspacePath, { recursive: true, force: true });
+  });
+
+  it('should install an nx version that uses the dist/src layout', () => {
+    const nxPackagePath = join(testWorkspacePath, 'node_modules', 'nx');
+    expect(
+      existsSync(
+        join(
+          nxPackagePath,
+          'dist',
+          'src',
+          'utils',
+          'find-matching-projects.js',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(nxPackagePath, 'src', 'utils', 'find-matching-projects.js'),
+      ),
+    ).toBe(false);
+  });
+
+  it('should return project details rather than a module resolution error', () => {
+    const result = invokeMCPInspectorCLI(
+      testWorkspacePath,
+      '--method tools/call',
+      '--tool-name nx_project_details',
+      `--tool-arg projectName="${workspaceName}"`,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.stringify(result.content)).not.toContain('Cannot find module');
+    expect(result.content[0]?.text).toContain('Project Details:');
+    expect(result.content[0]?.text).toContain('"name":');
+  });
+
+  it('should resolve a project through the select path', () => {
+    const result = invokeMCPInspectorCLI(
+      testWorkspacePath,
+      '--method tools/call',
+      '--tool-name nx_project_details',
+      `--tool-arg projectName="${workspaceName}"`,
+      '--tool-arg select="name"',
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]?.text).toContain(`"${workspaceName}"`);
+  });
+});

--- a/libs/shared/npm/src/lib/local-nx-utils/find-matching-projects.ts
+++ b/libs/shared/npm/src/lib/local-nx-utils/find-matching-projects.ts
@@ -1,24 +1,14 @@
 import type { ProjectGraphProjectNode } from 'nx/src/devkit-exports';
-import { join } from 'path';
-import {
-  importWorkspaceDependency,
-  workspaceDependencyPath,
-} from '../workspace-dependencies';
+import { importNxPackagePath } from '../workspace-dependencies';
 
 export async function findMatchingProjects(
   projectsToRun: string | string[],
   projects: Record<string, ProjectGraphProjectNode>,
   workspacePath: string,
 ): Promise<string[]> {
-  const nxPath = await workspaceDependencyPath(workspacePath, 'nx');
-  if (!nxPath) {
-    throw 'local nx dependency not found';
-  }
-  const importPath = join(nxPath, 'src/utils/find-matching-projects');
-  const { findMatchingProjects } =
-    await importWorkspaceDependency<
-      typeof import('nx/src/utils/find-matching-projects')
-    >(importPath);
+  const { findMatchingProjects } = await importNxPackagePath<
+    typeof import('nx/src/utils/find-matching-projects')
+  >(workspacePath, 'src/utils/find-matching-projects');
   const projectsArray = Array.isArray(projectsToRun)
     ? projectsToRun
     : [projectsToRun];

--- a/libs/shared/npm/src/lib/local-nx-utils/get-local-workspace-plugins.ts
+++ b/libs/shared/npm/src/lib/local-nx-utils/get-local-workspace-plugins.ts
@@ -1,8 +1,4 @@
-import { join } from 'path';
-import {
-  importWorkspaceDependency,
-  workspaceDependencyPath,
-} from '../workspace-dependencies';
+import { importNxPackagePath } from '../workspace-dependencies';
 import { NxWorkspace } from '@nx-console/shared-types';
 import type { ProjectsConfigurations } from 'nx/src/devkit-exports';
 import type { PluginCapabilities } from 'nx/src/utils/plugins/plugin-capabilities';
@@ -11,15 +7,9 @@ export async function getLocalWorkspacePlugins(
   workspacePath: string,
   workspace: NxWorkspace,
 ): Promise<Map<string, PluginCapabilities>> {
-  const nxPath = await workspaceDependencyPath(workspacePath, 'nx');
-  if (!nxPath) {
-    throw 'local nx dependency not found';
-  }
-  const importPath = join(nxPath, 'src/utils/plugins/local-plugins');
-  const { getLocalWorkspacePlugins } =
-    await importWorkspaceDependency<
-      typeof import('nx/src/utils/plugins/local-plugins')
-    >(importPath);
+  const { getLocalWorkspacePlugins } = await importNxPackagePath<
+    typeof import('nx/src/utils/plugins/local-plugins')
+  >(workspacePath, 'src/utils/plugins/local-plugins');
 
   const projectsConfiguration: ProjectsConfigurations = {
     // placeholder, doesn't actually matter

--- a/libs/shared/npm/src/lib/workspace-dependencies.spec.ts
+++ b/libs/shared/npm/src/lib/workspace-dependencies.spec.ts
@@ -3,6 +3,7 @@ import { mocked } from 'jest-mock';
 import {
   importNxPackagePath,
   importWorkspaceDependency,
+  importWorkspacePackagePath,
   workspaceDependencyPath,
 } from './workspace-dependencies';
 
@@ -134,6 +135,20 @@ describe('workspace-dependencies', () => {
       ).rejects.toBeDefined();
     });
 
+    it('should fall back to dist/src/... for find-matching-projects', async () => {
+      jest.mock(
+        '/workspace/node_modules/nx/dist/src/utils/find-matching-projects',
+        () => ({ findMatchingProjects: jest.fn() }),
+        { virtual: true },
+      );
+
+      const result = await importNxPackagePath<{
+        findMatchingProjects: unknown;
+      }>('/workspace', 'src/utils/find-matching-projects');
+
+      expect(result.findMatchingProjects).toBeDefined();
+    });
+
     it('should fall back to dist/src/... on Windows when callers pass forward-slash paths', async () => {
       jest.mock(
         '/workspace/node_modules/nx/dist/src/utils/package-manager',
@@ -151,6 +166,22 @@ describe('workspace-dependencies', () => {
       } finally {
         jest.mocked(os.platform).mockReturnValue('darwin');
       }
+    });
+  });
+
+  describe('importWorkspacePackagePath', () => {
+    it('should fall back to dist/src/... for packages other than nx', async () => {
+      jest.mock(
+        '/workspace/node_modules/@nx/js/dist/src/utils/typescript/ts-solution-setup.js',
+        () => ({ isUsingTsSolutionSetup: jest.fn() }),
+        { virtual: true },
+      );
+
+      const result = await importWorkspacePackagePath<{
+        isUsingTsSolutionSetup: unknown;
+      }>('/workspace', '@nx/js', 'src/utils/typescript/ts-solution-setup.js');
+
+      expect(result.isUsingTsSolutionSetup).toBeDefined();
     });
   });
 });

--- a/libs/shared/npm/src/lib/workspace-dependencies.ts
+++ b/libs/shared/npm/src/lib/workspace-dependencies.ts
@@ -98,26 +98,38 @@ export async function importNxPackagePath<T>(
   nestedPath: string,
   logger?: Logger,
 ): Promise<T> {
-  const nxWorkspaceDepPath = await workspaceDependencyPath(workspacePath, 'nx');
+  return importWorkspacePackagePath<T>(workspacePath, 'nx', nestedPath, logger);
+}
 
-  if (!nxWorkspaceDepPath) {
+export async function importWorkspacePackagePath<T>(
+  workspacePath: string,
+  packageName: string,
+  nestedPath: string,
+  logger?: Logger,
+): Promise<T> {
+  const packageDepPath = await workspaceDependencyPath(
+    workspacePath,
+    packageName,
+  );
+
+  if (!packageDepPath) {
     logger?.log(
-      `Unable to load the "nx" package from the workspace. Please ensure that the proper dependencies are installed locally.`,
+      `Unable to load the "${packageName}" package from the workspace. Please ensure that the proper dependencies are installed locally.`,
     );
-    throw 'local Nx dependency not found';
+    throw `local ${packageName} dependency not found`;
   }
 
-  // Nx 22.7+ moved files from `nx/src/...` to `nx/dist/src/...`. Try the
+  // Nx 22.7+ moved files from `<pkg>/src/...` to `<pkg>/dist/src/...`. Try the
   // pre-22.7 layout first, then fall back to the dist/ variant for src-prefixed paths.
   // Callers pass forward-slash literals (e.g. 'src/utils/package-manager'), so the
   // prefix check must not depend on the OS path separator.
-  const candidates = [join(nxWorkspaceDepPath, nestedPath)];
+  const candidates = [join(packageDepPath, nestedPath)];
   if (
     nestedPath === 'src' ||
     nestedPath.startsWith('src/') ||
     nestedPath.startsWith('src\\')
   ) {
-    candidates.push(join(nxWorkspaceDepPath, 'dist', nestedPath));
+    candidates.push(join(packageDepPath, 'dist', nestedPath));
   }
 
   let lastError: unknown;

--- a/libs/vscode/typescript-plugin/src/lib/typescript-plugin.ts
+++ b/libs/vscode/typescript-plugin/src/lib/typescript-plugin.ts
@@ -1,8 +1,5 @@
 import { gte } from '@nx-console/nx-version';
-import {
-  importWorkspaceDependency,
-  workspaceDependencyPath,
-} from '@nx-console/shared-npm';
+import { importWorkspacePackagePath } from '@nx-console/shared-npm';
 import {
   GlobalConfigurationStore,
   WorkspaceConfigurationStore,
@@ -12,7 +9,6 @@ import { getNxVersion, getNxWorkspace } from '@nx-console/vscode-nx-workspace';
 import { vscodeLogger } from '@nx-console/vscode-output-channels';
 import { watchFile } from '@nx-console/vscode-utils';
 import type { ProjectGraph } from 'nx/src/devkit-exports';
-import { join } from 'path';
 import * as vscode from 'vscode';
 import { Actor, createActor, fromPromise, setup } from 'xstate';
 import {
@@ -287,25 +283,9 @@ async function isUsingTsSolutionSetup(workspaceRoot: string): Promise<boolean> {
   const nxVersion = await getNxVersion();
   if (nxVersion && gte(nxVersion.full, '20.1.0')) {
     try {
-      const nxJsPath = await workspaceDependencyPath(
-        workspaceRoot,
-        join('@nx', 'js'),
-      );
-      if (!nxJsPath) {
-        return false;
-      }
-      const tsSolutionSetupPath = join(
-        nxJsPath,
-        'src',
-        'utils',
-        'typescript',
-        'ts-solution-setup.js',
-      );
-
-      const { isUsingTsSolutionSetup } =
-        await importWorkspaceDependency<typeof import('@nx/js/internal')>(
-          tsSolutionSetupPath,
-        );
+      const { isUsingTsSolutionSetup } = await importWorkspacePackagePath<
+        typeof import('@nx/js/internal')
+      >(workspaceRoot, '@nx/js', 'src/utils/typescript/ts-solution-setup.js');
       return isUsingTsSolutionSetup();
     } catch (e) {
       return false;


### PR DESCRIPTION
## Current Behavior

`nx_project_details` fails for every project when nx-mcp runs against an Nx version that publishes its internals under `nx/dist/src/**` (Nx 22.7+):

```
MCP error -32603: Cannot find module '<workspace>/node_modules/nx/src/utils/find-matching-projects'
```

Reported in #3186 against Nx 23.0.1 with the `node-modules` Yarn linker (not a PnP issue).

## Expected Behavior

`nx_project_details` returns the resolved project configuration on current published Nx packages.

## Root Cause

`libs/shared/npm/src/lib/local-nx-utils/find-matching-projects.ts` constructed an absolute `<nxPath>/src/utils/find-matching-projects` and passed it to `importWorkspaceDependency`. That bypasses both the `nx` package's exports mapping and the `src` → `dist/src` fallback that `importNxPackagePath` already implements.

## Changes

Grepping for the same pattern turned up **three** call sites with the identical defect, not just the reported one:

| File | Path it loaded |
| --- | --- |
| `local-nx-utils/find-matching-projects.ts` | `nx/src/utils/find-matching-projects` (reported) |
| `local-nx-utils/get-local-workspace-plugins.ts` | `nx/src/utils/plugins/local-plugins` |
| `vscode/typescript-plugin/src/lib/typescript-plugin.ts` | `@nx/js/src/utils/typescript/ts-solution-setup.js` |

The third one needs a package other than `nx`, so `importNxPackagePath` is generalized into `importWorkspacePackagePath(workspacePath, packageName, nestedPath, logger)`, with `importNxPackagePath` kept as a thin wrapper over it. All three now go through the fallback. Behavior when the package is missing is unchanged at each call site (same thrown value; the typescript-plugin one still returns `false` via its existing catch).

Checked and deliberately left alone:
- `nx-json-schema.ts` and `output-schemas.ts` read `schemas/`, which is still top-level in the published package.
- `parse-target-string.ts` imports `@nx/devkit`'s package root, which resolves via its `main`.

## Why CI didn't catch this

Every e2e fixture workspace is created at the suite default:

```ts
// libs/shared/e2e-utils/src/lib/utils.ts
export const defaultVersion = process.env['NXLS_E2E_DEFAULT_VERSION'] ?? '21.3.0';
```

21.3.0 predates the 22.7 `dist/src` move, so the three existing `nx_project_details` e2e files could never reach the broken path. The `nx-workspace.test.ts` unit test mocks `findMatchingProject` outright, so it couldn't either.

This PR adds `apps/nx-mcp-e2e/src/nx-project-details-modern-nx-layout.test.ts`, which pins Nx 22.7.0, asserts the installed package really uses `dist/src` (and has no `src`), and calls `nx_project_details` through the MCP inspector. The atomizer picks it up as `e2e-ci--src/nx-project-details-modern-nx-layout.test.ts`.

## Verification

| | Result |
| --- | --- |
| New e2e, with fix | 3 passed |
| New e2e, `find-matching-projects.ts` reverted to pre-fix | 2 failed — `MCP error -32603: Cannot find module '.../node_modules/nx/src/utils/find-matching-projects'` |

That failure string matches the issue report verbatim. Also added mocked unit coverage in `workspace-dependencies.spec.ts` for the `find-matching-projects` path and for a non-`nx` package. `shared-npm` unit tests pass (17/17), `tsc --build` clean on `shared-npm` and `vscode-typescript-plugin`, eslint clean.

## Notes for reviewers

Two things found while building the e2e that are out of scope here but worth a look:

1. The e2e `defaultVersion` of 21.3.0 means no e2e exercises modern Nx internals by default. Bumping it (or adding a matrix) would catch this whole class of regression.
2. `create-nx-workspace@23.x` fails locally on the `react-standalone` preset — `Cannot convert undefined or null to object` on 23.0.1, `Cannot read properties of undefined (reading 'Latest')` on 23.1.0 — on both Node 24 and 26. That's why the new test pins 22.7.0, which is the earliest version with the `dist/src` layout and works fine.

Fixes #3186

🤖 Generated with [Claude Code](https://claude.com/claude-code)
