### PR TITLE
fix(socket-utils): create the socket dir owner-only and resolve its path from one env

### DIFF
--- a/libs/shared/socket-utils/src/lib/shared-socket-utils.spec.ts
+++ b/libs/shared/socket-utils/src/lib/shared-socket-utils.spec.ts
@@ -1,0 +1,231 @@
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+jest.mock('@nx-console/shared-npm', () => ({
+  importNxPackagePath: jest.fn(async () => ({
+    hashArray: (input: Array<string | undefined | null>) =>
+      jest
+        .requireActual('crypto')
+        .createHash('sha1')
+        .update(input.join(','))
+        .digest('hex')
+        .slice(0, 16),
+  })),
+}));
+
+jest.mock('os', () => {
+  const actual = jest.requireActual('os');
+  return {
+    ...actual,
+    platform: jest.fn(() => actual.platform()),
+  };
+});
+
+// fs exports are non-configurable on modern Node, so jest.spyOn cannot wrap
+// them. Mock the module instead, keeping the real implementations.
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    mkdirSync: jest.fn(actual.mkdirSync),
+    chmodSync: jest.fn(actual.chmodSync),
+  };
+});
+
+const mockedPlatform = jest.requireMock('os').platform as jest.Mock;
+const mockedMkdirSync = fs.mkdirSync as unknown as jest.Mock;
+const mockedChmodSync = fs.chmodSync as unknown as jest.Mock;
+
+import { getNxConsoleSocketPath } from './shared-socket-utils';
+
+const actualPlatform = jest.requireActual('os').platform();
+const describeOnPosix = actualPlatform === 'win32' ? describe.skip : describe;
+
+const MODE_MASK = 0o777;
+
+function modeOf(path: string): number {
+  return jest.requireActual('fs').statSync(path).mode & MODE_MASK;
+}
+
+describe('shared-socket-utils', () => {
+  const realFs = jest.requireActual('fs');
+  const tmpDirs: string[] = [];
+
+  function makeTmpDir(prefix = 'nxc-ws-'): string {
+    const dir = realFs.mkdtempSync(join(tmpdir(), prefix));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockedPlatform.mockImplementation(() => actualPlatform);
+  });
+
+  afterAll(() => {
+    for (const dir of tmpDirs) {
+      realFs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  describeOnPosix('socket directory permissions', () => {
+    it('creates the socket directory owner-only (0700)', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = join(makeTmpDir('nxc-sock-'), 'nested');
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: socketDir,
+      });
+
+      expect(dirname(socketPath)).toEqual(socketDir);
+      expect(realFs.existsSync(socketDir)).toBe(true);
+      expect(modeOf(socketDir)).toEqual(0o700);
+    });
+
+    it('creates the hashed default socket directory owner-only (0700)', async () => {
+      const workspaceRoot = makeTmpDir();
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {});
+
+      const socketDir = dirname(socketPath);
+      tmpDirs.push(socketDir);
+      expect(modeOf(socketDir)).toEqual(0o700);
+    });
+
+    // mkdirSync's `mode` is masked by the umask and only applies to directories
+    // it actually creates, so a directory left at 0755 by an older version would
+    // otherwise stay 0755 forever - and Nx would refuse it.
+    it('tightens a pre-existing group/world-readable directory to 0700', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = join(makeTmpDir('nxc-sock-'), 'nested');
+      realFs.mkdirSync(socketDir, { recursive: true });
+      realFs.chmodSync(socketDir, 0o755);
+      expect(modeOf(socketDir)).toEqual(0o755);
+
+      await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: socketDir,
+      });
+
+      expect(modeOf(socketDir)).toEqual(0o700);
+      expect(mockedChmodSync).toHaveBeenCalledWith(socketDir, 0o700);
+    });
+
+    it('leaves an already-0700 directory untouched', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = join(makeTmpDir('nxc-sock-'), 'nested');
+      realFs.mkdirSync(socketDir, { recursive: true });
+      realFs.chmodSync(socketDir, 0o700);
+
+      await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: socketDir,
+      });
+
+      expect(mockedChmodSync).not.toHaveBeenCalled();
+      expect(modeOf(socketDir)).toEqual(0o700);
+    });
+
+    // chmod follows symlinks, so re-permissioning through one would silently
+    // change a directory we were never pointed at.
+    it('does not chmod through a symlinked socket directory', async () => {
+      const workspaceRoot = makeTmpDir();
+      const realDir = join(makeTmpDir('nxc-sock-'), 'real');
+      realFs.mkdirSync(realDir, { recursive: true });
+      realFs.chmodSync(realDir, 0o755);
+      const linkDir = join(makeTmpDir('nxc-link-'), 'link');
+      realFs.symlinkSync(realDir, linkDir);
+
+      await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: linkDir,
+      });
+
+      expect(mockedChmodSync).not.toHaveBeenCalled();
+      expect(modeOf(realDir)).toEqual(0o755);
+    });
+  });
+
+  describe('windows named pipes', () => {
+    it('returns a named pipe and never touches directory permissions', async () => {
+      mockedPlatform.mockReturnValue('win32');
+      const workspaceRoot = makeTmpDir();
+      const socketDir = join(makeTmpDir('nxc-sock-'), 'never-created');
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: socketDir,
+      });
+
+      expect(socketPath.startsWith('\\\\.\\pipe\\nx\\')).toBe(true);
+      expect(socketPath).toContain('nx-console.sock');
+      expect(mockedMkdirSync).not.toHaveBeenCalled();
+      expect(mockedChmodSync).not.toHaveBeenCalled();
+      expect(realFs.existsSync(socketDir)).toBe(false);
+    });
+  });
+
+  describe('socket dir environment variables', () => {
+    it('honours NX_SOCKET_DIR', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: socketDir,
+      });
+
+      expect(socketPath).toEqual(join(socketDir, 'nx-console.sock'));
+    });
+
+    it('honours NX_DAEMON_SOCKET_DIR when NX_SOCKET_DIR is unset', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {
+        NX_DAEMON_SOCKET_DIR: socketDir,
+      });
+
+      expect(socketPath).toEqual(join(socketDir, 'nx-console.sock'));
+    });
+
+    it('prefers NX_SOCKET_DIR over NX_DAEMON_SOCKET_DIR', async () => {
+      const workspaceRoot = makeTmpDir();
+      const preferred = makeTmpDir('nxc-sock-');
+      const ignored = makeTmpDir('nxc-sock-');
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: preferred,
+        NX_DAEMON_SOCKET_DIR: ignored,
+      });
+
+      expect(socketPath).toEqual(join(preferred, 'nx-console.sock'));
+    });
+
+    it('resolves a relative NX_SOCKET_DIR against the workspace root', async () => {
+      const workspaceRoot = makeTmpDir();
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {
+        NX_SOCKET_DIR: 'tmp/sockets',
+      });
+
+      expect(socketPath).toEqual(
+        join(workspaceRoot, 'tmp', 'sockets', 'nx-console.sock'),
+      );
+    });
+
+    it('returns a stable path across calls for the same workspace root', async () => {
+      const workspaceRoot = makeTmpDir();
+
+      const first = await getNxConsoleSocketPath(workspaceRoot, {});
+      const second = await getNxConsoleSocketPath(workspaceRoot, {});
+
+      tmpDirs.push(dirname(first));
+      expect(first).toEqual(second);
+    });
+
+    it('derives different paths for different workspace roots', async () => {
+      const first = await getNxConsoleSocketPath(makeTmpDir(), {});
+      const second = await getNxConsoleSocketPath(makeTmpDir(), {});
+
+      tmpDirs.push(dirname(first), dirname(second));
+      expect(first).not.toEqual(second);
+    });
+  });
+});

