### PR TITLE
fix(intellij): preserve saved run arguments and add recorded automation

### DIFF
--- a/apps/intellij/AUTOMATION.md
+++ b/apps/intellij/AUTOMATION.md
@@ -1,0 +1,115 @@
+# IntelliJ automation with Kotlin
+
+Run the development plugin in a separate IntelliJ sandbox and execute Kotlin
+programs against it with JetBrains Driver. The IDE stays open between programs.
+The automation sources are separate from the plugin and are never packaged in it.
+
+## Launch the IDE
+
+Install the workspace dependencies with `yarn install --immutable`, then run:
+
+```sh
+CI=true JAVA_TOOL_OPTIONS='-XX:ActiveProcessorCount=4 -Dorg.gradle.workers.max=2 -Dorg.gradle.priority=low' \
+  yarn nx run intellij:runAutomationIde --batch=false --parallel=2
+```
+
+This builds the plugin and its language server/webviews, opens the current
+worktree, and uses `dist/apps/intellij/automation-sandbox` for IDE settings,
+plugins, logs, and caches. Keep this command running while executing scenarios
+from another terminal. Close this IDE normally to stop it.
+
+`CI=true` selects the repository's build configuration that skips Plugin
+Verifier's recommended IDE downloads. It does not make IntelliJ headless.
+The launcher removes `CI` and `NX_DAEMON` from the IDE's environment so those
+build settings do not disable Nx's daemon and file watching in test workspaces.
+`--batch=false` uses the regular Nx Gradle executor; the currently installed
+batch runner exits before executing tasks in this environment.
+
+The launch target uses a separate Gradle project cache so its long-running task
+does not lock out scenario compilation. To open a reproduction workspace, pass
+`--args='--project-cache-dir=.gradle/automation-ide --max-workers=2 --priority=low -PautomationProject=/absolute/path'`.
+Use a workspace with its own lockfile and installed dependencies: Nx Console
+invokes its package manager to start the daemon.
+The automation IDE uses `idea.trust.all.projects=true` to open reproduction
+workspaces without repeated trust prompts. This launch property applies only
+to the automation sandbox. The first launch can still require normal IDE setup.
+
+Nx Console requires the IDE's JavaScript support. If a fresh sandbox starts in
+free mode, use **Help → Register** to activate your existing Ultimate
+subscription, close the dialog, and restart the automation IDE. The inspector
+saves the UI hierarchy even when Nx Console is disabled, so startup dialogs can
+also be inspected through Driver.
+
+The JMX port is derived from the worktree path and printed on startup. Override
+it with `-PautomationPort=7777` on both the launch and scenario commands if
+necessary. JMX is bound to loopback and allows local processes to execute code
+in the test IDE. The runner checks the worktree identity before running a
+scenario.
+
+## Inspect and control the running IDE
+
+```sh
+CI=true JAVA_TOOL_OPTIONS='-XX:ActiveProcessorCount=4 -Dorg.gradle.workers.max=2 -Dorg.gradle.priority=low' \
+  yarn nx run intellij:runAutomation --batch=false --parallel=2 \
+  --args='--max-workers=2 --priority=low'
+```
+
+The default `InspectIde.kt` scenario verifies that Nx Console is enabled and
+writes `inspection.txt` and the Swing UI hierarchy `ui.html` under
+`dist/apps/intellij/automation`.
+
+Run the example that opens the Nx Console tool window and checks its visibility:
+
+```sh
+CI=true JAVA_TOOL_OPTIONS='-XX:ActiveProcessorCount=4 -Dorg.gradle.workers.max=2 -Dorg.gradle.priority=low' \
+  yarn nx run intellij:runAutomation --batch=false --parallel=2 \
+  --args='--max-workers=2 --priority=low -PautomationMain=dev.nx.console.automation.OpenNxConsoleKt'
+```
+
+Both Nx targets are uncached: each invocation interacts with the live IDE.
+Kotlin compilation and ordinary build dependencies can still use their caches.
+
+`CaptureIdeKt` captures the test IDE's windows through JetBrains' component
+capture API and prints the image paths in a new directory for each run. Run it with
+the same command and `-PautomationMain=dev.nx.console.automation.CaptureIdeKt`.
+
+## Write a scenario
+
+Add a `.kt` file under `src/automation/kotlin/dev/nx/console/automation` with a
+`main` function. Run it by passing its generated main class with
+`-PautomationMain=dev.nx.console.automation.MyScenarioKt`.
+
+```kotlin
+package dev.nx.console.automation
+
+import com.intellij.driver.sdk.openToolWindow
+import com.intellij.driver.sdk.waitForProjectOpen
+import kotlin.time.Duration.Companion.minutes
+
+fun main() = withAutomationDriver {
+    waitForProjectOpen(2.minutes)
+    openToolWindow("Nx Console")
+    inspectIde()
+}
+```
+
+Use the saved hierarchy to discover selectors, then use `ui.x(selector)` to
+interact with Swing controls. Driver also supports `invokeAction(actionId)` and
+`ui.jcef(selector)` for JCEF HTML/JavaScript inspection. These operations require
+the corresponding SDK imports. Prefer condition-based waits and explicit
+assertions; a delivered click alone does not establish success. Native keyboard
+and mouse actions may require macOS Accessibility permission for the test IDE.
+
+Driver artifacts are resolved using the configured IDE's exact build number.
+Its APIs are experimental, so check the matching SDK sources when changing IDE
+versions. The IDE's bundled Performance Testing plugin supplies the server.
+
+For a bug fix, preserve the scenario and its baseline failure, rebuild/relaunch
+the IDE after changing the plugin, and rerun against the same fixture. Running
+a scenario again does not reload plugin code or reset the opened workspace.
+
+References:
+
+- [JetBrains Driver SDK](https://github.com/JetBrains/intellij-community/blob/master/tools/intellij.tools.ide.starter.driver/README.md)
+- [UI testing and selectors](https://plugins.jetbrains.com/docs/intellij/integration-tests-ui.html)
+- [JCEF helper for IntelliJ 252](https://github.com/JetBrains/intellij-community/blob/idea/252.23892.409/platform/remote-driver/test-sdk/src/com/intellij/driver/sdk/ui/components/common/JCefUI.kt)

--- a/apps/intellij/AUTOMATION.md
+++ b/apps/intellij/AUTOMATION.md
@@ -107,6 +107,114 @@ versions. The IDE's bundled Performance Testing plugin supplies the server.
 For a bug fix, preserve the scenario and its baseline failure, rebuild/relaunch
 the IDE after changing the plugin, and rerun against the same fixture. Running
 a scenario again does not reload plugin code or reset the opened workspace.
+Nx caching is disabled for `instrumentCode`: its inferred inputs currently omit
+the compiled classes, which can restore old plugin bytecode after a Kotlin
+change. Gradle still performs its own incremental checks for that step.
+
+## Record reproduction and verification videos
+
+Install `ffmpeg` on the machine running the scenarios. Wrap the scenario in
+`recordIde` to save an MP4 even when an assertion fails:
+
+```kotlin
+fun main() = withAutomationDriver {
+    waitForProjectOpen(2.minutes)
+    recordIde(System.getenv("NX_AUTOMATION_LABEL") ?: "issue-repro") {
+        openToolWindow("Nx Console")
+        inspectIde()
+        // Perform the issue's actions and assert the expected behavior here.
+    }
+}
+```
+
+Set `NX_AUTOMATION_LABEL=issue-repro` for the baseline run and
+`NX_AUTOMATION_LABEL=post-fix` when rerunning the same scenario after rebuilding
+and relaunching the changed plugin. Each run writes to a unique directory under
+`dist/apps/intellij/automation`, containing the labeled MP4, captured PNGs,
+frame timing manifest, and `result.txt` with PASS or the assertion failure.
+Keep the baseline failure and post-fix success with the PR's verification notes.
+A successful investigation run is not evidence of a reproduced bug.
+
+The recording samples the main IDE window through JetBrains' component capture
+API, preserves elapsed time, and encodes a silent H.264 MP4. Actual capture rate
+depends on IDE responsiveness (typically 2–4 frames per second). Restore a
+minimized IDE before recording so JCEF can initialize. Separate popup/dialog
+windows are retained in the IDE screenshot log directories, but are not overlaid
+on the main-window video.
+
+`ReproGraphKt` checks cold full-graph loading, project focus, returning to the
+full graph, restoring a manually hidden project, and focusing after closing the
+graph. It expects an opened fixture with `demo → ui → core` and an independent
+`unrelated` project. Its expected focus selection uses the Nx 23 graph's default
+dependency distance of 1. Run it with:
+
+```sh
+NX_AUTOMATION_LABEL=graph-investigation CI=true \
+  JAVA_TOOL_OPTIONS='-XX:ActiveProcessorCount=4 -Dorg.gradle.workers.max=2 -Dorg.gradle.priority=low' \
+  yarn nx run intellij:runAutomation --batch=false --parallel=2 \
+  --args='--max-workers=2 --priority=low -PautomationMain=dev.nx.console.automation.ReproGraphKt'
+```
+
+The scenario saves the selected projects and graph URL at each assertion.
+Its focus step invokes the real action with an editor context-menu event.
+On IntelliJ 252, Driver's `invokeAction(..., place = "EditorPopup")` alone does
+not mark an event as a context-menu event, so it opens the project picker.
+
+### Saved run arguments (#3191)
+
+`ReproRunArgumentsKt` seeds a saved `demo:hello` run configuration with
+`--greeting="hello from Nx Console"`, selects its Nx Console tree node, and
+invokes the tree's registered Run action through `ActionManager`. It checks
+both the saved configuration after launch and the arguments received by a real
+Node process. This exercises the tree action without native mouse input.
+
+Use an opened fixture named `intellij-automation-fixture`, with its own Nx
+installation and lockfile. Set `"analytics": false` in its `nx.json` to avoid
+the interactive Nx 23 analytics prompt. Its `demo/project.json` needs:
+
+```json
+{
+  "name": "demo",
+  "targets": {
+    "hello": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "command": "node demo/print-args.cjs"
+      }
+    }
+  }
+}
+```
+
+Create `demo/print-args.cjs` in that fixture:
+
+```js
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+console.log('Arguments received by the target:', JSON.stringify(args));
+fs.mkdirSync('.nx', { recursive: true });
+fs.writeFileSync('.nx/automation-args.json', JSON.stringify(args));
+```
+
+Select the Projects/Targets list layout in Nx Console, then run:
+
+```sh
+NX_AUTOMATION_LABEL=issue-3191-repro CI=true \
+  JAVA_TOOL_OPTIONS='-XX:ActiveProcessorCount=4 -Dorg.gradle.workers.max=2 -Dorg.gradle.priority=low' \
+  yarn nx run intellij:runAutomation --batch=false --parallel=2 \
+  --args='--max-workers=2 --priority=low -PautomationMain=dev.nx.console.automation.ReproRunArgumentsKt'
+```
+
+Rerun with `NX_AUTOMATION_LABEL=issue-3191-fixed` after rebuilding and restarting
+the IDE. The scenario resets the saved argument and deletes the previous target
+output each time. The video shows the initial saved argument in a diagnostic
+editor tab and the actual task output in the Run tool window. A separate text
+report records the saved argument before/after and the received argument array.
+
+The tree Run action uses the SDK's EDT/read-action context, matching
+`Driver.invokeAction`. Calling `actionPerformed` directly on the EDT can fail
+IntelliJ's write-intent lock checks during execution startup.
 
 References:
 

--- a/apps/intellij/AUTOMATION.md
+++ b/apps/intellij/AUTOMATION.md
@@ -107,9 +107,10 @@ versions. The IDE's bundled Performance Testing plugin supplies the server.
 For a bug fix, preserve the scenario and its baseline failure, rebuild/relaunch
 the IDE after changing the plugin, and rerun against the same fixture. Running
 a scenario again does not reload plugin code or reset the opened workspace.
-Nx caching is disabled for `instrumentCode`: its inferred inputs currently omit
-the compiled classes, which can restore old plugin bytecode after a Kotlin
-change. Gradle still performs its own incremental checks for that step.
+`instrumentCode` explicitly includes source files and compiled classes from its
+task dependencies in its Nx cache inputs. The inferred inputs omit compiled
+classes, which can restore old plugin bytecode after a Kotlin change. Keeping
+this build step cacheable also allows its dependents to run on Nx Agents.
 
 ## Record reproduction and verification videos
 

--- a/apps/intellij/build.gradle.kts
+++ b/apps/intellij/build.gradle.kts
@@ -3,6 +3,7 @@ import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
 import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
     repositories { mavenCentral() }
@@ -35,6 +36,73 @@ plugins {
 group = providers.gradleProperty("pluginGroup").get()
 
 version = providers.gradleProperty("version").get()
+
+val automation by sourceSets.creating
+val automationPort =
+    providers
+        .gradleProperty("automationPort")
+        .map(String::toInt)
+        .orElse(20000 + (rootDir.absolutePath.hashCode().toUInt() % 20000u).toInt())
+val automationOutput = layout.buildDirectory.dir("automation")
+val automationDriverVersion = providers.provider { intellijPlatform.productInfo.buildNumber }
+
+dependencies {
+    listOf("driver-sdk", "driver-model").forEach { artifact ->
+        add(
+            automation.implementationConfigurationName,
+            automationDriverVersion.map { "com.jetbrains.intellij.driver:$artifact:$it" },
+        )
+    }
+}
+
+intellijPlatformTesting {
+    runIde {
+        create("runAutomationIde") {
+            localPath = layout.dir(providers.provider { intellijPlatform.platformPath.toFile() })
+            sandboxDirectory = layout.buildDirectory.dir("automation-sandbox")
+            prepareSandboxTask {
+                from(nxlsRoot) { into("${intellijPlatform.projectName.get()}/nxls") }
+            }
+            task {
+                environment = environment.filterKeys { it != "CI" && it != "NX_DAEMON" }
+                systemProperty("com.sun.management.jmxremote", "true")
+                systemProperty("com.sun.management.jmxremote.host", "127.0.0.1")
+                systemProperty("com.sun.management.jmxremote.port", automationPort.get())
+                systemProperty("com.sun.management.jmxremote.rmi.port", automationPort.get())
+                systemProperty("com.sun.management.jmxremote.authenticate", "false")
+                systemProperty("com.sun.management.jmxremote.ssl", "false")
+                systemProperty(
+                    "com.sun.management.jmxremote.serial.filter.pattern",
+                    "java.**;javax.**;com.intellij.driver.model.**",
+                )
+                systemProperty("java.rmi.server.hostname", "127.0.0.1")
+                systemProperty("nx.console.automation.workspace", rootDir.absolutePath)
+                systemProperty("expose.ui.hierarchy.url", "true")
+                systemProperty("idea.trust.all.projects", "true")
+                systemProperty("ide.show.tips.on.startup.default.value", "false")
+                args(
+                    providers.gradleProperty("automationProject").orElse(rootDir.absolutePath).get()
+                )
+                doFirst {
+                    logger.lifecycle("Automation JMX endpoint: 127.0.0.1:${automationPort.get()}")
+                }
+            }
+        }
+    }
+}
+
+tasks.register<JavaExec>("runAutomation") {
+    group = "verification"
+    description = "Runs a Kotlin scenario against this worktree's automation IDE."
+    classpath = automation.runtimeClasspath
+    mainClass =
+        providers.gradleProperty("automationMain").orElse("dev.nx.console.automation.InspectIdeKt")
+    systemProperty("nx.console.automation.port", automationPort.get())
+    systemProperty("nx.console.automation.workspace", rootDir.absolutePath)
+    systemProperty("nx.console.automation.output", automationOutput.get().asFile.absolutePath)
+    workingDir = rootDir
+    maxHeapSize = "1g"
+}
 
 // Configure project's dependencies
 repositories { intellijPlatform { defaultRepositories() } }
@@ -148,7 +216,7 @@ if (System.getenv("CI") == null) {
     }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
         freeCompilerArgs.add("-Xskip-metadata-version-check")

--- a/apps/intellij/project.json
+++ b/apps/intellij/project.json
@@ -22,6 +22,37 @@
     "runIde": {
       "cache": false
     },
+    "runAutomationIde": {
+      "cache": false,
+      "options": {
+        "args": [
+          "--project-cache-dir=.gradle/automation-ide",
+          "--max-workers=2",
+          "--priority=low"
+        ]
+      }
+    },
+    "runAutomation": {
+      "cache": false
+    },
+    "compileAutomationKotlin": {
+      "inputs": ["kotlin", "{workspaceRoot}/gradle/wrapper/**/*"]
+    },
+    "ktfmtCheckAutomation": {
+      "inputs": ["kotlin", "{workspaceRoot}/gradle/wrapper/**/*"]
+    },
+    "ktfmtFormatAutomation": {
+      "inputs": ["kotlin", "{workspaceRoot}/gradle/wrapper/**/*"]
+    },
+    "prepareSandbox_runAutomationIde": {
+      "dependsOn": [
+        "^build",
+        "^build-webview-files",
+        "composedJar",
+        "^jar",
+        "initializeIntellijPlatformPlugin"
+      ]
+    },
     "prepareSandbox": {
       "dependsOn": [
         "^build",

--- a/apps/intellij/project.json
+++ b/apps/intellij/project.json
@@ -35,6 +35,9 @@
     "runAutomation": {
       "cache": false
     },
+    "instrumentCode": {
+      "cache": false
+    },
     "compileAutomationKotlin": {
       "inputs": ["kotlin", "{workspaceRoot}/gradle/wrapper/**/*"]
     },

--- a/apps/intellij/project.json
+++ b/apps/intellij/project.json
@@ -36,7 +36,17 @@
       "cache": false
     },
     "instrumentCode": {
-      "cache": false
+      "cache": true,
+      "inputs": [
+        "kotlin",
+        "sharedGlobals",
+        "{projectRoot}/src/main/**/*",
+        "{workspaceRoot}/gradle/wrapper/**/*",
+        {
+          "dependentTasksOutputFiles": "**/*.class",
+          "transitive": true
+        }
+      ]
     },
     "compileAutomationKotlin": {
       "inputs": ["kotlin", "{workspaceRoot}/gradle/wrapper/**/*"]

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/Automation.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/Automation.kt
@@ -1,0 +1,29 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.client.impl.JmxHost
+import com.intellij.driver.sdk.jdk.getSystemProperty
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.time.Duration.Companion.seconds
+
+fun withAutomationDriver(scenario: Driver.() -> Unit) {
+    val port = System.getProperty("nx.console.automation.port").toInt()
+    val workspace = System.getProperty("nx.console.automation.workspace")
+    Driver.create(JmxHost(null, null, "127.0.0.1:$port")).use { driver ->
+        val deadline = System.nanoTime() + 60.seconds.inWholeNanoseconds
+        while (!runCatching { driver.isConnected }.getOrDefault(false)) {
+            check(System.nanoTime() < deadline) {
+                "Cannot connect to the automation IDE on port $port. Start intellij:runAutomationIde first."
+            }
+            Thread.sleep(500)
+        }
+        check(driver.getSystemProperty("nx.console.automation.workspace") == workspace) {
+            "The IDE on port $port belongs to a different worktree."
+        }
+        driver.withContext { scenario() }
+    }
+}
+
+fun automationOutput(): Path =
+    Path.of(System.getProperty("nx.console.automation.output")).createDirectories()

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/CaptureIde.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/CaptureIde.kt
@@ -1,0 +1,24 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Remote
+import com.intellij.driver.client.utility
+import com.intellij.driver.sdk.jdk.getSystemProperty
+import java.nio.file.Path
+import kotlin.io.path.listDirectoryEntries
+
+@Remote(
+    "com.jetbrains.performancePlugin.commands.TakeScreenshotCommandKt",
+    plugin = "com.jetbrains.performancePlugin",
+)
+interface IdeWindowCapture {
+    fun takeScreenshotOfAllWindowsBlocking(output: String)
+}
+
+fun main() = withAutomationDriver {
+    val name = "automation-${System.currentTimeMillis()}"
+    utility<IdeWindowCapture>().takeScreenshotOfAllWindowsBlocking(name)
+    val directory = Path.of(getSystemProperty("idea.log.path"), "screenshots", name)
+    val captures = directory.listDirectoryEntries("*.png")
+    check(captures.isNotEmpty()) { "The IDE did not capture any windows." }
+    captures.forEach { println("IDE window capture: $it") }
+}

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/InspectIde.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/InspectIde.kt
@@ -1,0 +1,31 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.client.service
+import com.intellij.driver.sdk.getOpenProjects
+import com.intellij.driver.sdk.getPlugin
+import com.intellij.driver.sdk.ui.remote.SwingHierarchyService
+import kotlin.io.path.writeText
+
+fun main() = withAutomationDriver { inspectIde() }
+
+fun Driver.inspectIde() {
+    val plugin = getPlugin("dev.nx.console")
+
+    val output = automationOutput()
+    val hierarchy = service<SwingHierarchyService>().getSwingHierarchyAsDOM(null, false)
+    check(hierarchy.contains("javaclass=")) { "The IDE returned an empty UI hierarchy." }
+    output.resolve("ui.html").writeText(hierarchy)
+
+    val report = buildString {
+        appendLine("IDE: ${getProductVersion()}")
+        appendLine("Plugin: ${plugin?.getName()} (enabled: ${plugin?.isEnabled()})")
+        getOpenProjects().forEach { appendLine("Project: ${it.getName()}") }
+        appendLine("UI hierarchy: ${output.resolve("ui.html")}")
+    }
+    output.resolve("inspection.txt").writeText(report)
+    println(report)
+    check(plugin != null && plugin.isEnabled()) {
+        "Nx Console is not enabled in the automation IDE."
+    }
+}

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/OpenNxConsole.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/OpenNxConsole.kt
@@ -1,0 +1,16 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.model.OnDispatcher
+import com.intellij.driver.sdk.getToolWindow
+import com.intellij.driver.sdk.openToolWindow
+import com.intellij.driver.sdk.waitForProjectOpen
+import kotlin.time.Duration.Companion.minutes
+
+fun main() = withAutomationDriver {
+    waitForProjectOpen(2.minutes)
+    openToolWindow("Nx Console")
+    withContext(OnDispatcher.EDT) {
+        check(getToolWindow("Nx Console").isVisible()) { "Nx Console did not become visible." }
+    }
+    inspectIde()
+}

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/RecordIde.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/RecordIde.kt
@@ -1,0 +1,129 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.client.utility
+import com.intellij.driver.sdk.jdk.getSystemProperty
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.io.path.copyTo
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+
+fun Driver.recordIde(label: String, scenario: Driver.() -> Unit) {
+    require(label.matches(Regex("[a-zA-Z0-9_-]+")))
+    check(
+        ProcessBuilder("ffmpeg", "-version")
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .start()
+            .waitFor() == 0
+    )
+    val name = "$label-${System.currentTimeMillis()}"
+    val output = automationOutput().resolve(name).createDirectories()
+    val frames = mutableListOf<Pair<String, Long>>()
+    val running = AtomicBoolean(true)
+    val ready = CountDownLatch(1)
+    val failure = AtomicReference<Throwable>()
+    val recorder =
+        thread(name = "ide-recording", isDaemon = true) {
+            try {
+                withAutomationDriver {
+                    val capture = utility<IdeWindowCapture>()
+                    val logs = Path.of(getSystemProperty("idea.log.path"), "screenshots")
+                    while (running.get()) {
+                        val frame = "frame-${frames.size.toString().padStart(5, '0')}"
+                        val captureName = "$name-$frame"
+                        val timestamp = System.nanoTime()
+                        capture.takeScreenshotOfAllWindowsBlocking(captureName)
+                        val source = logs.resolve(captureName).resolve("frame0.png")
+                        check(source.exists()) { "No main IDE window captured at $source" }
+                        source.copyTo(output.resolve("$frame.png"))
+                        frames.add("$frame.png" to timestamp)
+                        ready.countDown()
+                        Thread.sleep(250)
+                    }
+                }
+            } catch (error: Throwable) {
+                failure.set(error)
+                ready.countDown()
+            }
+        }
+    var scenarioError: Throwable? = null
+    try {
+        check(ready.await(30, TimeUnit.SECONDS)) { "IDE recording did not start" }
+        failure.get()?.let { throw it }
+        scenario()
+    } catch (error: Throwable) {
+        scenarioError = error
+        throw error
+    } finally {
+        running.set(false)
+        val ended = System.nanoTime()
+        recorder.join(30_000)
+        try {
+            output
+                .resolve("result.txt")
+                .writeText(
+                    if (scenarioError == null) "PASS\n"
+                    else "FAIL\n${scenarioError.stackTraceToString()}"
+                )
+            check(!recorder.isAlive) { "IDE recorder did not stop" }
+            failure.get()?.let { throw it }
+            check(frames.isNotEmpty()) { "IDE recorder produced no frames" }
+            output
+                .resolve("frames.ffconcat")
+                .writeText(
+                    buildString {
+                        appendLine("ffconcat version 1.0")
+                        frames.forEachIndexed { index, (file, started) ->
+                            appendLine("file '$file'")
+                            val next = frames.getOrNull(index + 1)?.second ?: ended
+                            appendLine("duration ${(next - started) / 1_000_000_000.0}")
+                        }
+                        appendLine("file '${frames.last().first}'")
+                    }
+                )
+            val result =
+                ProcessBuilder(
+                        "ffmpeg",
+                        "-hide_banner",
+                        "-loglevel",
+                        "error",
+                        "-y",
+                        "-f",
+                        "concat",
+                        "-safe",
+                        "1",
+                        "-i",
+                        "frames.ffconcat",
+                        "-vf",
+                        "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+                        "-r",
+                        "12",
+                        "-c:v",
+                        "libx264",
+                        "-threads",
+                        "2",
+                        "-pix_fmt",
+                        "yuv420p",
+                        "-movflags",
+                        "+faststart",
+                        "$label.mp4",
+                    )
+                    .directory(output.toFile())
+                    .inheritIO()
+                    .start()
+                    .waitFor()
+            check(result == 0) { "ffmpeg failed with exit code $result" }
+            println("IDE recording: ${output.resolve("$label.mp4")}")
+        } catch (error: Throwable) {
+            output.resolve("recording-error.txt").writeText(error.stackTraceToString())
+            if (scenarioError == null) output.resolve("result.txt").writeText("RECORDING FAILED\n")
+            if (scenarioError != null) scenarioError.addSuppressed(error) else throw error
+        }
+    }
+}

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproGraph.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproGraph.kt
@@ -1,0 +1,153 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.client.Remote
+import com.intellij.driver.client.service
+import com.intellij.driver.client.utility
+import com.intellij.driver.model.OnDispatcher
+import com.intellij.driver.sdk.ActionManager
+import com.intellij.driver.sdk.closeToolWindow
+import com.intellij.driver.sdk.invokeAction
+import com.intellij.driver.sdk.openFile
+import com.intellij.driver.sdk.ui.components.common.jcef
+import com.intellij.driver.sdk.ui.remote.Component
+import com.intellij.driver.sdk.ui.ui
+import com.intellij.driver.sdk.waitForProjectOpen
+import java.awt.event.InputEvent
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@Remote("com.intellij.openapi.wm.impl.IdeFrameImpl")
+interface GraphIdeFrame {
+    fun setExtendedState(state: Int)
+
+    fun toFront()
+
+    fun getBalloonLayout(): GraphBalloonLayout
+}
+
+@Remote("com.intellij.ui.BalloonLayoutImpl")
+interface GraphBalloonLayout {
+    fun closeAll()
+}
+
+@Remote("com.intellij.ide.DataManager")
+interface GraphDataManager {
+    fun getDataContext(component: Component): GraphDataContext
+}
+
+@Remote("com.intellij.openapi.actionSystem.DataContext") interface GraphDataContext
+
+@Remote("com.intellij.openapi.actionSystem.Presentation") interface GraphPresentation
+
+@Remote("com.intellij.openapi.actionSystem.AnActionEvent")
+interface GraphActionEvent {
+    fun isFromContextMenu(): Boolean
+
+    fun createFromInputEvent(
+        input: InputEvent?,
+        place: String,
+        presentation: GraphPresentation,
+        context: GraphDataContext,
+        contextMenu: Boolean,
+        toolbar: Boolean,
+    ): GraphActionEvent
+}
+
+@Remote("com.intellij.openapi.actionSystem.AnAction")
+interface GraphAction {
+    fun getTemplatePresentation(): GraphPresentation
+
+    fun actionPerformed(event: GraphActionEvent)
+}
+
+private const val FULL_GRAPH_ACTION = "dev.nx.console.graph.actions.NxGraphSelectAllAction"
+private const val FOCUS_PROJECT_ACTION = "dev.nx.console.graph.actions.NxGraphFocusProjectAction"
+
+private fun Driver.focusDemo() {
+    openFile("demo/project.json")
+    withContext(OnDispatcher.EDT) {
+        val manager = service<ActionManager>()
+        val action = cast(checkNotNull(manager.getAction(FOCUS_PROJECT_ACTION)), GraphAction::class)
+        val context =
+            service<GraphDataManager>()
+                .getDataContext(ui.x("//div[@class='EditorComponentImpl']").component)
+        val event =
+            utility<GraphActionEvent>()
+                .createFromInputEvent(
+                    null,
+                    "EditorPopup",
+                    action.getTemplatePresentation(),
+                    context,
+                    true,
+                    false,
+                )
+        check(event.isFromContextMenu())
+        action.actionPerformed(event)
+    }
+}
+
+fun main() = withAutomationDriver {
+    waitForProjectOpen(2.minutes)
+    val frame = ui.x("//div[@class='IdeFrameImpl']").component
+    withContext(OnDispatcher.EDT) {
+        cast(frame, GraphIdeFrame::class).apply {
+            setExtendedState(0)
+            toFront()
+            getBalloonLayout().closeAll()
+        }
+    }
+    closeToolWindow("Project")
+    val output =
+        automationOutput().resolve("graph-${System.currentTimeMillis()}").createDirectories()
+    fun observe(step: String, expected: String) {
+        val graph = ui.jcef()
+        val deadline = System.nanoTime() + 30.seconds.inWholeNanoseconds
+        var selected = ""
+        do {
+            selected =
+                runCatching {
+                        graph.jcefWorker.callJs(
+                            "[...document.querySelectorAll('button[aria-pressed=true]')].map(e => e.textContent.trim()).sort().join(',')",
+                            1000,
+                        )
+                    }
+                    .getOrDefault("")
+            if (selected == expected) break
+            Thread.sleep(250)
+        } while (System.nanoTime() < deadline)
+        val state =
+            graph.jcefWorker.callJs(
+                "JSON.stringify({href:location.href,selected:[...document.querySelectorAll('button[aria-pressed=true]')].map(e => e.textContent.trim()).sort(),text:document.body.innerText})",
+                5000,
+            )
+        output.resolve("$step.json").writeText(state)
+        println("$step: $state")
+        check(selected == expected) { "$step: expected $expected; got $selected" }
+        Thread.sleep(2000)
+    }
+    recordIde(System.getenv("NX_AUTOMATION_LABEL") ?: "graph-investigation") {
+        invokeAction("CloseAllEditors", component = frame)
+        Thread.sleep(1500)
+        invokeAction(FULL_GRAPH_ACTION, component = frame)
+        observe("01-cold-full", "core,demo,ui,unrelated")
+        focusDemo()
+        observe("02-focus-demo", "demo,ui")
+        invokeAction("CloseAllEditors", component = frame)
+        Thread.sleep(1500)
+        focusDemo()
+        observe("03-cold-focus", "demo,ui")
+        invokeAction(FULL_GRAPH_ACTION, component = frame)
+        observe("04-full-after-focus", "core,demo,ui,unrelated")
+        ui.jcef()
+            .jcefWorker
+            .callJs("document.querySelector('button[title=\"Hide demo\"]').click(); 'hidden'", 5000)
+        observe("05-hide-demo", "core,ui,unrelated")
+        invokeAction(FULL_GRAPH_ACTION, component = frame)
+        observe("06-full-after-hide", "core,demo,ui,unrelated")
+        inspectIde()
+        println("Graph reproduction artifacts: $output")
+    }
+}

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproRunArguments.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproRunArguments.kt
@@ -1,0 +1,193 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Remote
+import com.intellij.driver.client.service
+import com.intellij.driver.client.utility
+import com.intellij.driver.model.LockSemantics
+import com.intellij.driver.model.OnDispatcher
+import com.intellij.driver.sdk.ActionManager
+import com.intellij.driver.sdk.AnAction
+import com.intellij.driver.sdk.Project
+import com.intellij.driver.sdk.VirtualFile
+import com.intellij.driver.sdk.closeToolWindow
+import com.intellij.driver.sdk.getOpenProjects
+import com.intellij.driver.sdk.invokeAction
+import com.intellij.driver.sdk.openFile
+import com.intellij.driver.sdk.openToolWindow
+import com.intellij.driver.sdk.ui.components.elements.JTreeUiComponent
+import com.intellij.driver.sdk.ui.remote.Component
+import com.intellij.driver.sdk.ui.ui
+import com.intellij.driver.sdk.waitForProjectOpen
+import java.nio.file.Path
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@Remote("dev.nx.console.run.GetOrCreateRunnerAndConfigurationSettingsKt", plugin = "dev.nx.console")
+interface RunArgumentsConfigurations {
+    fun getOrCreateRunnerConfigurationSettings(
+        project: Project,
+        nxProject: String,
+        nxTarget: String,
+        nxTargetConfiguration: String,
+        args: List<String>,
+    ): SavedRunConfiguration
+}
+
+@Remote("com.intellij.execution.RunnerAndConfigurationSettings")
+interface SavedRunConfiguration {
+    fun getConfiguration(): NxRunConfigurationRef
+}
+
+@Remote("dev.nx.console.run.NxCommandConfiguration", plugin = "dev.nx.console")
+interface NxRunConfigurationRef {
+    fun getNxRunSettings(): NxRunArgumentsRef
+}
+
+@Remote("dev.nx.console.run.NxRunSettings", plugin = "dev.nx.console")
+interface NxRunArgumentsRef {
+    fun getArguments(): String
+}
+
+@Remote("com.intellij.execution.RunManager")
+interface SavedRunManager {
+    fun addConfiguration(settings: SavedRunConfiguration)
+
+    fun setSelectedConfiguration(settings: SavedRunConfiguration)
+}
+
+@Remote("com.intellij.openapi.vfs.LocalFileSystem")
+interface RunArgumentsFileSystem {
+    fun getInstance(): RunArgumentsFileSystem
+
+    fun refreshAndFindFileByPath(path: String): VirtualFile?
+}
+
+@Remote("javax.swing.JTree")
+interface RunArgumentsTree {
+    fun setSelectionRow(row: Int)
+
+    fun scrollRowToVisible(row: Int)
+}
+
+@Remote("com.intellij.openapi.actionSystem.AnAction")
+interface RunArgumentsAction {
+    fun getTemplateText(): String?
+}
+
+@Remote("com.intellij.openapi.actionSystem.ex.ActionUtil")
+interface RunArgumentsActionUtil {
+    fun getActions(component: Component): List<RunArgumentsAction>
+}
+
+fun main() = withAutomationDriver {
+    waitForProjectOpen(2.minutes)
+    val project = getOpenProjects().single()
+    val workspace = Path.of(project.getBasePath())
+    check(workspace.fileName.toString() == "intellij-automation-fixture")
+    val receivedArgs = workspace.resolve(".nx/automation-args.json")
+    receivedArgs.deleteIfExists()
+    val expectedArguments = "--greeting=\"hello from Nx Console\""
+    val frame = ui.x("//div[@class='IdeFrameImpl']").component
+    withContext(OnDispatcher.EDT) {
+        cast(frame, GraphIdeFrame::class).apply {
+            setExtendedState(0)
+            toFront()
+            getBalloonLayout().closeAll()
+        }
+    }
+    runCatching { invokeAction("CloseAllEditors", component = frame) }
+    runCatching { closeToolWindow("Run") }
+    closeToolWindow("Project")
+    openToolWindow("Nx Console")
+    val saved =
+        withContext(OnDispatcher.EDT) {
+            utility<RunArgumentsConfigurations>()
+                .getOrCreateRunnerConfigurationSettings(
+                    project,
+                    "demo",
+                    "hello",
+                    "",
+                    listOf("demo:hello", expectedArguments),
+                )
+                .also {
+                    service<SavedRunManager>(project).addConfiguration(it)
+                    service<SavedRunManager>(project).setSelectedConfiguration(it)
+                }
+        }
+    val before = saved.getConfiguration().getNxRunSettings().getArguments()
+    check(before == expectedArguments)
+    val evidence = workspace.resolve("demo/run-arguments-repro.txt")
+    evidence.writeText(
+        "Issue #3191: saved run arguments\n\nTarget: demo:hello\nSaved arguments: $before\n\nRun hello from the Nx Console tree.\nExpected target arguments: --greeting=hello from Nx Console\n"
+    )
+    checkNotNull(
+        utility<RunArgumentsFileSystem>()
+            .getInstance()
+            .refreshAndFindFileByPath(evidence.toString())
+    )
+    openFile("demo/run-arguments-repro.txt")
+    val tree = ui.x("//div[@class='NxProjectsTree']", JTreeUiComponent::class.java)
+    tree.expandAll()
+    println("Nx Console tree: ${tree.collectExpandedPaths()}")
+    inspectIde()
+    recordIde(System.getenv("NX_AUTOMATION_LABEL") ?: "issue-3191-repro") {
+        Thread.sleep(2000)
+        val action =
+            withContext(OnDispatcher.EDT) {
+                val row =
+                    checkNotNull(
+                            tree.findExpandedPath("Projects", "demo", "hello", fullMatch = true)
+                        )
+                        .row
+                cast(tree.component, RunArgumentsTree::class).apply {
+                    setSelectionRow(row)
+                    scrollRowToVisible(row)
+                }
+                val actions = utility<RunArgumentsActionUtil>().getActions(tree.component)
+                println("Tree actions: ${actions.map { it.getTemplateText() }}")
+                actions.single { it.getTemplateText() == "Run" }
+            }
+        val callback =
+            withContext(OnDispatcher.EDT, LockSemantics.READ_ACTION) {
+                service<ActionManager>()
+                    .tryToExecute(
+                        cast(action, AnAction::class),
+                        null,
+                        tree.component,
+                        "NxToolWindow",
+                        true,
+                    )
+            }
+        check(!callback.isRejected()) { "Tree Run action rejected: ${callback.getError()}" }
+        val deadline = System.nanoTime() + 60.seconds.inWholeNanoseconds
+        while (!receivedArgs.exists() && System.nanoTime() < deadline) Thread.sleep(250)
+        val after = saved.getConfiguration().getNxRunSettings().getArguments()
+        val received = if (receivedArgs.exists()) receivedArgs.readText() else "No task output"
+        val report =
+            "Issue #3191: tree Run result\n\nSaved before launch: $before\nSaved after launch: ${after.ifEmpty { "<empty>" }}\nTarget received: $received\n"
+        println(report)
+        automationOutput()
+            .resolve("run-arguments-${System.currentTimeMillis()}.txt")
+            .writeText(report)
+        val resultFile = workspace.resolve("demo/run-arguments-result.txt")
+        resultFile.writeText(report)
+        checkNotNull(
+            utility<RunArgumentsFileSystem>()
+                .getInstance()
+                .refreshAndFindFileByPath(resultFile.toString())
+        )
+        openFile("demo/run-arguments-result.txt")
+        Thread.sleep(5000)
+        check(receivedArgs.exists()) { "The Nx target did not produce its output" }
+        check(after == expectedArguments) {
+            "Launching the tree target erased saved arguments: $report"
+        }
+        check(received.contains("--greeting=hello from Nx Console")) {
+            "The target did not receive the saved argument: $report"
+        }
+    }
+}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/run/getOrCreateRunnerAndConfigurationSettings.kt
@@ -25,8 +25,11 @@ fun getOrCreateRunnerConfigurationSettings(
                 nxRunSettings.nxTargetsConfiguration == nxTargetConfiguration
         }
         ?.also {
-            (it.configuration as NxCommandConfiguration).apply {
-                nxRunSettings = nxRunSettings.copy(arguments = arguments)
+            // Only explicit commands override saved arguments; tree actions pass no command.
+            if (args.isNotEmpty()) {
+                (it.configuration as NxCommandConfiguration).apply {
+                    nxRunSettings = nxRunSettings.copy(arguments = arguments)
+                }
             }
         }
         ?: runManager

--- a/apps/intellij/src/test/kotlin/dev/nx/console/run/GetOrCreateRunnerAndConfigurationSettingsTest.kt
+++ b/apps/intellij/src/test/kotlin/dev/nx/console/run/GetOrCreateRunnerAndConfigurationSettingsTest.kt
@@ -6,6 +6,17 @@ import kotlin.test.assertEquals
 
 class GetOrCreateRunnerAndConfigurationSettingsTest : BasePlatformTestCase() {
 
+    override fun tearDown() {
+        try {
+            val runManager = RunManager.getInstance(project)
+            runManager
+                .getConfigurationSettingsList(NxCommandConfigurationType.Util.getInstance())
+                .forEach { runManager.removeConfiguration(it) }
+        } finally {
+            super.tearDown()
+        }
+    }
+
     fun testCreatesNewConfigurationWithArguments() {
         val settings =
             getOrCreateRunnerConfigurationSettings(
@@ -63,7 +74,30 @@ class GetOrCreateRunnerAndConfigurationSettingsTest : BasePlatformTestCase() {
         assertEquals("--prod --configuration=production", config.nxRunSettings.arguments)
     }
 
-    fun testReusesExistingConfigurationAndClearsArguments() {
+    fun testReusesExistingConfigurationAndPreservesArgumentsWhenNoneAreProvided() {
+        val runManager = RunManager.getInstance(project)
+        val first =
+            getOrCreateRunnerConfigurationSettings(
+                project,
+                "myapp",
+                "build",
+                "",
+                listOf("myapp:build", "--localize", "true"),
+            )
+        runManager.addConfiguration(first)
+
+        val second = getOrCreateRunnerConfigurationSettings(project, "myapp", "build")
+
+        assertSame(
+            "Should reuse the saved configuration",
+            first.configuration,
+            second.configuration,
+        )
+        val config = second.configuration as NxCommandConfiguration
+        assertEquals("--localize true", config.nxRunSettings.arguments)
+    }
+
+    fun testReusesExistingConfigurationAndClearsArgumentsForExplicitCommand() {
         val runManager = RunManager.getInstance(project)
 
         val first =
@@ -76,7 +110,14 @@ class GetOrCreateRunnerAndConfigurationSettingsTest : BasePlatformTestCase() {
             )
         runManager.addConfiguration(first)
 
-        val second = getOrCreateRunnerConfigurationSettings(project, "myapp", "build")
+        val second =
+            getOrCreateRunnerConfigurationSettings(
+                project,
+                "myapp",
+                "build",
+                "",
+                listOf("myapp:build"),
+            )
 
         assertEquals(
             first.configuration,


### PR DESCRIPTION
Launching an Nx target from the JetBrains tree currently erases saved CLI arguments. Preserve those arguments when reusing a configuration without an explicit command; Run Anything can still replace or clear them. Fixes #3191.

Add a separate Kotlin Driver source set and sandbox launcher so local agents can inspect the IDE, invoke real plugin actions, and verify changes. Record the IDE window to MP4 even when assertions fail, with reusable graph and run-argument scenarios and setup instructions in `apps/intellij/AUTOMATION.md`. Automation sources are excluded from the shipped plugin.

Include Kotlin sources and compiled dependency classes explicitly in the `instrumentCode` cache inputs. This prevents stale plugin bytecode after a rebuild while keeping the build step cacheable for distributed CI on Nx Agents.

Validation:
- Regression baseline: 6 focused tests, 1 failure. Fixed: all 6 pass, including explicit argument replacement/clearing. Clean up saved configurations between tests.
- Real IntelliJ IDEA 2025.2.2 run: the tree Run action previously erased the saved greeting and the Node task received `[]`; after rebuilding, the setting survives and the task receives `["--greeting=hello from Nx Console"]`.
- Captured a 9.25-second repro video and a 9.08-second fixed video using the same fixture, tree action, and behavioral assertions.
- Nx formatting, Kotlin formatting/checks, and `git diff --check` pass.

The graph scenario documents a separate upstream Nx focus-to-full-graph regression; this PR does not fix that Nx graph state bug. GUI verification used the tree's registered Run action through Driver, not native double-click input in PhpStorm.


Video evidence is attached to the [automatically created Polygraph session](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/d48e78ac-76ee-469f-9f48-0b30f45f33fa):
- `issue-3191-repro.mp4` — failing baseline (9.25 seconds): saved arguments erased; target receives `[]`.
- `issue-3191-fixed.mp4` — passing verification (9.08 seconds): saved arguments preserved and received by the target.
