### PR TITLE
fix(intellij): reuse the generate dry-run tab when run tabs are pinned

### DIFF
--- a/apps/intellij/AUTOMATION.md
+++ b/apps/intellij/AUTOMATION.md
@@ -243,6 +243,44 @@ and restarting the IDE. The video shows the selected tree row: the folder
 `packages` with no target before the fix, and the project `packages-aggregator`
 with its `hello` target and both nested projects after it.
 
+### Generate UI dry-run tabs (#2054)
+
+`ReproGenerateDryRunTabsKt` enables the platform's advanced setting that pins
+new Run tool window tabs (`start.run.configurations.pinned`), opens **Nx
+Generate (UI)** for a local generator, and changes its `name` field three times.
+Each change triggers a dry run. The scenario asserts that the Run tool window
+holds a single `Nx Generate` tab showing the latest dry run and that nothing was
+written to disk. It restores the setting afterwards. Set
+`NX_AUTOMATION_PINNED_TABS=false` to run the same steps with unpinned tabs.
+
+The generator is chosen through the popup's list and `JBPopup.closeOk`, and the
+field is changed by setting the input's value and dispatching an `input` event
+in the Generate UI webview. Neither step uses native mouse or keyboard input.
+
+Use a fixture named `generate-dry-run-tabs-fixture` with `"analytics": false`
+and a local plugin installed as a dev dependency
+(`npm install -D ./tools/notes-plugin`). Its `package.json` names it
+`@fixture/notes-plugin` and points `generators` at a `note` generator whose
+schema has a required string `name` and whose factory writes
+`notes/<name>.md`:
+
+```js
+module.exports = async function (tree, options) {
+  tree.write(`notes/${options.name}.md`, `# ${options.name}\n`);
+};
+```
+
+```sh
+NX_AUTOMATION_LABEL=issue-2054-repro CI=true \
+  JAVA_TOOL_OPTIONS='-XX:ActiveProcessorCount=4 -Dorg.gradle.workers.max=2 -Dorg.gradle.priority=low' \
+  yarn nx run intellij:runAutomation --batch=false --parallel=2 \
+  --args='--max-workers=2 --priority=low -PautomationMain=dev.nx.console.automation.ReproGenerateDryRunTabsKt'
+```
+
+Rerun with `NX_AUTOMATION_LABEL=issue-2054-fixed` after rebuilding and
+restarting the IDE. The video shows one pinned `Nx Generate` tab per dry run
+before the fix, and a single tab replaced by each dry run after it.
+
 References:
 
 - [JetBrains Driver SDK](https://github.com/JetBrains/intellij-community/blob/master/tools/intellij.tools.ide.starter.driver/README.md)

--- a/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproGenerateDryRunTabs.kt
+++ b/apps/intellij/src/automation/kotlin/dev/nx/console/automation/ReproGenerateDryRunTabs.kt
@@ -1,0 +1,247 @@
+package dev.nx.console.automation
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.client.Remote
+import com.intellij.driver.client.service
+import com.intellij.driver.client.utility
+import com.intellij.driver.model.OnDispatcher
+import com.intellij.driver.sdk.AdvancedSettingsRef
+import com.intellij.driver.sdk.Project
+import com.intellij.driver.sdk.closeToolWindow
+import com.intellij.driver.sdk.getOpenProjects
+import com.intellij.driver.sdk.invokeAction
+import com.intellij.driver.sdk.ui.components.common.jcef
+import com.intellij.driver.sdk.ui.components.elements.JListUiComponent
+import com.intellij.driver.sdk.ui.remote.Component
+import com.intellij.driver.sdk.ui.ui
+import com.intellij.driver.sdk.waitForProjectOpen
+import java.awt.event.InputEvent
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@Remote("com.intellij.execution.ui.RunContentManager")
+interface DryRunContentManager {
+    fun getAllDescriptors(): List<DryRunDescriptor>
+}
+
+@Remote("com.intellij.execution.ui.RunContentDescriptor")
+interface DryRunDescriptor {
+    fun getDisplayName(): String
+
+    fun getAttachedContent(): DryRunContent?
+
+    fun getProcessHandler(): DryRunProcessHandler?
+
+    fun getExecutionConsole(): DryRunConsole?
+}
+
+@Remote("com.intellij.ui.content.Content")
+interface DryRunContent {
+    fun isPinned(): Boolean
+
+    fun getManager(): DryRunContentManagerUi?
+}
+
+@Remote("com.intellij.ui.content.ContentManager")
+interface DryRunContentManagerUi {
+    fun removeContent(content: DryRunContent, dispose: Boolean): Boolean
+}
+
+@Remote("com.intellij.execution.process.ProcessHandler")
+interface DryRunProcessHandler {
+    fun isProcessTerminated(): Boolean
+}
+
+@Remote("com.intellij.execution.impl.ConsoleViewImpl")
+interface DryRunConsole {
+    fun flushDeferredText()
+
+    fun getText(): String
+}
+
+@Remote("javax.swing.JList")
+interface DryRunGeneratorList {
+    fun setSelectedIndex(index: Int)
+}
+
+@Remote("com.intellij.openapi.ui.popup.util.PopupUtil")
+interface DryRunPopupUtil {
+    fun getPopupContainerFor(component: Component): DryRunPopup?
+}
+
+@Remote("com.intellij.openapi.ui.popup.JBPopup")
+interface DryRunPopup {
+    fun closeOk(event: InputEvent?)
+}
+
+private const val PINNED_TABS_SETTING = "start.run.configurations.pinned"
+private const val GENERATE_UI_ACTION = "dev.nx.console.generate.actions.NxGenerateUiAction"
+private const val GENERATOR_ROW = "@fixture/notes-plugin - note"
+private const val TAB_NAME = "Nx Generate"
+
+private fun Driver.generatorTabs(project: Project): List<DryRunDescriptor> =
+    withContext(OnDispatcher.EDT) {
+        service<DryRunContentManager>(project).getAllDescriptors().filter {
+            it.getDisplayName() == TAB_NAME
+        }
+    }
+
+private fun Driver.consoleText(descriptor: DryRunDescriptor): String =
+    withContext(OnDispatcher.EDT) {
+        runCatching {
+                val console = descriptor.getExecutionConsole() ?: return@runCatching ""
+                console.flushDeferredText()
+                console.getText()
+            }
+            .getOrDefault("")
+    }
+
+private fun waitUntil(timeout: Duration, message: () -> String, condition: () -> Boolean) {
+    val deadline = System.nanoTime() + timeout.inWholeNanoseconds
+    while (!condition()) {
+        check(System.nanoTime() < deadline, message)
+        Thread.sleep(250)
+    }
+}
+
+private fun Driver.chooseGenerator(frame: Component) {
+    invokeAction(GENERATE_UI_ACTION, component = frame)
+    var items = emptyList<String>()
+    var lastError: Throwable? = null
+    waitUntil(
+        60.seconds,
+        {
+            "The generator popup never listed $GENERATOR_ROW; saw $items; last error: ${lastError?.stackTraceToString()}"
+        },
+    ) {
+        ui.xx("//div[@class='JBList']", JListUiComponent::class.java).list().any { list ->
+            runCatching {
+                    items = list.items
+                    val index = items.indexOfFirst { it.startsWith(GENERATOR_ROW) }
+                    if (index < 0) return@runCatching false
+                    withContext(OnDispatcher.EDT) {
+                        cast(list.component, DryRunGeneratorList::class).setSelectedIndex(index)
+                        checkNotNull(
+                                utility<DryRunPopupUtil>().getPopupContainerFor(list.component)
+                            )
+                            .closeOk(null)
+                    }
+                    true
+                }
+                .onFailure { lastError = it }
+                .getOrDefault(false)
+        }
+    }
+}
+
+private fun Driver.setNoteName(name: String) {
+    val result =
+        ui.jcef()
+            .jcefWorker
+            .callJs(
+                """(() => {
+                  const input = document.getElementById('name-field');
+                  if (!input) return 'missing';
+                  input.focus();
+                  input.value = '$name';
+                  input.dispatchEvent(new Event('input', { bubbles: true }));
+                  return input.value;
+                })()""",
+                5000,
+            )
+    check(result == name) { "Could not type into the Generate UI name field: $result" }
+}
+
+private fun Driver.removeGeneratorTabs(project: Project) {
+    withContext(OnDispatcher.EDT) {
+        service<DryRunContentManager>(project).getAllDescriptors().forEach { descriptor ->
+            if (descriptor.getDisplayName() == TAB_NAME) {
+                descriptor.getAttachedContent()?.let { content ->
+                    content.getManager()?.removeContent(content, true)
+                }
+            }
+        }
+    }
+}
+
+fun main() = withAutomationDriver {
+    waitForProjectOpen(2.minutes)
+    val project = getOpenProjects().single()
+    val workspace = Path.of(project.getBasePath())
+    check(workspace.fileName.toString() == "generate-dry-run-tabs-fixture")
+    val frame = ui.x("//div[@class='IdeFrameImpl']").component
+    withContext(OnDispatcher.EDT) {
+        cast(frame, GraphIdeFrame::class).apply {
+            setExtendedState(0)
+            toFront()
+            getBalloonLayout().closeAll()
+        }
+    }
+    runCatching { invokeAction("CloseAllEditors", component = frame) }
+    runCatching { closeToolWindow("Project") }
+    removeGeneratorTabs(project)
+
+    val settings = utility<AdvancedSettingsRef>()
+    val pinnedBefore = settings.getBoolean(PINNED_TABS_SETTING)
+    val pinned = System.getenv("NX_AUTOMATION_PINNED_TABS")?.toBooleanStrict() ?: true
+    settings.setBoolean(PINNED_TABS_SETTING, pinned)
+    val label = System.getenv("NX_AUTOMATION_LABEL") ?: "issue-2054-repro"
+    val report = StringBuilder()
+    report.appendLine("Issue #2054: Generate UI dry runs and Run tool window tabs")
+    report.appendLine("Advanced setting $PINNED_TABS_SETTING: $pinned (was $pinnedBefore)")
+    report.appendLine("Generator: $GENERATOR_ROW, dry run on change enabled")
+    try {
+        recordIde(label) {
+            chooseGenerator(frame)
+            waitUntil(60.seconds, { "The Generate UI form did not render a name field" }) {
+                runCatching {
+                        ui.jcef()
+                            .jcefWorker
+                            .callJs("String(document.getElementById('name-field') !== null)", 1000)
+                    }
+                    .getOrNull() == "true"
+            }
+            Thread.sleep(2000)
+            val names = listOf("first-note", "second-note", "third-note")
+            names.forEachIndexed { index, name ->
+                setNoteName(name)
+                var tabs = emptyList<DryRunDescriptor>()
+                waitUntil(90.seconds, { "No finished dry run for $name" }) {
+                    tabs = generatorTabs(project)
+                    tabs.any { tab ->
+                        tab.getProcessHandler()?.isProcessTerminated() == true &&
+                            consoleText(tab).contains("notes/$name.md")
+                    }
+                }
+                val pinnedTabs =
+                    withContext(OnDispatcher.EDT) {
+                        tabs.map { it.getAttachedContent()?.isPinned() }
+                    }
+                report.appendLine(
+                    "After dry run ${index + 1} ($name): ${tabs.size} '$TAB_NAME' tab(s), pinned=$pinnedTabs"
+                )
+                Thread.sleep(2500)
+            }
+            val tabs = generatorTabs(project)
+            val latest = tabs.map { consoleText(it) }.filter { it.contains("notes/third-note.md") }
+            report.appendLine("Final '$TAB_NAME' tabs: ${tabs.size}")
+            report.appendLine("Tabs showing the latest dry run: ${latest.size}")
+            report.appendLine("notes/ written to disk: ${workspace.resolve("notes").exists()}")
+            println(report)
+            automationOutput()
+                .resolve("$label-${System.currentTimeMillis()}.txt")
+                .writeText(report.toString())
+            check(!workspace.resolve("notes").exists()) { "A dry run wrote files: $report" }
+            check(latest.size == 1) { "The latest dry run output is not shown: $report" }
+            check(tabs.size == 1) {
+                "Each Generate UI dry run opened a new Run tab instead of reusing one: $report"
+            }
+        }
+    } finally {
+        settings.setBoolean(PINNED_TABS_SETTING, pinnedBefore)
+    }
+}

--- a/apps/intellij/src/main/kotlin/dev/nx/console/generate/run_generator/RunGeneratorManager.kt
+++ b/apps/intellij/src/main/kotlin/dev/nx/console/generate/run_generator/RunGeneratorManager.kt
@@ -4,7 +4,9 @@ import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.filters.TextConsoleBuilderFactory
 import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessListener
+import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.RunContentDescriptor
 import com.intellij.execution.ui.RunContentManager
 import com.intellij.lang.javascript.modules.ConsoleProgress
@@ -25,6 +27,7 @@ class RunGeneratorManager(val project: Project) {
 
     private var queuedGeneratorDefinition: List<String>? = null
     private var runningProcessHandler: KillableColoredProcessHandler? = null
+    private var lastDryRunDescriptor: RunContentDescriptor? = null
 
     fun queueGeneratorToBeRun(generator: String, flags: List<String>, cwd: String? = null) {
         var generatorDefinition: List<String>
@@ -78,20 +81,7 @@ class RunGeneratorManager(val project: Project) {
                         console.attachToProcess(processHandler)
                         ConsoleProgress.install(console, processHandler)
 
-                        val contentDescriptor =
-                            RunContentDescriptor(
-                                console,
-                                processHandler,
-                                console.component,
-                                "Nx Generate",
-                                NxIcons.Action,
-                            )
-
-                        val runContentManager = RunContentManager.getInstance(project)
-                        runContentManager.showRunContent(
-                            DefaultRunExecutor.getRunExecutorInstance(),
-                            contentDescriptor,
-                        )
+                        showRunContent(console, processHandler, definition.isDryRun())
 
                         processHandler.startNotify()
                         this.setProcessHandler(processHandler, definition.isDryRun().not())
@@ -101,6 +91,32 @@ class RunGeneratorManager(val project: Project) {
         } catch (e: Exception) {
             thisLogger().info("Cannot execute command", e)
         }
+    }
+
+    internal fun showRunContent(
+        console: ConsoleView,
+        processHandler: ProcessHandler,
+        dryRun: Boolean,
+    ) {
+        val contentDescriptor =
+            RunContentDescriptor(
+                console,
+                processHandler,
+                console.component,
+                "Nx Generate",
+                NxIcons.Action,
+            )
+
+        // The Run tool window never reuses a pinned tab on its own, and new tabs are pinned when
+        // "start.run.configurations.pinned" is enabled. Passing the previous dry run explicitly
+        // keeps dry runs triggered by form changes in a single tab either way.
+        RunContentManager.getInstance(project)
+            .showRunContent(
+                DefaultRunExecutor.getRunExecutorInstance(),
+                contentDescriptor,
+                lastDryRunDescriptor,
+            )
+        lastDryRunDescriptor = contentDescriptor.takeIf { dryRun }
     }
 
     private fun setProcessHandler(

--- a/apps/intellij/src/test/kotlin/dev/nx/console/generate/run_generator/RunGeneratorManagerTest.kt
+++ b/apps/intellij/src/test/kotlin/dev/nx/console/generate/run_generator/RunGeneratorManagerTest.kt
@@ -1,0 +1,74 @@
+package dev.nx.console.generate.run_generator
+
+import com.intellij.execution.Executor
+import com.intellij.execution.filters.TextConsoleBuilderFactory
+import com.intellij.execution.process.NopProcessHandler
+import com.intellij.execution.ui.RunContentDescriptor
+import com.intellij.execution.ui.RunContentManager
+import com.intellij.openapi.util.Disposer
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.replaceService
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class RunGeneratorManagerTest : BasePlatformTestCase() {
+
+    private class RecordingRunContentManager(delegate: RunContentManager) :
+        RunContentManager by delegate {
+        val reused = mutableMapOf<RunContentDescriptor, RunContentDescriptor?>()
+        var last: RunContentDescriptor? = null
+
+        override fun showRunContent(
+            executor: Executor,
+            descriptor: RunContentDescriptor,
+            contentToReuse: RunContentDescriptor?,
+        ) {
+            reused[descriptor] = contentToReuse
+            last = descriptor
+        }
+    }
+
+    private lateinit var runContentManager: RecordingRunContentManager
+    private lateinit var runGeneratorManager: RunGeneratorManager
+
+    override fun setUp() {
+        super.setUp()
+        runContentManager = RecordingRunContentManager(RunContentManager.getInstance(project))
+        project.replaceService(RunContentManager::class.java, runContentManager, testRootDisposable)
+        runGeneratorManager = RunGeneratorManager(project)
+    }
+
+    private fun show(dryRun: Boolean): RunContentDescriptor {
+        val console = TextConsoleBuilderFactory.getInstance().createBuilder(project).console
+        runGeneratorManager.showRunContent(console, NopProcessHandler(), dryRun)
+        val descriptor = checkNotNull(runContentManager.last)
+        runContentManager.last = null
+        Disposer.register(testRootDisposable, descriptor)
+        return descriptor
+    }
+
+    fun testEachDryRunReusesThePreviousDryRunTab() {
+        val first = show(dryRun = true)
+        val second = show(dryRun = true)
+        val third = show(dryRun = true)
+
+        assertNull(runContentManager.reused[first])
+        assertSame(first, runContentManager.reused[second])
+        assertSame(second, runContentManager.reused[third])
+    }
+
+    fun testGenerateReusesTheDryRunTab() {
+        val dryRun = show(dryRun = true)
+        val generate = show(dryRun = false)
+
+        assertSame(dryRun, runContentManager.reused[generate])
+    }
+
+    fun testDryRunAfterGenerateKeepsTheGenerateTab() {
+        show(dryRun = true)
+        show(dryRun = false)
+        val dryRun = show(dryRun = true)
+
+        assertNull(runContentManager.reused[dryRun])
+    }
+}


### PR DESCRIPTION
Fixes #2054.

## Problem

In JetBrains IDEs, **Nx Generate (UI)** starts a dry run on every form change. When **Settings → Advanced Settings → Run/Debug → Make configurations pinned by default** (`start.run.configurations.pinned`) is enabled, each of those dry runs opened another pinned **Nx Generate** tab in the Run tool window. A commenter on the issue traced the behaviour to that setting.

`RunGeneratorManager` called `RunContentManager.showRunContent(executor, descriptor)` and relied on the platform to reuse the previous tab. The platform only reuses a terminated tab that is **not pinned** (`canReuseContent` in `RunContentManagerImpl`), and every new tab is pinned while that setting is on.

## Fix

Keep the previous dry run's descriptor and pass it as `contentToReuse`. The platform then reuses that tab even when it is pinned, as long as it still exists and its process has finished.

- A dry run replaces the previous dry run's tab.
- **Generate** replaces the last dry run's tab. This matches what already happens with unpinned tabs.
- A dry run after a real generator run opens a new tab, so the output of an actual generation is not replaced.

## Verification

In IntelliJ IDEA Ultimate 2025.3.6.1 (IU-253.33813.55), using the automation harness and a fixture on Nx 23.2.0 with a local `note` generator that supports `--dry-run`. The scenario enables the setting, opens Generate UI, and changes the `name` field three times. Each change triggers a dry run. It asserts on the Run tool window's descriptors, their pinned state, the console text of the latest dry run, and that nothing was written to disk.

| Build | Pinned by default | "Nx Generate" tabs after 3 dry runs | Result |
| --- | --- | --- | --- |
| `master` f1425880 | on | 3, all pinned | FAIL (reproduces #2054) |
| `master` f1425880 (control) | off | 1 | tab reused |
| this branch | on | 1, pinned, shows the latest dry run | PASS |

- The generator is chosen through the popup's `JList` and `JBPopup.closeOk`. The field is changed by setting the input's value and dispatching an `input` event inside the Generate UI webview. No native mouse or keyboard input is used.
- The fixed IDE was rebuilt and restarted, and its sandbox jar was checked for the new `lastDryRunDescriptor` field before the run. The recorded build matches this commit apart from a trailing comma that ktfmt added afterwards.

**Evidence:** [Polygraph session](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/a08eeb72-04b0-4185-b78d-571f255bf535) has `issue-2054-repro.mp4` (master, fails), `issue-2054-fixed.mp4` (this branch, passes), `issue-2054-control-unpinned.mp4` (master with pinning off), final frames of both runs, `issue-2054-verification-report.md`, the fixture (`issue-2054-fixture.tar.gz`), and the scenario logs.

## Tests

- `RunGeneratorManagerTest`: three platform tests for the reuse rules. All three pass, and all three fail when the `contentToReuse` argument is removed.
- `ReproGenerateDryRunTabsKt` automation scenario, documented in `apps/intellij/AUTOMATION.md`.

## Limitations

- The scenario turns the advanced setting on through the `AdvancedSettings` API, not the Settings dialog, and restores it afterwards.
- Only tabs opened by the same Generate UI editor are reused. Each Generate UI editor has its own `RunGeneratorManager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CsCNpRFNTtSuWgiQgjQ9U