--- a/libs/shared/socket-utils/src/lib/shared-socket-utils.spec.ts
+++ b/libs/shared/socket-utils/src/lib/shared-socket-utils.spec.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { Server, createServer } from 'net';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 
@@ -37,7 +38,12 @@ const mockedPlatform = jest.requireMock('os').platform as jest.Mock;
 const mockedMkdirSync = fs.mkdirSync as unknown as jest.Mock;
 const mockedChmodSync = fs.chmodSync as unknown as jest.Mock;
 
-import { getNxConsoleSocketPath } from './shared-socket-utils';
+import { loadRootEnvFiles } from '@nx-console/shared-utils';
+
+import {
+  getNxConsoleSocketPath,
+  testIdeConnection,
+} from './shared-socket-utils';
 
 const actualPlatform = jest.requireActual('os').platform();
 const describeOnPosix = actualPlatform === 'win32' ? describe.skip : describe;
@@ -51,6 +57,7 @@ function modeOf(path: string): number {
 describe('shared-socket-utils', () => {
   const realFs = jest.requireActual('fs');
   const tmpDirs: string[] = [];
+  const servers: Server[] = [];
 
   function makeTmpDir(prefix = 'nxc-ws-'): string {
     const dir = realFs.mkdtempSync(join(tmpdir(), prefix));
@@ -58,12 +65,22 @@ describe('shared-socket-utils', () => {
     return dir;
   }
 
+  function writeEnvFile(workspaceRoot: string, contents: string) {
+    realFs.writeFileSync(join(workspaceRoot, '.env'), contents);
+  }
+
   afterEach(() => {
     jest.clearAllMocks();
     mockedPlatform.mockImplementation(() => actualPlatform);
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+    );
     for (const dir of tmpDirs) {
       realFs.rmSync(dir, { recursive: true, force: true });
     }
@@ -226,6 +243,107 @@ describe('shared-socket-utils', () => {
 
       tmpDirs.push(dirname(first), dirname(second));
       expect(first).not.toEqual(second);
+    });
+  });
+
+  // The regression the server/client `.env` asymmetry used to cause: the
+  // messaging server loaded the workspace `.env` before resolving the socket
+  // path and the clients did not, so a `.env`-provided NX_SOCKET_DIR moved only
+  // the server and the two ends stopped finding each other.
+  describe('workspace .env files', () => {
+    it('honours NX_SOCKET_DIR from the workspace .env', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+      writeEnvFile(workspaceRoot, `NX_SOCKET_DIR=${socketDir}\n`);
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {});
+
+      expect(socketPath).toEqual(join(socketDir, 'nx-console.sock'));
+    });
+
+    it('honours NX_DAEMON_SOCKET_DIR from the workspace .env', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+      writeEnvFile(workspaceRoot, `NX_DAEMON_SOCKET_DIR=${socketDir}\n`);
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {});
+
+      expect(socketPath).toEqual(join(socketDir, 'nx-console.sock'));
+    });
+
+    it('lets .env.local win over .env, matching dotenv load order', async () => {
+      const workspaceRoot = makeTmpDir();
+      const fromEnv = makeTmpDir('nxc-sock-');
+      const fromEnvLocal = makeTmpDir('nxc-sock-');
+      writeEnvFile(workspaceRoot, `NX_SOCKET_DIR=${fromEnv}\n`);
+      realFs.writeFileSync(
+        join(workspaceRoot, '.env.local'),
+        `NX_SOCKET_DIR=${fromEnvLocal}\n`,
+      );
+
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot, {});
+
+      expect(socketPath).toEqual(join(fromEnvLocal, 'nx-console.sock'));
+    });
+
+    it('does not mutate the env object it is handed', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+      writeEnvFile(workspaceRoot, `NX_SOCKET_DIR=${socketDir}\n`);
+
+      const env: NodeJS.ProcessEnv = {};
+      await getNxConsoleSocketPath(workspaceRoot, env);
+
+      expect(env).toEqual({});
+    });
+  });
+
+  describeOnPosix('server and client agree on the same path', () => {
+    async function listenOn(socketPath: string): Promise<Server> {
+      const server = createServer();
+      servers.push(server);
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(socketPath, () => resolve());
+      });
+      return server;
+    }
+
+    // The old messaging server resolved its path from a dotenv-expanded env
+    // while clients passed process.env, so a `.env`-provided NX_SOCKET_DIR split
+    // them apart. Both inputs must now land on the same path.
+    it('resolves the same path whether or not the caller pre-loads .env', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+      writeEnvFile(workspaceRoot, `NX_SOCKET_DIR=${socketDir}\n`);
+
+      const preloaded = loadRootEnvFiles(workspaceRoot, { ...process.env });
+      const serverPath = await getNxConsoleSocketPath(workspaceRoot, preloaded);
+      const clientPath = await getNxConsoleSocketPath(workspaceRoot);
+
+      expect(serverPath).toEqual(clientPath);
+      expect(clientPath).toEqual(join(socketDir, 'nx-console.sock'));
+    });
+
+    it('testIdeConnection finds a server bound at the .env-provided path', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+      writeEnvFile(workspaceRoot, `NX_SOCKET_DIR=${socketDir}\n`);
+
+      // what the messaging server binds
+      const socketPath = await getNxConsoleSocketPath(workspaceRoot);
+      await listenOn(socketPath);
+
+      // what a client (nx-mcp) probes - it only knows the workspace root
+      await expect(testIdeConnection(workspaceRoot)).resolves.toBe(true);
+    });
+
+    it('testIdeConnection reports false when nothing is listening', async () => {
+      const workspaceRoot = makeTmpDir();
+      const socketDir = makeTmpDir('nxc-sock-');
+      writeEnvFile(workspaceRoot, `NX_SOCKET_DIR=${socketDir}\n`);
+
+      await expect(testIdeConnection(workspaceRoot)).resolves.toBe(false);
     });
   });
 });

