### PR TITLE
fix(nxls): keep a top-level project a project when other projects nest inside it

### DIFF
--- a/apps/intellij/AUTOMATION.md
+++ b/apps/intellij/AUTOMATION.md
@@ -217,6 +217,32 @@ The tree Run action uses the SDK's EDT/read-action context, matching
 `Driver.invokeAction`. Calling `actionPerformed` directly on the EDT can fail
 IntelliJ's write-intent lock checks during execution startup.
 
+### Folder tree roots
+
+`ReproFolderTreeRootsKt` checks that a project whose root is a top-level
+directory still renders as a project when other projects are nested inside it.
+It expands the whole Nx Console tree, scrolls the node under test into view, and
+asserts on the paths the tree actually renders.
+
+Use a fixture with **more than ten projects**, so the automatic tool window style
+resolves to the folder tree rather than the flat list, and with no project at the
+workspace root. It needs a project rooted at `packages` named
+`packages-aggregator` with a `hello` target, two projects nested below it at
+`packages/a` and `packages/b` (`child-a`, `child-b`), and enough other projects
+elsewhere to clear the ten-project threshold.
+
+```sh
+NX_AUTOMATION_LABEL=issue-folder-tree-roots-repro CI=true \
+  JAVA_TOOL_OPTIONS='-XX:ActiveProcessorCount=4 -Dorg.gradle.workers.max=2 -Dorg.gradle.priority=low' \
+  yarn nx run intellij:runAutomation --batch=false --parallel=2 \
+  --args='--max-workers=2 --priority=low -PautomationMain=dev.nx.console.automation.ReproFolderTreeRootsKt'
+```
+
+Rerun with `NX_AUTOMATION_LABEL=issue-folder-tree-roots-fixed` after rebuilding
+and restarting the IDE. The video shows the selected tree row: the folder
+`packages` with no target before the fix, and the project `packages-aggregator`
+with its `hello` target and both nested projects after it.
+
 References:
 
 - [JetBrains Driver SDK](https://github.com/JetBrains/intellij-community/blob/master/tools/intellij.tools.ide.starter.driver/README.md)

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/RecordIde.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/RecordIde.kt
@@ -3,6 +3,7 @@ package dev.nx.console.automation
 import com.intellij.driver.client.Driver
 import com.intellij.driver.client.utility
 import com.intellij.driver.sdk.jdk.getSystemProperty
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -12,7 +13,26 @@ import kotlin.concurrent.thread
 import kotlin.io.path.copyTo
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
+import kotlin.io.path.name
 import kotlin.io.path.writeText
+
+/**
+ * The IDE writes each capture into its own directory under the log's `screenshots` directory,
+ * prefixing the requested name with a zero-padded index of the capture within the session
+ * (`0042_<name>`). Older builds used the bare name, so accept both.
+ */
+private fun captureDirectory(screenshots: Path, captureName: String): Path {
+    val exact = screenshots.resolve(captureName)
+    if (exact.exists()) return exact
+    val indexed =
+        runCatching {
+                Files.list(screenshots).use { entries ->
+                    entries.filter { it.name.endsWith("_$captureName") }.findFirst().orElse(null)
+                }
+            }
+            .getOrNull()
+    return indexed ?: exact
+}
 
 fun Driver.recordIde(label: String, scenario: Driver.() -> Unit) {
     require(label.matches(Regex("[a-zA-Z0-9_-]+")))
@@ -39,7 +59,7 @@ fun Driver.recordIde(label: String, scenario: Driver.() -> Unit) {
                         val captureName = "$name-$frame"
                         val timestamp = System.nanoTime()
                         capture.takeScreenshotOfAllWindowsBlocking(captureName)
-                        val source = logs.resolve(captureName).resolve("frame0.png")
+                        val source = captureDirectory(logs, captureName).resolve("frame0.png")
                         check(source.exists()) { "No main IDE window captured at $source" }
                         source.copyTo(output.resolve("$frame.png"))
                         frames.add("$frame.png" to timestamp)

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproFolderTreeRoots.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproFolderTreeRoots.kt
@@ -1,0 +1,120 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.client.Remote
+import com.intellij.driver.model.OnDispatcher
+import com.intellij.driver.sdk.closeToolWindow
+import com.intellij.driver.sdk.openToolWindow
+import com.intellij.driver.sdk.ui.components.elements.JTreeUiComponent
+import com.intellij.driver.sdk.ui.ui
+import com.intellij.driver.sdk.waitForProjectOpen
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.time.Duration.Companion.minutes
+
+@Remote("com.intellij.openapi.wm.impl.IdeFrameImpl")
+interface FolderTreeIdeFrame {
+    fun setExtendedState(state: Int)
+
+    fun toFront()
+
+    fun getBalloonLayout(): FolderTreeBalloonLayout
+}
+
+@Remote("com.intellij.ui.BalloonLayoutImpl")
+interface FolderTreeBalloonLayout {
+    fun closeAll()
+}
+
+@Remote("javax.swing.JTree")
+interface FolderTreeSwingTree {
+    fun setSelectionRow(row: Int)
+
+    fun scrollRowToVisible(row: Int)
+}
+
+private const val AGGREGATOR = "packages-aggregator"
+private const val AGGREGATOR_DIR = "packages"
+
+private fun Driver.expandedPaths(tree: JTreeUiComponent): List<List<String>> {
+    tree.expandAll()
+    return tree.collectExpandedPaths().map { it.path }
+}
+
+fun main() = withAutomationDriver {
+    waitForProjectOpen(2.minutes)
+    withContext(OnDispatcher.EDT) {
+        cast(ui.x("//div[@class='IdeFrameImpl']").component, FolderTreeIdeFrame::class).apply {
+            setExtendedState(0)
+            toFront()
+            getBalloonLayout().closeAll()
+        }
+    }
+    closeToolWindow("Project")
+    openToolWindow("Nx Console")
+
+    val tree = ui.x("//div[@class='NxProjectsTree']", JTreeUiComponent::class.java)
+
+    // The tree is filled from an async nxls request and each level of children is resolved
+    // lazily, so expanding once is not enough to see the whole tree.
+    val deadline = System.nanoTime() + 3.minutes.inWholeNanoseconds
+    var paths = emptyList<List<String>>()
+    while (System.nanoTime() < deadline) {
+        val current = runCatching { expandedPaths(tree) }.getOrDefault(emptyList())
+        if (current.size >= 13 && current == paths) break
+        paths = current
+        Thread.sleep(1000)
+    }
+
+    recordIde(System.getenv("NX_AUTOMATION_LABEL") ?: "issue-folder-tree-roots-repro") {
+        paths = expandedPaths(tree)
+        val topLevel = paths.filter { it.size == 2 && it.first() == "Projects" }.map { it[1] }
+
+        // Bring the node under test on screen so the recording shows it, whichever way it
+        // rendered. Everything below is asserted on the collected paths, not on the frame.
+        val onScreen = listOf(AGGREGATOR, AGGREGATOR_DIR).firstOrNull { topLevel.contains(it) }
+        if (onScreen != null) {
+            withContext(OnDispatcher.EDT) {
+                val row =
+                    checkNotNull(tree.findExpandedPath("Projects", onScreen, fullMatch = true)).row
+                cast(tree.component, FolderTreeSwingTree::class).apply {
+                    scrollRowToVisible(row + 3)
+                    scrollRowToVisible(row)
+                    setSelectionRow(row)
+                }
+            }
+        }
+        Thread.sleep(4000)
+
+        val output =
+            automationOutput()
+                .resolve("folder-tree-${System.currentTimeMillis()}")
+                .createDirectories()
+        output.resolve("tree.txt").writeText(paths.joinToString("\n") { it.joinToString(" / ") })
+        println("Nx Console tree:\n${paths.joinToString("\n") { it.joinToString(" / ") }}")
+
+        check(topLevel.isNotEmpty()) { "The Projects section rendered no top-level nodes." }
+        check(!topLevel.contains(AGGREGATOR_DIR)) {
+            "The project rooted at '$AGGREGATOR_DIR' is rendered as the folder '$AGGREGATOR_DIR'. " +
+                "Top-level nodes: $topLevel"
+        }
+        check(topLevel.contains(AGGREGATOR)) {
+            "The project rooted at '$AGGREGATOR_DIR' is missing from the tree as '$AGGREGATOR'. " +
+                "Top-level nodes: $topLevel"
+        }
+
+        val underAggregator =
+            paths
+                .filter { it.size == 3 && it[0] == "Projects" && it[1] == AGGREGATOR }
+                .map { it[2] }
+        check(underAggregator.contains("hello")) {
+            "'$AGGREGATOR' does not offer its 'hello' target. Children: $underAggregator"
+        }
+        listOf("child-a", "child-b").forEach { child ->
+            check(underAggregator.contains(child)) {
+                "'$AGGREGATOR' lost its nested project '$child'. Children: $underAggregator"
+            }
+        }
+        println("PASS: '$AGGREGATOR' renders as a project with $underAggregator")
+    }
+}

--- a/libs/language-server/workspace/src/lib/build-project-folder-tree.spec.ts
+++ b/libs/language-server/workspace/src/lib/build-project-folder-tree.spec.ts
@@ -1,0 +1,92 @@
+import type { ProjectGraphProjectNode } from 'nx/src/devkit-exports';
+import { buildProjectFolderTree } from './build-project-folder-tree';
+
+function nodes(
+  ...roots: [name: string, root: string][]
+): Record<string, ProjectGraphProjectNode> {
+  return Object.fromEntries(
+    roots.map(([name, root]) => [
+      name,
+      { name, type: 'lib', data: { root } } as ProjectGraphProjectNode,
+    ]),
+  );
+}
+
+describe('buildProjectFolderTree', () => {
+  it('nests a project under the folder of its parent directory', () => {
+    const { roots, serializedTreeMap } = buildProjectFolderTree(
+      nodes(['app', 'apps/app']),
+    );
+
+    expect(roots.map((r) => r.dir)).toEqual(['apps']);
+    expect(roots[0].projectName).toBeUndefined();
+    expect(roots[0].children).toEqual(['apps/app']);
+    expect(
+      serializedTreeMap.find((e) => e.dir === 'apps/app')?.node.projectName,
+    ).toEqual('app');
+  });
+
+  it('keeps a top-level project as a project when a nested project is added first', () => {
+    const { roots } = buildProjectFolderTree(
+      nodes(['child', 'packages/child'], ['aggregator', 'packages']),
+    );
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].dir).toEqual('packages');
+    expect(roots[0].projectName).toEqual('aggregator');
+    expect(roots[0].projectConfiguration).toBeDefined();
+    expect(roots[0].children).toEqual(['packages/child']);
+  });
+
+  it('does not depend on the order projects arrive in', () => {
+    const nested = buildProjectFolderTree(
+      nodes(['child', 'packages/child'], ['aggregator', 'packages']),
+    );
+    const parentFirst = buildProjectFolderTree(
+      nodes(['aggregator', 'packages'], ['child', 'packages/child']),
+    );
+
+    expect(nested.roots).toEqual(parentFirst.roots);
+  });
+
+  it('returns the same node object for a root as for its treeMap entry', () => {
+    const { roots, serializedTreeMap } = buildProjectFolderTree(
+      nodes(['child', 'packages/child'], ['aggregator', 'packages']),
+    );
+
+    expect(roots[0]).toBe(
+      serializedTreeMap.find((e) => e.dir === 'packages')?.node,
+    );
+  });
+
+  it('makes the workspace root project the singular root', () => {
+    const { roots } = buildProjectFolderTree(
+      nodes(['root', '.'], ['app', 'apps/app'], ['aggregator', 'packages']),
+    );
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].dir).toEqual('.');
+    expect(roots[0].projectName).toEqual('root');
+    expect(roots[0].children).toEqual(['apps', 'packages']);
+  });
+
+  it('does not make the workspace root project its own child', () => {
+    const { roots } = buildProjectFolderTree(
+      nodes(
+        ['child', 'packages/child'],
+        ['root', '.'],
+        ['aggregator', 'packages'],
+      ),
+    );
+
+    expect(roots[0].children).not.toContain('.');
+  });
+
+  it('sorts roots by directory', () => {
+    const { roots } = buildProjectFolderTree(
+      nodes(['z', 'zed/z'], ['a', 'alpha/a'], ['m', 'mid/m']),
+    );
+
+    expect(roots.map((r) => r.dir)).toEqual(['alpha', 'mid', 'zed']);
+  });
+});

