### PR TITLE
fix(nxls): describe and validate the whole of project.json

### DIFF
--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsDiagnosticsAnnotator.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsDiagnosticsAnnotator.kt
@@ -1,0 +1,72 @@
+package dev.nx.console.nxls
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.ExternalAnnotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import dev.nx.console.utils.DocumentUtils
+import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.DiagnosticSeverity
+import org.eclipse.lsp4j.Position
+
+class NxlsDiagnosticsAnnotator : ExternalAnnotator<List<Diagnostic>, List<Diagnostic>>() {
+
+    override fun collectInformation(file: PsiFile): List<Diagnostic>? {
+        if (!DocumentUtils.isNxFile(file.name)) {
+            return null
+        }
+        val virtualFile = file.virtualFile ?: return null
+        return NxlsDiagnosticsService.getInstance(file.project)
+            .diagnosticsFor(virtualFile)
+            .ifEmpty { null }
+    }
+
+    override fun doAnnotate(collectedInfo: List<Diagnostic>?): List<Diagnostic>? = collectedInfo
+
+    override fun apply(
+        file: PsiFile,
+        annotationResult: List<Diagnostic>?,
+        holder: AnnotationHolder,
+    ) {
+        if (annotationResult.isNullOrEmpty()) {
+            return
+        }
+        val document = PsiDocumentManager.getInstance(file.project).getDocument(file) ?: return
+        annotationResult.forEach { diagnostic ->
+            val range = diagnostic.range.toTextRange(document) ?: return@forEach
+            holder
+                .newAnnotation(severityOf(diagnostic.severity), diagnostic.message)
+                .range(range)
+                .create()
+        }
+    }
+
+    private fun severityOf(severity: DiagnosticSeverity?): HighlightSeverity =
+        when (severity) {
+            DiagnosticSeverity.Error -> HighlightSeverity.ERROR
+            DiagnosticSeverity.Information,
+            DiagnosticSeverity.Hint -> HighlightSeverity.INFORMATION
+            else -> HighlightSeverity.WARNING
+        }
+}
+
+private fun org.eclipse.lsp4j.Range.toTextRange(document: Document): TextRange? {
+    val start = position(document, start)
+    val end = position(document, end)
+    // A zero-width range would not be visible, so fall back to highlighting to the end of the line.
+    if (end > start) {
+        return TextRange(start, end)
+    }
+    val lineEnd = document.getLineEndOffset(document.getLineNumber(start))
+    return if (lineEnd > start) TextRange(start, lineEnd) else null
+}
+
+private fun position(document: Document, position: Position): Int {
+    val line = position.line.coerceIn(0, (document.lineCount - 1).coerceAtLeast(0))
+    val lineStart = document.getLineStartOffset(line)
+    val lineEnd = document.getLineEndOffset(line)
+    return (lineStart + position.character).coerceIn(lineStart, lineEnd)
+}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsDiagnosticsService.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsDiagnosticsService.kt
@@ -1,0 +1,56 @@
+package dev.nx.console.nxls
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.psi.PsiManager
+import java.util.concurrent.ConcurrentHashMap
+import org.eclipse.lsp4j.Diagnostic
+
+/**
+ * Holds the diagnostics nxls publishes for the Nx configuration files, keyed by the same file url
+ * the client sends in `textDocument/didOpen`. [NxlsDiagnosticsAnnotator] renders them.
+ */
+@Service(Service.Level.PROJECT)
+class NxlsDiagnosticsService(private val project: Project) {
+
+    private val diagnosticsByUrl = ConcurrentHashMap<String, List<Diagnostic>>()
+
+    fun setDiagnostics(url: String, diagnostics: List<Diagnostic>) {
+        if (diagnostics.isEmpty()) {
+            if (diagnosticsByUrl.remove(url) == null) {
+                return
+            }
+        } else {
+            if (diagnosticsByUrl.put(url, diagnostics) == diagnostics) {
+                return
+            }
+        }
+        rerunHighlighting(url)
+    }
+
+    fun diagnosticsFor(file: VirtualFile): List<Diagnostic> =
+        diagnosticsByUrl[file.url] ?: emptyList()
+
+    private fun rerunHighlighting(url: String) {
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) {
+                return@invokeLater
+            }
+            val file = VirtualFileManager.getInstance().findFileByUrl(url) ?: return@invokeLater
+            val psiFile =
+                runReadAction { PsiManager.getInstance(project).findFile(file) }
+                    ?: return@invokeLater
+            DaemonCodeAnalyzer.getInstance(project).restart(psiFile)
+        }
+    }
+
+    companion object {
+        fun getInstance(project: Project): NxlsDiagnosticsService =
+            project.getService(NxlsDiagnosticsService::class.java)
+    }
+}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/NxlsWrapper.kt
@@ -69,7 +69,7 @@ class NxlsWrapper(val project: Project, private val cs: CoroutineScope) {
 
             nxlsProcess.callOnExit { cs.launch { stop() } }
             if (status !== NxlsState.STOPPED) {
-                languageClient = NxlsLanguageClient()
+                languageClient = NxlsLanguageClient(project)
                 val executorService = Executors.newCachedThreadPool()
 
                 Launcher.createIoLauncher(

--- a/apps/intellij/src/main/kotlin/dev/nx/console/nxls/client/NxlsLanguageClient.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/nxls/client/NxlsLanguageClient.kt
@@ -1,5 +1,7 @@
 package dev.nx.console.nxls.client
 
+import com.intellij.openapi.project.Project
+import dev.nx.console.nxls.NxlsDiagnosticsService
 import dev.nx.console.utils.NxConsoleLogger
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.MessageActionItem
@@ -11,7 +13,7 @@ import org.eclipse.lsp4j.services.LanguageClient
 
 private val log by lazy { NxConsoleLogger.getInstance() }
 
-class NxlsLanguageClient : LanguageClient {
+class NxlsLanguageClient(private val project: Project) : LanguageClient {
 
     val refreshCallbacks: MutableList<() -> Unit> = mutableListOf()
     val refreshStartedCallback: MutableList<() -> Unit> = mutableListOf()
@@ -22,7 +24,9 @@ class NxlsLanguageClient : LanguageClient {
     }
 
     override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams?) {
-        TODO("Not yet implemented")
+        val params = diagnostics ?: return
+        NxlsDiagnosticsService.getInstance(project)
+            .setDiagnostics(params.uri, params.diagnostics ?: emptyList())
     }
 
     override fun showMessage(messageParams: MessageParams?) {

--- a/apps/intellij/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij/src/main/resources/META-INF/plugin.xml
@@ -32,6 +32,8 @@
                             implementationClass="dev.nx.console.completion.NxCompletionContributor"/>
     <lang.documentationProvider language="JSON"
                                 implementationClass="dev.nx.console.nxls.NxlsDocumentationProvider"/>
+    <externalAnnotator language="JSON"
+                       implementationClass="dev.nx.console.nxls.NxlsDiagnosticsAnnotator"/>
 
     <editorFactoryListener implementation="dev.nx.console.listeners.NxEditorListener"/>
 

--- a/apps/nxls/src/main.ts
+++ b/apps/nxls/src/main.ts
@@ -1,9 +1,12 @@
 import {
+  clearDiagnostics,
   completionHandler,
   configureSchemaForProject,
   configureSchemas,
   projectSchemaIsRegistered,
   resetInferencePluginsCompletionCache,
+  revalidateOpenDocuments,
+  validateDocument,
 } from '@nx-console/language-server-capabilities-code-completion';
 import { getDefinition } from '@nx-console/language-server-capabilities-definition';
 import { getDocumentLinks } from '@nx-console/language-server-capabilities-document-links';
@@ -291,6 +294,11 @@ const jsonDocumentMapper = getLanguageModelCache();
 documents.onDidClose((e) => {
   NativeWatcher.onCloseDocument(e.document.uri);
   jsonDocumentMapper.onDocumentRemoved(e.document);
+  clearDiagnostics(connection, e.document.uri);
+});
+
+documents.onDidChangeContent(async (e) => {
+  await validateDocument(connection, e.document, jsonDocumentMapper);
 });
 
 documents.onDidOpen(async (e) => {
@@ -314,7 +322,14 @@ documents.onDidOpen(async (e) => {
     return;
   }
 
-  configureSchemaForProject(project.name, WORKING_PATH, CLIENT_CAPABILITIES);
+  await configureSchemaForProject(
+    project.name,
+    WORKING_PATH,
+    CLIENT_CAPABILITIES,
+  );
+  // The project schema only exists once it is registered, so the validation that ran on open
+  // saw the base schema. Run it again now that this project's targets are known.
+  await validateDocument(connection, e.document, jsonDocumentMapper);
 });
 
 connection.onShutdown(async () => {
@@ -507,6 +522,7 @@ async function reconfigure(
   );
   await configureSchemas(workingPath, CLIENT_CAPABILITIES);
   lspLogger.debug?.('reconfigure: Schemas configured');
+  await revalidateOpenDocuments(connection, documents, jsonDocumentMapper);
 
   lspLogger.debug?.('reconfigure: Unregistering previous file watcher...');
   await unregisterFileWatcher?.();

--- a/libs/language-server/capabilities/code-completion/src/index.ts
+++ b/libs/language-server/capabilities/code-completion/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/get-completion-items';
 export * from './lib/schema-completion';
+export * from './lib/schema-validation';
 export * from './lib/completion-handler';
 export * from './lib/inference-plugins-completion';

--- a/libs/language-server/capabilities/code-completion/src/lib/schema-completion.ts
+++ b/libs/language-server/capabilities/code-completion/src/lib/schema-completion.ts
@@ -10,6 +10,7 @@ import {
   getNxJsonSchema,
   getProjectJsonSchema,
   implicitDependencies,
+  mergeWithInstalledSchema,
   namedInputs,
   tags,
 } from '@nx-console/shared-json-schema';
@@ -75,15 +76,11 @@ export async function configureSchemas(
     const nxVersion = await getNxVersion(workingPath);
     currentExecutors = [];
 
-    const projectJsonSchema = getProjectJsonSchema(
-      currentExecutors,
-      {},
-      nxVersion,
+    const projectJsonSchema = mergeWithInstalledSchema(
+      await readInstalledProjectSchema(workingPath),
+      getProjectJsonSchema(currentExecutors, {}, nxVersion),
     );
-    const packageJsonSchema = await getPackageJsonSchema(
-      workingPath,
-      projectJsonSchema,
-    );
+    const packageJsonSchema = getPackageJsonSchema(projectJsonSchema);
     const nxSchema = await getNxJsonSchema(
       currentExecutors,
       {},
@@ -109,16 +106,12 @@ export async function configureSchemas(
   const { nxVersion, nxJson, projectGraph } = currentNxWorkspace;
 
   currentExecutors = await getExecutors(workingPath);
-  const projectJsonSchema = getProjectJsonSchema(
-    currentExecutors,
-    nxJson.targetDefaults,
-    nxVersion,
+  const projectJsonSchema = mergeWithInstalledSchema(
+    await readInstalledProjectSchema(workingPath),
+    getProjectJsonSchema(currentExecutors, nxJson.targetDefaults, nxVersion),
   );
 
-  const packageJsonSchema = await getPackageJsonSchema(
-    workingPath,
-    projectJsonSchema,
-  );
+  const packageJsonSchema = getPackageJsonSchema(projectJsonSchema);
 
   const nxSchema = await getNxJsonSchema(
     currentExecutors,
@@ -256,41 +249,35 @@ async function getProjectSchema(
   };
 }
 
-async function getPackageJsonSchema(
+/**
+ * Nx ships the authoritative project.json schema with the installed package. It describes every
+ * property of the file, while the schema built here only describes the parts that need workspace
+ * knowledge - executors, project names, target names, inputs. Reading the installed one keeps the
+ * two in step with whichever Nx version the workspace has.
+ */
+async function readInstalledProjectSchema(
   workspacePath: string,
-  projectJsonSchema: JSONSchema,
-) {
+): Promise<JSONSchema | undefined> {
   try {
-    const projectJsonSchemaPath = await findNxPackagePath(
+    const schemaPath = await findNxPackagePath(
       workspacePath,
       join('schemas', 'project-schema.json'),
     );
-    if (projectJsonSchemaPath) {
-      const nxProjectSchema = await readAndParseJson(projectJsonSchemaPath);
-      return {
-        type: 'object',
-        properties: {
-          nx: {
-            ...nxProjectSchema,
-            ...projectJsonSchema,
-            properties: {
-              ...nxProjectSchema?.properties,
-              ...projectJsonSchema?.properties,
-            },
-          },
-        },
-      };
+    if (!schemaPath) {
+      return undefined;
     }
+    return await readAndParseJson(schemaPath);
   } catch (e) {
-    // fall through to default return
+    lspLogger.log(`Unable to read the installed project.json schema: ${e}`);
+    return undefined;
   }
+}
 
+function getPackageJsonSchema(projectJsonSchema: JSONSchema): JSONSchema {
   return {
     type: 'object',
     properties: {
-      nx: {
-        ...projectJsonSchema,
-      },
+      nx: projectJsonSchema,
     },
   };
 }

--- a/libs/language-server/capabilities/code-completion/src/lib/schema-validation.ts
+++ b/libs/language-server/capabilities/code-completion/src/lib/schema-validation.ts
@@ -1,0 +1,76 @@
+import {
+  getJsonLanguageService,
+  LanguageModelCache,
+  lspLogger,
+} from '@nx-console/language-server-utils';
+import { JSONDocument, TextDocument } from 'vscode-json-languageservice';
+import { Connection } from 'vscode-languageserver';
+import { TextDocuments } from 'vscode-languageserver/node';
+
+/**
+ * Schema problems are reported as warnings rather than errors: the schema is assembled from the
+ * installed Nx package plus whatever executor schemas the workspace resolves, so a mismatch is a
+ * strong hint rather than a certainty and should never look like a build failure.
+ */
+const VALIDATION_SETTINGS = {
+  schemaValidation: 'warning',
+  comments: 'ignore',
+  trailingCommas: 'ignore',
+} as const;
+
+const VALIDATED_FILES = ['project.json', 'nx.json'];
+
+export function isValidatedNxFile(uri: string): boolean {
+  const fileName = uri.split(/[\\/]/).pop();
+  return !!fileName && VALIDATED_FILES.includes(fileName);
+}
+
+export async function validateDocument(
+  connection: Connection,
+  document: TextDocument,
+  jsonDocumentMapper: LanguageModelCache<JSONDocument>,
+) {
+  if (!isValidatedNxFile(document.uri)) {
+    return;
+  }
+  const jsonLanguageService = getJsonLanguageService();
+  if (!jsonLanguageService) {
+    return;
+  }
+  try {
+    // The cache hands back the document with the `$schema` line blanked out. Validating that one
+    // keeps the file from being checked twice against the schema it points at, and blanking leaves
+    // every other line where it was, so the reported ranges still line up with what the user sees.
+    const { jsonAst, document: parsedDocument } =
+      jsonDocumentMapper.retrieve(document);
+    const diagnostics = await jsonLanguageService.doValidation(
+      parsedDocument,
+      jsonAst,
+      VALIDATION_SETTINGS,
+    );
+    connection.sendDiagnostics({ uri: document.uri, diagnostics });
+  } catch (e) {
+    lspLogger.log(`Unable to validate ${document.uri}: ${e}`);
+  }
+}
+
+export function clearDiagnostics(connection: Connection, uri: string) {
+  if (!isValidatedNxFile(uri)) {
+    return;
+  }
+  connection.sendDiagnostics({ uri, diagnostics: [] });
+}
+
+/**
+ * The schemas are built from the project graph, so what a file validates against changes whenever
+ * the workspace is reconfigured. Re-run every open document rather than leaving stale warnings.
+ */
+export async function revalidateOpenDocuments(
+  connection: Connection,
+  documents: TextDocuments<TextDocument>,
+  jsonDocumentMapper: LanguageModelCache<JSONDocument>,
+) {
+  for (const document of documents.all()) {
+    await validateDocument(connection, document, jsonDocumentMapper);
+  }
+}

--- a/libs/shared/json-schema/src/index.ts
+++ b/libs/shared/json-schema/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/project-json-schema';
 export * from './lib/completion-type';
 export * from './lib/nx-json-schema';
 export * from './lib/common-json-schema';
+export * from './lib/merge-schemas';

--- a/libs/shared/json-schema/src/lib/merge-schemas.spec.ts
+++ b/libs/shared/json-schema/src/lib/merge-schemas.spec.ts
@@ -1,0 +1,67 @@
+import { JSONSchema } from 'vscode-json-languageservice';
+import { mergeWithInstalledSchema } from './merge-schemas';
+
+const installedSchema = {
+  $schema: 'http://json-schema.org/schema',
+  $id: 'NxProjectConfiguration',
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    projectType: { type: 'string', enum: ['library', 'application'] },
+    tags: { type: 'array', items: { type: 'string' } },
+    targets: { type: 'object', description: 'from the installed package' },
+  },
+  definitions: { inputs: { type: 'array' } },
+} as JSONSchema;
+
+const dynamicSchema = {
+  type: 'object',
+  properties: {
+    tags: { type: 'array', 'x-completion-type': 'tags' },
+    targets: { type: 'object', description: 'knows this workspace' },
+  },
+} as JSONSchema;
+
+describe('mergeWithInstalledSchema', () => {
+  it('keeps the properties only the installed schema describes', () => {
+    const merged = mergeWithInstalledSchema(installedSchema, dynamicSchema);
+
+    expect(merged.properties?.['name']).toEqual({ type: 'string' });
+    expect(merged.properties?.['projectType']).toEqual({
+      type: 'string',
+      enum: ['library', 'application'],
+    });
+  });
+
+  it('lets the workspace-aware schema win where the two overlap', () => {
+    const merged = mergeWithInstalledSchema(installedSchema, dynamicSchema);
+
+    expect(merged.properties?.['tags']).toEqual({
+      type: 'array',
+      'x-completion-type': 'tags',
+    });
+    expect(merged.properties?.['targets']).toEqual({
+      type: 'object',
+      description: 'knows this workspace',
+    });
+  });
+
+  it('keeps definitions so internal $refs still resolve', () => {
+    const merged = mergeWithInstalledSchema(installedSchema, dynamicSchema);
+
+    expect(merged.definitions?.['inputs']).toEqual({ type: 'array' });
+  });
+
+  it('drops the installed schema identity', () => {
+    const merged = mergeWithInstalledSchema(installedSchema, dynamicSchema);
+
+    expect(merged.$schema).toBeUndefined();
+    expect(merged.$id).toBeUndefined();
+  });
+
+  it('falls back to the workspace-aware schema when Nx is not installed', () => {
+    expect(mergeWithInstalledSchema(undefined, dynamicSchema)).toBe(
+      dynamicSchema,
+    );
+  });
+});

--- a/libs/shared/json-schema/src/lib/merge-schemas.ts
+++ b/libs/shared/json-schema/src/lib/merge-schemas.ts
@@ -1,0 +1,30 @@
+import type { JSONSchema } from 'vscode-json-languageservice';
+
+/**
+ * Nx ships the authoritative project.json schema with the installed package: it describes every
+ * property of the file. The schemas built in this library describe only the parts that need
+ * workspace knowledge - executors, project names, target names, inputs - so the two are merged,
+ * with the workspace-aware one winning wherever they overlap.
+ *
+ * `$schema` and `$id` are dropped because the result is a new document served under an `nx://` uri,
+ * and a leftover identity would send `$ref` resolution somewhere else.
+ */
+export function mergeWithInstalledSchema(
+  installedSchema: JSONSchema | undefined,
+  dynamicSchema: JSONSchema,
+): JSONSchema {
+  if (!installedSchema) {
+    return dynamicSchema;
+  }
+  const merged = {
+    ...installedSchema,
+    ...dynamicSchema,
+    properties: {
+      ...installedSchema.properties,
+      ...dynamicSchema.properties,
+    },
+  } as JSONSchema & Record<string, unknown>;
+  delete merged['$schema'];
+  delete merged['$id'];
+  return merged;
+}


### PR DESCRIPTION
Closes #1986

## The bug

Completion for `project.json` in JetBrains IDEs comes from nxls, and the schema nxls serves described only the five properties that need workspace knowledge:

```ts
// libs/shared/json-schema/src/lib/project-json-schema.ts
properties: { sourceRoot, implicitDependencies, tags, namedInputs, targets }
```

Everything else Nx supports was invisible — no completion and no hover documentation for `name`, `projectType`, `generators`, `metadata`, `release` or `root`. That is @Den-dp's report. It affects VS Code equally, since it goes through the same server.

On top of that, nxls never validated anything, so a `project.json` could contradict Nx's schema without any editor saying so, and the IntelliJ client's `publishDiagnostics` was `TODO("Not yet implemented")` — it would have thrown had the server ever sent one.

## The fix

**nxls** merges Nx's own `schemas/project-schema.json` — read from the installed package, so it tracks the Nx version in use — into the schema it serves, with the workspace-aware entries winning where the two overlap. `getPackageJsonSchema` already did exactly this for the `nx` key inside `package.json`; this reuses the pattern for `project.json` itself, so both files now describe the same thing.

It also runs the json language service's validation for `project.json` and `nx.json` and publishes the result. Problems are **warnings**, not errors: the schema is assembled from the installed package plus whatever executor schemas the workspace resolves, so a mismatch is a strong hint rather than a certainty.

**The IntelliJ client** stores what arrives and renders it through an `ExternalAnnotator`, which is what makes the validation visible in the editor.

## Deliberately out of scope

The IDE's own schema mapping is untouched. JetBrains IDEs still resolve SchemaStore's `project.json` entry for this file — that entry is for .NET Core's unrelated format, but displacing a SchemaStore mapping is a decision about every `project.json` on the machine, not just Nx's, so this change leaves it alone and adds the Nx knowledge through the server instead.

## Verification

Real IntelliJ IDEA `IU-253.33813.55`, same fixture and same automation scenario for both runs. Before/after table, videos and raw results in the comment below.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AkE7irXfqsmXtntFZUAmM