--- a/libs/shared/socket-utils/src/lib/shared-socket-utils.ts
+++ b/libs/shared/socket-utils/src/lib/shared-socket-utils.ts
@@ -1,5 +1,5 @@
 import { importNxPackagePath } from '@nx-console/shared-npm';
-import { consoleLogger } from '@nx-console/shared-utils';
+import { consoleLogger, loadRootEnvFiles } from '@nx-console/shared-utils';
 import { chmodSync, lstatSync, mkdirSync, unlinkSync } from 'fs';
 import { Socket } from 'net';
 import { platform, tmpdir } from 'os';
@@ -91,14 +91,26 @@ async function getSocketDir(workspaceRoot: string, env: NodeJS.ProcessEnv) {
 }
 
 /**
- * Get the full OS-specific socket path for Nx Console communication
+ * Get the full OS-specific socket path for Nx Console communication.
+ *
+ * The workspace's `.env` files are loaded here rather than by callers so that
+ * every end - the messaging server that binds the socket and the clients that
+ * connect to it - resolves the same path from the same inputs. A `NX_SOCKET_DIR`
+ * set in a workspace `.env` used to move only the server, leaving clients
+ * connecting to a path nothing was listening on.
  */
 export const getNxConsoleSocketPath = async (
   workspaceRoot: string,
-  env = process.env,
+  env: NodeJS.ProcessEnv = process.env,
 ) => {
+  // loadRootEnvFiles mutates the env it is handed, so always give it a copy.
+  const envWithLocalFiles = loadRootEnvFiles(workspaceRoot, { ...env });
+
   const path = resolve(
-    join(await getSocketDir(workspaceRoot, env), 'nx-console.sock'),
+    join(
+      await getSocketDir(workspaceRoot, envWithLocalFiles),
+      'nx-console.sock',
+    ),
   );
   return platform() === 'win32' ? '\\\\.\\pipe\\nx\\' + path : path;
 };