--- a/libs/language-server/workspace/src/lib/build-project-folder-tree.ts
+++ b/libs/language-server/workspace/src/lib/build-project-folder-tree.ts
@@ -1,0 +1,102 @@
+import { TreeNode } from '@nx-console/shared-types';
+import type { ProjectGraphProjectNode } from 'nx/src/devkit-exports';
+import { parse } from 'path';
+
+/*
+ * Construct a tree (all nodes are saved in a map) from the project definitions by doing the following:
+ * - Create a node for each project and recursively add its parent folders as nodes
+ * - If a project is added where a folder exists already, overwrite the folder node
+ * - In the end, if a folder with the '.' root exists, it will be the singular root node
+ */
+/* eslint-disable @typescript-eslint/no-non-null-assertion -- dealing with maps is hard */
+export function buildProjectFolderTree(
+  projectNodes: Record<string, ProjectGraphProjectNode>,
+): {
+  serializedTreeMap: { dir: string; node: TreeNode }[];
+  roots: TreeNode[];
+} {
+  const treeMap = new Map<string, TreeNode>();
+  // Roots are tracked by directory rather than by node, because a folder node is
+  // replaced by a new object once the project rooted at the same directory is added.
+  const rootDirs = new Set<string>();
+
+  function connectNodeToParent(node: TreeNode, parent: TreeNode) {
+    parent.children.push(node.dir);
+  }
+
+  function addProjectOrFolderTreeNode(
+    dir: string,
+    projectName?: string,
+    projectConfiguration?: ProjectGraphProjectNode,
+  ) {
+    // if a node is only a folder and exists already, we don't need to add it again
+    if (!projectConfiguration && !projectName && treeMap.has(dir)) {
+      return;
+    }
+
+    // if a node is a project and exists already, we need to replace the folder node with a new project node
+    if (projectConfiguration && projectName && treeMap.has(dir)) {
+      const oldNode = treeMap.get(dir)!;
+      treeMap.set(dir, {
+        dir,
+        projectName: projectName,
+        projectConfiguration,
+        children: oldNode.children,
+      });
+      return;
+    }
+
+    // if a node doesn't exist, we need to add it
+    const treeNode = {
+      dir,
+      projectName,
+      projectConfiguration,
+      children: [],
+    };
+    treeMap.set(dir, treeNode);
+
+    // after adding, we need to connect it to its parent or create it if it doesn't exist
+    // if there is no parent, the node is a root
+    const parentPath = parse(dir).dir;
+    if (!parentPath) {
+      rootDirs.add(dir);
+      return;
+    }
+
+    if (treeMap.has(parentPath)) {
+      connectNodeToParent(treeMap.get(dir)!, treeMap.get(parentPath)!);
+    } else {
+      addProjectOrFolderTreeNode(parentPath);
+      connectNodeToParent(treeMap.get(dir)!, treeMap.get(parentPath)!);
+    }
+  }
+
+  for (const [projectName, projectDef] of Object.entries(projectNodes)) {
+    addProjectOrFolderTreeNode(projectDef.data.root, projectName, projectDef);
+  }
+
+  // special case: if there is a '.' project, it will be the singular root
+  if (treeMap.has('.')) {
+    const workspaceRootProjectNode = treeMap.get('.')!;
+    rootDirs.forEach((rootDir) => {
+      if (rootDir === '.') {
+        return;
+      }
+      workspaceRootProjectNode.children.push(rootDir);
+    });
+    rootDirs.clear();
+    rootDirs.add('.');
+  }
+
+  const serializedTreeMap = Array.from(treeMap.entries()).map(
+    ([dir, node]) => ({
+      dir,
+      node,
+    }),
+  );
+  const roots = Array.from(rootDirs)
+    .sort((a, b) => a.localeCompare(b))
+    .map((dir) => treeMap.get(dir)!);
+
+  return { serializedTreeMap, roots };
+}

