### PR TITLE
fix(repo): keep kotlin compile tasks in the batched gradle run for intellij tests

### DIFF
--- a/apps/intellij/project.json
+++ b/apps/intellij/project.json
@@ -30,6 +30,14 @@
         "^jar",
         "initializeIntellijPlatformPlugin"
       ]
+    },
+    "test": {
+      "options": {
+        "includeDependsOnTasks": [
+          ":intellij:compileKotlin",
+          ":intellij:compileJava"
+        ]
+      }
     }
   },
   "tags": ["type:intellij"],


### PR DESCRIPTION
## What this PR found

Started as a cache-busting experiment for the `intellij:test` failures seen on #3207. The first run reproduced the failure and the agent log showed the cause.

**Root cause.** On Nx Cloud agents the `@nx/gradle` batch executor groups ready Gradle tasks of a project into one Gradle invocation and passes `-x` for every transitive Nx dependency of the batched tasks. `intellij:test` itself only depends on `^build`, but when the scheduler batches it together with `intellij:classes` / `intellij:buildPlugin`, their dependencies get excluded, including `:intellij:compileKotlin` and `:intellij:compileJava`. `compileTestKotlin` then fails while evaluating its `friendPathsSet` provider:

```
Execution failed for task ':intellij:compileTestKotlin'.
> Error while evaluating property 'friendPathsSet$kotlin_gradle_plugin_common' of task ':intellij:compileTestKotlin'.
   > Querying the mapped value of provider(java.util.Set) before task ':intellij:compileJava' has completed is not supported
```

The batch dies during Gradle configuration, so the task shows exit code 2 in under a second with no terminal output, and the GitHub main job polls until its 60 minute timeout. Whether `test` shares a batch with those siblings depends on agent scheduling, which is why #3207 passed on one run out of three and why the first run of this PR failed while the second passed (its `test` batch contained only `test`). Master has been green only because `intellij:test` was a remote cache hit; the last real agent execution before #3207 was Sept 2.

**Evidence.**
- The agent's exact Gradle command reproduces the failure locally 3 of 3. Bisecting the 19 excluded tasks: excluding `:intellij:compileKotlin` gives the `friendPathsSet` error, excluding `:intellij:compileJava` fails `instrumentCode` validation, the other 17 are harmless. `--parallel` is irrelevant.
- Feeding the failing batch composition to the locked `@nx/gradle` 23.2.0-rc.2 batch planner (`getGradlewTasksToRun`) without the option excludes both compile tasks; with the option it keeps exactly those two and still excludes the rest.
- The agent's exclusion list minus those two builds successfully locally.

**Fix.** `@nx/gradle` has `includeDependsOnTasks` for "provider-based dependencies that Gradle must resolve". The `intellij` test target now keeps `:intellij:compileKotlin` and `:intellij:compileJava` in any batch it is part of.

**History.** The investigation ran on this branch with a cache bust (`nx.json` `bust` 10 → 11) so `intellij:test` executed for real on agents; the bust was dropped before merge. The two e2e failures it surfaced (`nxls-e2e` generator-options 22.7 beta, `nx-mcp-e2e` project details dist/src layout) are pre-existing, unrelated, and normally hidden by cache hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMbu9J9xNnkyMBoda85kQv