--- a/libs/shared/socket-utils/src/lib/shared-socket-utils.ts
+++ b/libs/shared/socket-utils/src/lib/shared-socket-utils.ts
@@ -1,11 +1,13 @@
 import { importNxPackagePath } from '@nx-console/shared-npm';
 import { consoleLogger } from '@nx-console/shared-utils';
-import { appendFileSync, mkdirSync, unlinkSync } from 'fs';
+import { chmodSync, lstatSync, mkdirSync, unlinkSync } from 'fs';
 import { Socket } from 'net';
 import { platform, tmpdir } from 'os';
 import { join, resolve } from 'path';
 
 const DAEMON_DIR_FOR_CURRENT_WORKSPACE = join('.nx', 'workspace-data', 'd');
+
+const OWNER_ONLY_DIR_MODE = 0o700;
 
 async function socketDirName(workspaceRoot: string): Promise<string> {
   const { hashArray } = await importNxPackagePath<
@@ -13,6 +15,60 @@ async function socketDirName(workspaceRoot: string): Promise<string> {
   >(workspaceRoot, 'src/native');
   const unique = hashArray([workspaceRoot.toLowerCase(), 'nx-console']);
   return join(tmpdir(), unique);
+}
+
+/**
+ * Nx refuses a socket root that it does not own or that is group/world
+ * accessible, and silently falls back to a different root when it finds one.
+ * Since Nx Console binds the socket and Nx connects to it, Nx Console is
+ * normally the process that creates this directory - so it has to create it the
+ * way Nx expects, or the two ends end up on different paths.
+ *
+ * `mkdirSync`'s `mode` is masked by the process umask and is only applied to
+ * directories it actually creates, so it is not enough on its own: a directory
+ * left at 0755 by an earlier version keeps that mode forever. Re-assert the mode
+ * explicitly whenever the directory is ours to change.
+ */
+function ensureOwnedPrivateDir(dir: string) {
+  mkdirSync(dir, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
+
+  const stats = lstatSync(dir);
+
+  // chmod follows symlinks, and a directory owned by someone else is not ours
+  // to re-permission (the call would fail anyway). In both cases Nx may well
+  // refuse the directory, so make the reason visible instead of failing later
+  // as a mysterious "no IDE detected".
+  if (stats.isSymbolicLink()) {
+    consoleLogger.log(
+      `Socket dir ${dir} is a symlink, leaving its permissions alone. Nx may refuse to use it.`,
+    );
+    return;
+  }
+  if (typeof process.getuid !== 'function') {
+    return;
+  }
+  if (stats.uid !== process.getuid()) {
+    consoleLogger.log(
+      `Socket dir ${dir} is not owned by the current user, leaving its permissions alone. Nx may refuse to use it.`,
+    );
+    return;
+  }
+
+  if ((stats.mode & 0o777) === OWNER_ONLY_DIR_MODE) {
+    return;
+  }
+
+  chmodSync(dir, OWNER_ONLY_DIR_MODE);
+
+  // Read the mode back rather than trusting chmod's return, the way Nx does:
+  // filesystems that ignore modes report success and change nothing, and the
+  // resulting mismatch would otherwise only surface as Nx quietly using a
+  // different socket root.
+  if ((lstatSync(dir).mode & 0o777) !== OWNER_ONLY_DIR_MODE) {
+    consoleLogger.log(
+      `Could not restrict socket dir ${dir} to 0700. Nx may refuse to use it.`,
+    );
+  }
 }
 
 async function getSocketDir(workspaceRoot: string, env: NodeJS.ProcessEnv) {
@@ -25,7 +81,7 @@ async function getSocketDir(workspaceRoot: string, env: NodeJS.ProcessEnv) {
     );
 
     if (platform() !== 'win32') {
-      mkdirSync(dir, { recursive: true });
+      ensureOwnedPrivateDir(dir);
     }
     return dir;
   } catch (e) {

--- a/libs/vscode/messaging/src/lib/messaging-server.ts
+++ b/libs/vscode/messaging/src/lib/messaging-server.ts
@@ -26,7 +26,6 @@ import {
   MessagingRequest0,
 } from './messaging-notification';
 import { vscodeLogger } from '@nx-console/vscode-output-channels';
-import { loadRootEnvFiles } from '@nx-console/shared-utils';
 
 const messages: Array<MessagingNotification | MessagingNotification2> = [
   NxTerminalMessage,
@@ -143,14 +142,7 @@ export async function initMessagingServer(
       await existingServer.dispose();
     }
 
-    const envWithLocalFiles = loadRootEnvFiles(workspacePath, {
-      ...process.env,
-    });
-
-    const socketPath = await getNxConsoleSocketPath(
-      workspacePath,
-      envWithLocalFiles,
-    );
+    const socketPath = await getNxConsoleSocketPath(workspacePath);
 
     const messagingServer = new NxMessagingServer(socketPath, context);
     await messagingServer.listen();

--- a/libs/vscode/messaging/tsconfig.lib.json
+++ b/libs/vscode/messaging/tsconfig.lib.json
@@ -14,9 +14,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../../shared/utils/tsconfig.lib.json"
-    },
-    {
       "path": "../../shared/socket-utils/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
## Current Behavior

Two independent bugs in `libs/shared/socket-utils`.

The socket directory is created with `mkdirSync(dir, { recursive: true })` and no `mode`, so it lands at the umask default, usually `0755`. Nx now ships an owner-only socket root: on `nx@23.2.0-beta.9`, `/tmp/.nx/<uid>` and its `sockets` directory are both `drwx------`. Nx's `ensureOwnedPrivateDir` refuses a directory that is group or world accessible and demotes to a different tier. Since Nx Console binds the socket, it normally creates that directory first, so a `0755` directory sends Nx looking somewhere else. To the user that appears as "No IDE detected, running in standalone mode" rather than as an error.

The socket path is also resolved from different environments on each side. `messaging-server.ts` loads the workspace `.env` before computing it; `json-rpc-client.ts` and `testIdeConnection` do not. An `NX_SOCKET_DIR` set in a workspace `.env` therefore moves the server but not the client.

## Expected Behavior

The directory is created `0700`. `mkdirSync`'s mode only applies to directories it actually creates, so a directory left at `0755` by an earlier version is tightened with `chmodSync`; one already at `0700` is left alone, and a symlink is not chmod'd through. The Windows named-pipe branch is unaffected.

`getNxConsoleSocketPath` loads the workspace `.env` itself, so the client and `testIdeConnection` became correct without changing them. `loadRootEnvFiles` mutates the environment it is handed, so it is given a copy.

Adds the library's first test file: 19 tests using real temp directories and real `chmod`/`stat`, so the mode assertions check on-disk state including umask interaction, plus a real bind and connect. Seven of them fail against the previous implementation.

## Verification

`nx run-many -t lint,test,build -p shared-socket-utils,vscode-messaging,nx-mcp` passes, as do `nx format:check` and `tsc -b` on all three.

Running any graph-dependent Nx command in this environment required temporarily removing `@nx/gradle` from `nx.json`, which was restored byte-identical and is not in these commits. `apps/intellij` was therefore not built or tested. Its only socket is a TCP `ServerSocket` in `NxGraphServer.kt`, so it is very unlikely to be affected, but that is reasoning rather than evidence.

## Related Issue(s)

Groundwork for NXC-4765, but stands alone: both bugs are live today and independent of moving the socket path. The mode fix in particular should land before or with any Nx-side tightening, or the two combine into the silent split described above.