--- a/libs/language-server/workspace/src/lib/get-project-folder-tree.ts
+++ b/libs/language-server/workspace/src/lib/get-project-folder-tree.ts
@@ -1,100 +1,13 @@
 import { TreeNode } from '@nx-console/shared-types';
-import { parse } from 'path';
 import { nxWorkspace } from '@nx-console/shared-nx-workspace-info';
-import type { ProjectGraphProjectNode } from 'nx/src/devkit-exports';
 import { lspLogger } from '@nx-console/language-server-utils';
+import { buildProjectFolderTree } from './build-project-folder-tree';
 
-/*
- * Construct a tree (all nodes are saved in a map) from the project definitions by doing the following:
- * - Create a node for each project and recursively add its parent folders as nodes
- * - If a project is added where a folder exists already, overwrite the folder node
- * - In the end, if a folder with the '.' root exists, it will be the singular root node
- */
-/* eslint-disable @typescript-eslint/no-non-null-assertion -- dealing with maps is hard */
 export async function getProjectFolderTree(workspacePath: string): Promise<{
   serializedTreeMap: { dir: string; node: TreeNode }[];
   roots: TreeNode[];
 }> {
   const { projectGraph } = await nxWorkspace(workspacePath, lspLogger);
 
-  const treeMap = new Map<string, TreeNode>();
-  const roots = new Set<TreeNode>();
-
-  function connectNodeToParent(node: TreeNode, parent: TreeNode) {
-    parent.children.push(node.dir);
-  }
-
-  function addProjectOrFolderTreeNode(
-    dir: string,
-    projectName?: string,
-    projectConfiguration?: ProjectGraphProjectNode,
-  ) {
-    // if a node is only a folder and exists already, we don't need to add it again
-    if (!projectConfiguration && !projectName && treeMap.has(dir)) {
-      return;
-    }
-
-    // if a node is a project and exists already, we need to replace the folder node with a new project node
-    if (projectConfiguration && projectName && treeMap.has(dir)) {
-      const oldNode = treeMap.get(dir)!;
-      treeMap.set(dir, {
-        dir,
-        projectName: projectName,
-        projectConfiguration,
-        children: oldNode.children,
-      });
-      return;
-    }
-
-    // if a node doesn't exist, we need to add it
-    const treeNode = {
-      dir,
-      projectName,
-      projectConfiguration,
-      children: [],
-    };
-    treeMap.set(dir, treeNode);
-
-    // after adding, we need to connect it to its parent or create it if it doesn't exist
-    // if there is no parent, the node is a root
-    const parentPath = parse(dir).dir;
-    if (!parentPath) {
-      roots.add(treeNode);
-      return;
-    }
-
-    if (treeMap.has(parentPath)) {
-      connectNodeToParent(treeMap.get(dir)!, treeMap.get(parentPath)!);
-    } else {
-      addProjectOrFolderTreeNode(parentPath);
-      connectNodeToParent(treeMap.get(dir)!, treeMap.get(parentPath)!);
-    }
-  }
-
-  for (const [projectName, projectDef] of Object.entries(projectGraph.nodes)) {
-    addProjectOrFolderTreeNode(projectDef.data.root, projectName, projectDef);
-  }
-
-  // special case: if there is a '.' project, it will be the singular root
-  if (treeMap.has('.')) {
-    const workspaceRootProjectNode = treeMap.get('.');
-    roots.forEach((root) => {
-      if (root.projectConfiguration?.data.root === '.') {
-        return;
-      }
-      workspaceRootProjectNode?.children.push(root.dir);
-    });
-    roots.clear();
-    roots.add(workspaceRootProjectNode!);
-  }
-  const serializedTreeMap = Array.from(treeMap.entries()).map(
-    ([dir, node]) => ({
-      dir,
-      node,
-    }),
-  );
-  const sortedRoots = Array.from(roots).sort((a, b) => {
-    return a.dir.localeCompare(b.dir);
-  });
-  return { serializedTreeMap, roots: sortedRoots };
+  return buildProjectFolderTree(projectGraph.nodes);
 }


