### PR TITLE
chore: refresh stale minimatch resolutions for two ReDoS advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,5 +168,8 @@
     "libs/**",
     "apps/**"
   ],
-  "packageManager": "yarn@4.15.0"
+  "packageManager": "yarn@4.15.0",
+  "resolutions": {
+    "minimatch@9.0.3": "^9.0.7"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10116,7 +10116,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.9":
+"brace-expansion@npm:5.0.9, brace-expansion@npm:^5.0.8":
   version: 5.0.9
   resolution: "brace-expansion@npm:5.0.9"
   dependencies:
@@ -10141,6 +10141,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/b358f2fe060e2d7a87aa015979ecea07f3c37d4018f8d6deb5bd4c229ad3a0384fe6029bb76cd8be63c81e516ee52d1a0673edbe2023d53a5191732ae3c3e49f
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.2":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
@@ -18000,7 +18009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.2.5, minimatch@npm:^10.2.2":
+"minimatch@npm:10.2.5":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -18009,21 +18018,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.1.2, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+"minimatch@npm:3.1.5, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2, minimatch@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:9.0.3":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/85f407dcd38ac3e180f425e86553911d101455ca3ad5544d6a7cec16286657e4f8a9aa6695803025c55e31e35a91a2252b5dc8e7d527211278b8b65b4dbd5eac
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
@@ -18036,39 +18036,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
+"minimatch@npm:^10.0.0, minimatch@npm:^10.2.2":
+  version: 10.2.6
+  resolution: "minimatch@npm:10.2.6"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "minimatch@npm:3.1.5"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
+    brace-expansion: "npm:^5.0.8"
+  checksum: 10c0/4559a836243b98bd4d17ea9f7edae698717c76399eea7be374f3737f33164e4907f19e9726891ddeb122f750a5a7fa80d2ac43e851d6e5984dc4ff42ec127d3a
   languageName: node
   linkType: hard
 
 "minimatch@npm:^5.0.1, minimatch@npm:^5.1.0, minimatch@npm:^5.1.6":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
   dependencies:
     brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
+  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+"minimatch@npm:^9.0.4, minimatch@npm:^9.0.7":
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 
@@ -22490,17 +22481,17 @@ __metadata:
   linkType: hard
 
 "serve-handler@npm:^6.1.6":
-  version: 6.1.6
-  resolution: "serve-handler@npm:6.1.6"
+  version: 6.1.7
+  resolution: "serve-handler@npm:6.1.7"
   dependencies:
     bytes: "npm:3.0.0"
     content-disposition: "npm:0.5.2"
     mime-types: "npm:2.1.18"
-    minimatch: "npm:3.1.2"
+    minimatch: "npm:3.1.5"
     path-is-inside: "npm:1.0.2"
     path-to-regexp: "npm:3.3.0"
     range-parser: "npm:1.2.0"
-  checksum: 10c0/1e1cb6bbc51ee32bc1505f2e0605bdc2e96605c522277c977b67f83be9d66bd1eec8604388714a4d728e036d86b629bc9aec02120ea030d3d2c3899d44696503
+  checksum: 10c0/35afb68d81afd3c38d15792a5bc2451915b739bef2898a47ebd190db6a4e29846530ac00292b8008fe7297a819257c3948be2deaf4ffd32c96689e8947cf0ae9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Current Behavior

`yarn.lock` resolves five `minimatch` versions below the patch floor for two ReDoS advisories, GHSA-3ppc-4f35-3m26 and GHSA-23c5-xmqv-rm74. Taking the higher floor of the two per major line - 3.1.4, 5.1.8, 9.0.7, 10.2.3 - the vulnerable resolutions are 3.1.2, 5.1.6, 9.0.3, 9.0.5 and 10.0.1.

`minimatch@5.1.6` reaches the tree through `vscode-languageclient@8.1.0`, which is a runtime `dependency` rather than a devDependency, and the extension is bundled with `@nx/esbuild:esbuild` - so this is not purely build-time.

## Expected Behavior

Almost all of it was stale lockfile state rather than anything that needed pinning:

- Four of the five are caret ranges (`^3.0.3`/`^3.0.4`/`^3.1.1`/`^3.1.2`, `^5.0.1`/`^5.1.0`/`^5.1.6`, `^9.0.4`, `^10.0.0`). `yarn up -R minimatch` floats them to 3.1.5, 5.1.9, 9.0.9 and 10.2.6 with no declared version changed.
- `serve-handler` exact-pinned `minimatch@3.1.2`. Its declared range is already `^6.1.6`, and 6.1.7 moves that pin to 3.1.5. Diffing the two manifests, the minimatch pin is the only change.

That leaves `minimatch@9.0.3`, exact-pinned by `@nx/devkit@19.6.0` and `@nx/devkit@20.2.2`. No dependency bump removes it:

- `@theunderscorer/nx-semantic-release@2.12.0` is the latest release and pins `@nx/devkit` at exactly 19.6.0.
- The `@nx/conformance` / `@nx/enterprise-cloud` / `@nx/owners` devDeps sit on `21.0.0-beta.0`, a beta published 2025-05-01 whose version number only looks newer than the real `latest`, 5.0.9. Moving them does clear `@nx/devkit@20.2.2`, but `@nx/owners@5.0.9` pins `minimatch@9.0.6` - one release short of the 9.0.7 floor - so it trades one vulnerable pin for another.

All four packages are in active use (nx.json `owners`/`conformance` config and the `semantic-release` executors), so none can simply be dropped. One `resolutions` entry covers the remainder:

```json
"resolutions": { "minimatch@9.0.3": "^9.0.7" }
```

After the change every resolution is at or above both floors: 3.1.5, 5.1.9, 9.0.7, 9.0.9, 10.2.5, 10.2.6. Lockfile churn is confined to `minimatch` and its own `brace-expansion`.

`yarn npm audit` does not carry either advisory - both are absent from the pre-change tree too, so that check proves nothing here and was not relied on. Verification is by enumerating every resolved `minimatch` version against the advisory ranges: five below floor before, zero after.

The stale `21.0.0-beta.0` powerpack pins are worth a separate ticket - they drag `@nx/devkit@20.2.2` into a repo running nx 23, and that bump deserves its own scrutiny rather than riding along on a security fix.

## Related Issue(s)

NXC-4882
