### PR TITLE
fix(repo): create e2e fixture workspaces with legacy peer resolution

### DIFF
--- a/libs/shared/e2e-utils/src/lib/utils.ts
+++ b/libs/shared/e2e-utils/src/lib/utils.ts
@@ -71,6 +71,13 @@ export function newWorkspace({
   const _env = {
     CI: 'true',
     NX_CLOUD_API: 'https://staging.nx.app', // create-nx-workspace invocations are tracked and we don't want to skew the stats through e2es
+    // npm's dependency resolver crashes walking vitest's optional peer set while
+    // installing the workspaces these presets generate:
+    //   TypeError: Cannot read properties of null (reading 'edgesOut')
+    //     at #loadPeerSet (@npmcli/arborist/lib/arborist/build-ideal-tree.js:1302)
+    // It reproduces on every npm from 10.2.4 (bundled with the node 20.11 agent image)
+    // through 11.5.2. Resolving peers the legacy way skips that walk entirely.
+    npm_config_legacy_peer_deps: 'true',
     ...(env ?? process.env),
   } as NodeJS.ProcessEnv;
 


### PR DESCRIPTION
## Current Behavior

Every PR that makes an e2e project affected fails `Main Linux`, because the fixture workspace cannot be installed:

```
 NX   Failed to create workspace

Failed to create a workspace: npm ERR! Cannot read properties of null (reading 'edgesOut')
```

```
✖ Failed           nxls-e2e:e2e-ci--src/generators/gener…     29s          Cache Miss
✖ Dependencies failed    nxls-e2e:e2e-ci
```

The throw is inside npm's own dependency resolver, and the unfinished timer names what it dies on:

```
TypeError: Cannot read properties of null (reading 'edgesOut')
    at #loadPeerSet (@npmcli/arborist/lib/arborist/build-ideal-tree.js:1302:38)
    at async #loadPeerSet (…:1310:11)   ← x3
    at async #buildDepStep (…:917:11)
verbose unfinished npm timer idealTree:node_modules/vitest
```

It is walking **vitest**'s optional peer set — the last three manifests fetched before the throw are `msw@^2.4.9`, `typescript@>= 4.8.x` and `vite@^6.0.0 || ^7.0.0 || ^8.0.0`.

`simpleReactWorkspaceOptions` is `react-standalone` + `vite` + `cypress`, so the generated fixture pins `vitest: ~4.1.0` and `vite: ^8.0.0`, currently resolving to vitest 4.1.11 / vite 8.2.2. Those ranges float, which is why this began failing with no change in this repo.

Bisected against the real `create-nx-workspace@22.7.0` fixture command:

| npm | react-standalone | with `legacy-peer-deps` |
| --- | --- | --- |
| 10.2.4 | ❌ `edgesOut` | ✅ |
| 10.8.2 | ❌ `edgesOut` | — |
| 10.9.4 | ❌ `edgesOut` | — |
| 11.0.0 | ❌ `edgesOut` | — |
| 11.5.2 | ❌ `edgesOut` | — |
| 11.19.0 | ✅ | ✅ |

**10.2.4 is the npm bundled with node 20.11**, which is the `ubuntu22.04-node20.11-v10` image both launch templates in `.nx/workflows/agents.yaml` use, so every agent that picks up one of these tasks hits it. It is not just an old-agents problem either — the crash survives well into npm 11, past what node 24 ships.

`master` looks green only because these tasks' inputs have not changed there and they are served from the Nx Cloud cache. A PR that changes their inputs runs them for real and fails.

Two specs are affected today:

- `nxls-e2e:e2e-ci--src/generators/generator-options-22-7-beta.test.ts` — this is what has been blocking #3211
- `nx-mcp-e2e`'s `nx-project-details-modern-nx-layout.test.ts` — flagged in #3213 as separately failing with the same error and no peer warning

## Expected Behavior

The fixture workspaces install.

Resolving peers the legacy way skips the peer-set walk that crashes. These are throwaway workspaces created by `create-nx-workspace`; their peer graph is not what any of these specs assert on, and every one of them only needs Nx and a plugin to be present on disk.

Applied once in `newWorkspace`, so it covers every current and future fixture rather than one spec at a time. It sits before the `process.env` spread, so a caller or a developer's environment can still override it.

## Verification

Same machine, same commands, with npm 10.2.4 first on `PATH` to match the agents:

| spec | `master` (`5b71ed29`) | this branch (`61f63e3c`) |
| --- | --- | --- |
| `nxls-e2e … generator-options-22-7-beta` | `Failed to create workspace` / `Tests: 1 failed` | `Successfully created the workspace` / `Tests: 1 passed` |
| `nx-mcp-e2e … modern-nx-layout` | `Failed to create workspace` / `Tests: 3 failed` | `Successfully created the workspace` / `Tests: 3 passed` |

```sh
npm i npm@10.2.4 --prefix /tmp/npm10
PATH="/tmp/npm10/node_modules/.bin:$PATH" \
  yarn nx run nxls-e2e:e2e-local --skip-nx-cache -- generator-options-22-7-beta
PATH="/tmp/npm10/node_modules/.bin:$PATH" \
  yarn nx run nx-mcp-e2e:e2e-local --skip-nx-cache -- modern-nx-layout
```

The baseline runs reproduce CI exactly, including the `npm WARN ERESOLVE overriding peer dependency` line that precedes the crash in the CI log for the prerelease pin.

Also checked directly against `create-nx-workspace` under npm 10.2.4 that the resulting workspaces are unchanged in the ways these specs care about: the react fixture still has projects `e2e` and `<workspaceName>`, `nx` is still laid out under `dist/src/**`, and `@nx/js`'s `convert-to-swc/schema.json` is still at `src/**` — with both `22.7.0` and `22.7.0-beta.17`.

`nx run-many -t lint,typecheck -p nxls-e2e,nx-mcp-e2e,shared-e2e-utils` passes. `nx format --fix` applied.

Logs and the full bisect are attached to the Polygraph session:
https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/able-tapir-a8aaa1b5

## Notes for reviewers

- I first tried moving the one failing spec to a preset without vitest. That fixes `nxls-e2e` but not `nx-mcp-e2e`, whose spec needs a project named after the workspace — which the `ts` preset does not create. This is the version that fixes both, and it does not change any fixture's shape or any assertion.
- The trade-off is that a genuine peer conflict in a fixture would no longer fail the install. Given that these workspaces are generated by `create-nx-workspace` and thrown away, and that the alternative is a permanently red required check, that seemed the right side to err on. Happy to scope it to the two affected specs instead if you'd rather keep strict resolution everywhere else.
- The underlying npm bug is not ours, and I did not pin an npm version in CI — that would only move the problem to whichever npm the agent image ships next.
- Related to #3213, which repins this spec from `22.7.0-beta.17` to stable `22.7.0`. That is orthogonal: the `edgesOut` crash is not caused by the prerelease, and I verified this change works with either version. Whichever lands second needs no rebase — the two touch different files now.

## Related Issue(s)

Unblocks #3211 and #3216. Related to #3213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/able-tapir-a8aaa1b5">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->