### PR DESCRIPTION
## Current Behavior

In the tree layout of the projects view, a project whose root is a **top-level directory that also contains other projects** is rendered as a plain folder. Its targets, run/debug actions, "Show project configuration" and project details are all unreachable from the tree, even though the project is in the graph and the projects nested below it still render fine.

Concretely, for a workspace with no project at `.` and:

```
packages/project.json      → packages-aggregator   (target: hello)
packages/a/project.json    → child-a
packages/b/project.json    → child-b
```

the tree shows `packages` as a folder, and `hello` is simply not there:

```
Projects / packages                  ← folder, not the project
Projects / packages / child-a
Projects / packages / child-a / hello
Projects / packages / child-b
Projects / packages / child-b / hello
```

## Cause

`getProjectFolderTree` kept its roots in a `Set<TreeNode>`, holding node *objects*:

```ts
const roots = new Set<TreeNode>();
…
if (projectConfiguration && projectName && treeMap.has(dir)) {
  const oldNode = treeMap.get(dir)!;
  treeMap.set(dir, { dir, projectName, projectConfiguration, children: oldNode.children });
  return;                       // ← treeMap now holds a new object; roots still holds the old one
}
```

When `packages/a` is processed first, `packages` is created as a *folder* node and — being a single-segment directory with no parent — is added to `roots`. When `packages` itself is processed, the map entry is replaced by a project node, but the set still holds the discarded folder node.

