### PR TITLE
fix(vscode): prevent command injection via Nx Cloud CIPE branch name

### DIFF
--- a/libs/vscode/nx-cloud-view/src/cipe-notification-service.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notification-service.ts
@@ -7,7 +7,7 @@ import {
 import { getTelemetry } from '@nx-console/vscode-telemetry';
 import { commands, window } from 'vscode';
 import { fetchAndPullChanges } from './nx-cloud-fix-webview';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 export class CIPENotificationService {
   private sentNotifications = new Set<string>();
@@ -242,7 +242,7 @@ export class CIPENotificationService {
     const targetBranch = cipe.branch;
     let hasBranchOnRemote: boolean;
     try {
-      execSync(`git rev-parse --verify origin/${targetBranch}`, {
+      execFileSync('git', ['rev-parse', '--verify', `origin/${targetBranch}`], {
         cwd: getNxWorkspacePath(),
       });
       hasBranchOnRemote = true;

--- a/libs/vscode/nx-cloud-view/src/cipe-notifications-service.spec.ts
+++ b/libs/vscode/nx-cloud-view/src/cipe-notifications-service.spec.ts
@@ -1,5 +1,7 @@
 import { CIPEInfo } from '@nx-console/shared-types';
-import { window } from 'vscode';
+import { WorkspaceConfigurationStore } from '@nx-console/vscode-configuration';
+import { execFileSync, execSync } from 'child_process';
+import { ExtensionContext, window } from 'vscode';
 import { CIPENotificationService } from './cipe-notification-service';
 
 const globalConfigMock = jest.fn().mockReturnValue('all');
@@ -27,6 +29,12 @@ jest.mock('vscode', () => ({
     Left: 1,
     Right: 2,
   },
+}));
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execSync: jest.fn(),
+  execFileSync: jest.fn(),
 }));
 
 jest.mock('./nx-cloud-fix-webview', () => ({
@@ -955,6 +963,80 @@ describe('CIPE Notifications', () => {
 
       expect(window.showErrorMessage).not.toHaveBeenCalled();
       expect(window.showInformationMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applied AI fix notifications', () => {
+    const appliedFixCIPE = (branch: string): CIPEInfo => ({
+      ciPipelineExecutionId: 'applied-fix',
+      aiFixesEnabled: true,
+      branch,
+      status: 'FAILED',
+      createdAt: Date.now() - 1000 * 60 * 10,
+      completedAt: Date.now() - 1000 * 60,
+      commitTitle: 'fix: fix fix',
+      commitUrl: null,
+      cipeUrl: 'https://cloud.nx.app/cipes/applied-fix',
+      runGroups: [
+        {
+          createdAt: Date.now() - 1000 * 60 * 10,
+          completedAt: Date.now() - 1000 * 60,
+          runGroup: 'rungroup-applied-fix',
+          ciExecutionEnv: '123123',
+          status: 'FAILED',
+          runs: [],
+          aiFix: {
+            aiFixId: 'applied-fix',
+            taskIds: [],
+            terminalLogsUrls: {},
+            suggestedFix: 'diff --git a/file.ts b/file.ts',
+            suggestedFixStatus: 'COMPLETED',
+            verificationStatus: 'COMPLETED',
+            userAction: 'APPLIED_AUTOMATICALLY',
+          },
+        },
+      ],
+    });
+
+    beforeAll(() => {
+      WorkspaceConfigurationStore.fromContext({
+        workspaceState: { get: () => '/workspace', update: jest.fn() },
+      } as unknown as ExtensionContext);
+    });
+
+    it('passes a branch name from Nx Cloud to git as a single argument, without a shell', () => {
+      const branch = 'fix/cipe$(touch /tmp/pwned)';
+
+      new CIPENotificationService().compareCIPEDataAndSendNotifications(
+        [],
+        [appliedFixCIPE(branch)],
+      );
+
+      expect(execSync).not.toHaveBeenCalled();
+      expect(execFileSync).toHaveBeenCalledWith(
+        'git',
+        ['rev-parse', '--verify', `origin/${branch}`],
+        { cwd: '/workspace' },
+      );
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        `Nx Cloud automatically applied a fix for #${branch}`,
+        'Fetch & Pull Changes',
+      );
+    });
+
+    it('does not offer to pull when the branch is not on the remote', () => {
+      jest.mocked(execFileSync).mockImplementationOnce(() => {
+        throw new Error('fatal: Needed a single revision');
+      });
+
+      new CIPENotificationService().compareCIPEDataAndSendNotifications(
+        [],
+        [appliedFixCIPE('feature')],
+      );
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        'Nx Cloud automatically applied a fix for #feature',
+      );
     });
   });
 });

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -26,7 +26,7 @@ import {
   getWorkspacePath,
   safeJsonStringify,
 } from '@nx-console/vscode-utils';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { join } from 'path';
 import {
   commands,
@@ -656,13 +656,15 @@ export async function fetchAndPullChanges(targetBranch: string): Promise<void> {
 
     if (currentBranch === targetBranch) {
       // On target branch: fast-forward your working tree
-      execSync(`git pull --ff-only origin ${targetBranch}`, {
+      execFileSync('git', ['pull', '--ff-only', 'origin', targetBranch], {
         cwd,
       });
     } else {
       // On another branch: fast-forward local target branch without checking it out
       // This creates the branch if missing, refuses if it wouldn't be a fast-forward
-      execSync(`git fetch origin ${targetBranch}:${targetBranch}`, { cwd });
+      execFileSync('git', ['fetch', 'origin', `${targetBranch}:${targetBranch}`], {
+        cwd,
+      });
     }
   } catch (e) {
     logAndShowError(

--- a/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
+++ b/libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts
@@ -662,9 +662,13 @@ export async function fetchAndPullChanges(targetBranch: string): Promise<void> {
     } else {
       // On another branch: fast-forward local target branch without checking it out
       // This creates the branch if missing, refuses if it wouldn't be a fast-forward
-      execFileSync('git', ['fetch', 'origin', `${targetBranch}:${targetBranch}`], {
-        cwd,
-      });
+      execFileSync(
+        'git',
+        ['fetch', 'origin', `${targetBranch}:${targetBranch}`],
+        {
+          cwd,
+        },
+      );
     }
   } catch (e) {
     logAndShowError(


### PR DESCRIPTION
## Summary

The Nx Cloud CIPE (CI Pipeline Execution) notification flow builds shell commands by string-interpolating a branch name that comes straight from the remote Nx Cloud API response. Because those commands run through `execSync` (which spawns `/bin/sh -c`), a branch name containing shell metacharacters is executed on the developer's machine.

## Details

`cipe.branch` is typed as a plain `string` (`libs/shared/types/src/lib/cloud-info.ts`) and is populated verbatim from the HTTP response in `getRecentCIPEData`:

```ts
const responseData = JSON.parse(response.responseText) as {
  ciPipelineExecutions: CIPEInfo[];
  workspaceUrl: string;
};
```

The value is never validated against git ref-name rules. It then reaches three shell commands:

- `libs/vscode/nx-cloud-view/src/cipe-notification-service.ts`
  ```ts
  execSync(`git rev-parse --verify origin/${targetBranch}`, { cwd: getNxWorkspacePath() });
  ```
- `libs/vscode/nx-cloud-view/src/nx-cloud-fix-webview.ts`
  ```ts
  execSync(`git pull --ff-only origin ${targetBranch}`, { cwd });
  execSync(`git fetch origin ${targetBranch}:${targetBranch}`, { cwd });
  ```

The `rev-parse` call is the most severe: it runs automatically inside `showAppliedFixNotification`, which is reached from `processCIPENotifications` during background CIPE polling. No user interaction is required. As soon as the extension observes an applied AI fix for a branch, the branch name is passed through the shell.

Git ref names permit `$`, `` ` ``, `(`, `)`, `;`, `&`, `|`, `{`, `}` and so on, so a branch like `$(touch${IFS}/tmp/pwned)` is both a valid branch and a working command-injection payload. An attacker who can get such a branch into a workspace connected to Nx Cloud (for example a fork PR that triggers a self-healing CI run) can achieve arbitrary command execution on any collaborator whose editor polls that CIPE data.

## Fix

Replace the three interpolated `execSync` calls with `execFileSync('git', [...args])`. `execFileSync` does not spawn a shell, so the branch is passed to `git` as a single literal argument and metacharacters carry no special meaning. Legitimate branch names behave exactly as before; a malformed ref simply fails the git command as it did previously.

No API or test changes are required.