The children array survives (it is passed by reference into the new node), which is why the nested projects still appear. What is lost is the identity: `roots[0]` comes back with `projectName: undefined` and `projectConfiguration: undefined`.

Both tool windows decide between a folder and a project purely from that field — IntelliJ in `NxFolderTreeBuilder.createFolderOrProjectNode`, VS Code in `TreeView.createFolderOrProjectTreeItemFromNode` — so both render the folder.

Two conditions have to hold, which is why this is not more visible: the directory has to be **single-segment** (only those reach `roots` directly — `e2es/parent` is attached to its `e2es` parent instead), and there has to be **no project at `.`** (the workspace-root special case rebuilds the root list from the map and hides it).

Verified against nxls directly, before the fix:

```
roots:   [{ dir: "packages", projectName: null, hasConfig: false, children: ["packages/a","packages/b"] }]
treeMap: [ …, { dir: "packages", projectName: "packages-aggregator", hasConfig: true, … } ]
```

## Expected Behavior

A root is the same node the tree map holds for that directory.

Roots are now tracked by directory and resolved against the map at the end, which cannot go stale. The workspace-root special case becomes a `rootDir === '.'` comparison instead of reaching into `projectConfiguration.data.root`.

The tree building moved into `build-project-folder-tree.ts` so it can be exercised without a workspace; `getProjectFolderTree` is now just the `nxWorkspace` call plus that function.

## Verification

Real IntelliJ IDEA `IU-253.33813.55`, fixture with nx 23.2.0 and 13 projects (above the ten-project threshold where the automatic tool window style switches from the flat list to the folder tree), no project at the workspace root. Same scenario file for both runs — the fixed run was recorded first, then the two product files were reverted to `master`, nxls rebuilt, the IDE relaunched, and the baseline recorded. The rebuilt `nxls/main.js` timestamp was checked against the source edit each time.

`ReproFolderTreeRootsKt` expands the whole tree, scrolls the node under test into view, and asserts on the paths the tree actually renders.

| | `master` (`5b71ed29`) | this branch (recorded at `f168c858`, rebased to `dfd97b68`) |
| --- | --- | --- |
| top-level node | `packages` (folder icon) | `packages-aggregator` (project icon) |
| its children | `child-a`, `child-b` | `hello`, `child-a`, `child-b` |
| `hello` target reachable | **no** | yes |
| scenario | FAIL | PASS |

```
The project rooted at 'packages' is rendered as the folder 'packages'.
Top-level nodes: [libs, packages]
```

Videos, both `result.txt` files, the full scenario output and the fixture description are attached to the Polygraph session:
https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/able-tapir-a8aaa1b5

The recorded frames show the selected row directly: the folder `packages` followed immediately by `child-a` before the fix, and `packages-aggregator` followed by its `hello` target after it. Verification is through the driver reading the live `JTree`'s expanded paths plus the recorded frames — no native mouse or keyboard input.

## Tests

`libs/language-server/workspace` had no tests; this adds its first spec, seven cases over `buildProjectFolderTree`, running in ~0.2s. Three of them fail against the previous implementation:

- keeps a top-level project a project when a nested project is added first
- does not depend on the order projects arrive in
- returns the same node object for a root as for its treeMap entry

`nx run-many -t test,lint,typecheck -p language-server-workspace` passes. `nx format --fix` and `nx run-many -t ktfmtFormat` applied.

## Notes for reviewers

- The second commit is separable and is test tooling only. `recordIde` could not capture a single frame on IntelliJ 2025.3 — the IDE writes each capture into `<index>_<name>` under the log's `screenshots` directory while the recorder resolved the bare name, so every recording died on frame 0 with `No main IDE window captured`. Without it there is no video evidence for this or any other fix on this IDE build.
- The existing `project-folder-tree` e2e cannot catch this: its workspace is created from a preset that has a project at `.`, and the workspace-root special case masks the stale root. That is why the regression coverage is a unit test rather than another e2e case.
- The fix is in shared nxls code, so VS Code's tree gets it too. I verified the defect by reading `TreeView.createFolderOrProjectTreeItemFromNode`, but only reproduced and recorded it in IntelliJ — the Kotlin harness does not drive VS Code.
- Rebased onto `97796b87` now that #3215 has landed, so the `nxls-e2e` fixture-install failure that was blocking every nxls-touching PR is gone. The rebase was a clean replay of both commits; the diff against `master` is byte-identical to what was recorded.

## Related Issue(s)

N/A — found while investigating #3193. That report is a different case (`e2es/parent` is two segments deep, so it never reaches the roots set) and both tree renderers already handle it; this is the neighbouring case that is still broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/able-tapir-a8aaa1b5">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->
