### PR TITLE
feat(vscode): record VS Code automation scenarios against a persistent IDE

### DIFF
--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -2,6 +2,25 @@ name: VS Code E2E
 
 on:
   workflow_dispatch:
+    inputs:
+      extension-version:
+        description: Released Nx Console version to test instead of this revision's build (for example 18.101.1)
+        required: false
+        default: ''
+      label:
+        description: Evidence label (for example issue-1234-repro)
+        required: false
+        default: ci
+      grep:
+        description: Only run scenarios whose title matches this regular expression
+        required: false
+        default: ''
+  pull_request:
+    paths:
+      - 'apps/vscode/**'
+      - 'apps/vscode-e2e/**'
+      - 'libs/vscode/**'
+      - '.github/workflows/vscode-e2e.yml'
 
 permissions:
   contents: read
@@ -14,13 +33,20 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ github.ref == 'refs/heads/master' && secrets.NX_CLOUD_READ_WRITE_TOKEN || secrets.NX_CLOUD_READ_TOKEN }}
 
 jobs:
-  main-linux:
-    name: VS Code E2E
-    runs-on: ubuntu-latest
+  e2e:
+    name: VS Code E2E (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     env:
-      NX_CI_EXECUTION_ENV: 'linux'
+      NX_CI_EXECUTION_ENV: vscode-e2e-${{ matrix.os }}
       NX_VERBOSE_LOGGING: true
-      PLAYWRIGHT_VSCODE_VIDEO: '1'
+      NX_AUTOMATION_LABEL: ${{ inputs.label || 'ci' }}
+      VSCODE_E2E_EXTENSION_VERSION: ${{ inputs.extension-version }}
+      SCENARIO_GREP: ${{ inputs.grep }}
       GIT_AUTHOR_EMAIL: test@test.com
       GIT_AUTHOR_NAME: Test
       GIT_COMMITTER_EMAIL: test@test.com
@@ -54,14 +80,46 @@ jobs:
       - name: Install NPM dependencies
         run: yarn install --immutable
 
-      - name: Run VS Code E2E
-        run: yarn nx run vscode-e2e:e2e
+      - name: Install display and recording dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb ffmpeg
+          yarn playwright install-deps chromium
 
-      - name: Upload VS Code E2E videos
+      - name: Install recording dependencies
+        if: runner.os == 'macOS'
+        run: brew install ffmpeg
+
+      - name: Harness unit tests
+        run: yarn nx run vscode-e2e:test
+
+      - name: Record VS Code scenarios
+        run: yarn nx run vscode-e2e:record ${SCENARIO_GREP:+--grep="$SCENARIO_GREP"}
+
+      - name: Run a scenario against the persistent automation IDE
+        if: inputs.extension-version == ''
+        run: |
+          node --require @swc-node/register apps/vscode-e2e/automation/launch.ts --fixture=demo &
+          launcher=$!
+          for _ in $(seq 1 180); do
+            [ -f dist/apps/vscode-e2e/automation-ide/session.json ] && break
+            kill -0 "$launcher" || exit 1
+            sleep 1
+          done
+          yarn nx run vscode-e2e:automation -- inspect
+          VSCODE_E2E_ATTACH=1 NX_AUTOMATION_LABEL=ci-attached yarn nx run vscode-e2e:record --grep="smoke"
+          kill "$launcher"
+          wait "$launcher"
+          test ! -f dist/apps/vscode-e2e/automation-ide/session.json
+
+      - name: Upload VS Code automation evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: vscode-e2e-videos-${{ github.run_id }}-${{ github.run_attempt }}
-          path: dist/apps/vscode-e2e/videos
-          if-no-files-found: warn
+          name: vscode-e2e-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            dist/apps/vscode-e2e/automation
+            dist/apps/vscode-e2e/automation-ide/ide.log
+          if-no-files-found: error
           retention-days: 14

--- a/apps/vscode-e2e/AUTOMATION.md
+++ b/apps/vscode-e2e/AUTOMATION.md
@@ -1,0 +1,199 @@
+# VS Code automation
+
+Run Nx Console in a real VS Code window, drive its UI with Playwright over the
+Chrome DevTools Protocol, and run code in its extension host. Scenarios are
+Playwright tests under `specs`. Every run writes labeled evidence: a video,
+screenshots, a trace, VS Code logs and a PASS/FAIL result. The automation
+sources live in `apps/vscode-e2e` and are never packaged in the extension.
+
+## Launch the IDE
+
+Install the workspace dependencies with `yarn install --immutable`, then run:
+
+```sh
+yarn nx run vscode-e2e:automation-ide --fixture=nested-projects
+```
+
+This builds the extension and the test runner, downloads VS Code 1.137.0 into
+`.vscode-test`, creates the fixture workspace and opens it. Keep this command
+running while you inspect the IDE or run scenarios from another terminal. Stop
+it with Ctrl+C or by closing the VS Code window; both also stop the fixture's Nx
+daemon.
+
+- `--fixture=<name>` selects a workspace from `fixtures/workspaces.ts`
+  (default `demo`). The fixture is recreated on every launch.
+- `--workspace=/absolute/path` opens an existing workspace instead. It needs its
+  own lockfile and installed dependencies: Nx Console starts the workspace's Nx
+  daemon.
+
+VS Code settings, extensions and logs live in a per-worktree directory under
+`/tmp/nxc-ide-<hash>` (the OS temp directory on Linux). Its path stays short
+because VS Code creates IPC sockets there. The launcher writes
+`dist/apps/vscode-e2e/automation-ide/session.json` and `ide.log`.
+
+The IDE does not inherit `NX_*`, `CI` or coding-agent environment variables
+from the terminal, and runs with `NX_NO_CLOUD=true` unless its fixture says
+otherwise. On Linux it runs on its own Xvfb display.
+
+The DevTools endpoint is bound to loopback and lets local processes control the
+IDE. The extension-host server additionally requires the per-launch token
+stored in `session.json`.
+
+## Inspect and control the running IDE
+
+```sh
+yarn nx run vscode-e2e:automation
+```
+
+The default `inspect` command writes `inspection.txt`, `ui.html` and
+`screenshot.png` under `dist/apps/vscode-e2e/automation/inspect-<time>`.
+`inspection.txt` lists the VS Code and Nx Console versions, the opened
+workspace, the Projects view style, the rendered sidebar rows with their
+expanded/collapsed state, and visible notifications. Use `ui.html` to find
+selectors.
+
+```sh
+yarn nx run vscode-e2e:automation -- capture
+yarn nx run vscode-e2e:automation -- eval "(vscode) => vscode.workspace.getConfiguration('nxConsole').get('projectViewingStyle')"
+yarn nx run vscode-e2e:automation -- run path/to/script.ts
+```
+
+`eval` runs a function in the extension host with the `vscode` API and prints
+its JSON result. The function is sent as source text, so it cannot use
+variables from the calling module. `run` loads a TypeScript module whose
+default export receives `{ page, evaluator, nxConsole, session, outputDir }`:
+
+```ts
+import type { AutomationScriptContext } from '../automation/cli';
+
+export default async ({ nxConsole, outputDir }: AutomationScriptContext) => {
+  await nxConsole.openNxConsoleSidebar();
+  await nxConsole.expandTreeRow('e2es');
+  await nxConsole.page.screenshot({ path: `${outputDir}/tree.png` });
+};
+```
+
+Nx targets here are uncached: each invocation interacts with the live IDE.
+Running a command again does not reload extension code or reset the workspace;
+restart the launcher after rebuilding the extension.
+
+## Write a scenario
+
+Add a `*.test.ts` file under `specs` and import `test` and `expect` from
+`../base-test`. The `vscode` fixture provides `page`, `nxConsole` (page
+objects), `evaluator` (extension-host calls), `workspacePath`, `extension` (the
+Nx Console build under test), `label`, and `proof()`.
+
+```ts
+import { expect, test } from '../base-test';
+
+test.use({ vscodeOptions: { fixture: 'nested-projects' } });
+
+test('parent projects expand to their nested projects', async ({ vscode }) => {
+  const proof = vscode.proof(['My scenario', '']);
+  await vscode.nxConsole.openNxConsoleSidebar();
+  await vscode.nxConsole.expandTreeRow('e2es');
+  const expandable = await vscode.nxConsole.isTreeRowExpandable('parent-e2e');
+  await proof.show(`parent-e2e expandable: ${expandable}`);
+  expect.soft(expandable).toBe(true);
+});
+```
+
+Add fixtures to `fixtures/workspaces.ts` with `writeWorkspace`. Fixtures link
+the repository's `node_modules`, set `"analytics": false`, and commit their
+files to their own Git repository. A fixture can also set VS Code settings and
+environment variables for the IDE. Values that exist only at run time, such as
+a mock server URL, are passed through `vscodeOptions.fixtureContext`; those
+scenarios always launch their own IDE.
+
+`proof()` opens a text file next to the UI and appends one line per measured
+fact, so a video shows why each assertion passed or failed. Prefer
+`expect.soft` for the facts under test so a reproduction run still reaches
+every step, and condition-based waits over sleeps. A delivered click alone does
+not establish success.
+
+While writing a scenario, run it against the running automation IDE instead of
+launching VS Code each time:
+
+```sh
+VSCODE_E2E_ATTACH=1 yarn nx run vscode-e2e:e2e -- nested-projects
+```
+
+The IDE must have opened the fixture the scenario declares. Attached runs reuse
+the window and its state. Without `VSCODE_E2E_ATTACH`, each scenario launches a
+fresh VS Code with a fresh fixture and closes it afterwards.
+
+## Record reproduction and verification videos
+
+Install `ffmpeg` on the machine running the scenarios, then:
+
+```sh
+NX_AUTOMATION_LABEL=issue-3193-repro yarn nx run vscode-e2e:record -- nested-projects
+```
+
+Each run writes to `dist/apps/vscode-e2e/automation/<label>-<time>-<id>`:
+`results.json`, `junit.xml`, an HTML `report`, `setup.json`, and a directory
+per scenario under `tests` containing:
+
+- `<label>.mp4`: the VS Code window, recorded through the DevTools screencast.
+  Frames arrive when the UI changes, and the video keeps real time.
+- `proof.txt`, `final.png`, `ui.html` and `trace.zip` (open it with
+  `npx playwright show-trace`).
+- `ide.log` (VS Code's output) and `logs` (VS Code and extension logs,
+  including Nx Console's).
+- `metadata.json`: the Git revision, a hash of uncommitted changes, the Nx
+  Console source, version and bundle hash, the VS Code version and the fixture.
+- `result.json` and `result.txt`: PASS, or the assertion and cleanup failures.
+
+The evidence is saved when an assertion or VS Code startup fails.
+`VSCODE_E2E_ATTACH=1` also works with `record`.
+
+For a bug fix, run the scenario with `NX_AUTOMATION_LABEL=issue-<number>-repro`
+before changing the code, keep the failing result, fix the bug, and rerun the
+same scenario with `NX_AUTOMATION_LABEL=issue-<number>-fixed`. The `record` and
+`e2e` targets rebuild the extension first. A successful investigation run is not
+evidence of a reproduced bug.
+
+### Test a released Nx Console or another build
+
+```sh
+VSCODE_E2E_EXTENSION_VERSION=18.101.1 NX_AUTOMATION_LABEL=issue-3193-18.101.1 \
+  yarn nx run vscode-e2e:record -- nested-projects
+```
+
+`VSCODE_E2E_EXTENSION_VERSION` downloads that release from the Visual Studio
+Marketplace into `dist/apps/vscode-e2e/extensions`. `VSCODE_E2E_EXTENSION_PATH`
+accepts a `.vsix` file or an unpacked extension directory. Both work with
+`automation-ide` too. VSIX files are extracted with `unzip`, so these options
+need macOS or Linux. `VSCODE_E2E_VERSION` selects another VS Code release.
+
+## CI
+
+`.github/workflows/vscode-e2e.yml` runs on pull requests that change VS Code
+sources, on Ubuntu and macOS. It runs the harness unit tests, records every
+scenario, then launches a persistent automation IDE, inspects it and runs the
+smoke scenario against it. Evidence is uploaded as the
+`vscode-e2e-<os>-<run id>-<attempt>` artifact. A manual run accepts an Nx
+Console `extension-version`, an evidence `label` and a `grep` pattern.
+
+## Scenarios
+
+### Smoke
+
+`specs/smoke.test.ts` opens the `demo` fixture, checks that Nx Console activates
+and registers its commands, and expands the `demo` project in the Projects view.
+
+### Nested projects in the Projects tree (#3193)
+
+`specs/nested-projects-tree.test.ts` uses the `nested-projects` fixture:
+`e2es/parent` (`parent-e2e`, no targets) with two nested projects,
+`e2es/parent-with-target` (`parent-with-target-e2e`, an `e2e` target) with one,
+and ten libraries so the `automatic` Projects view style resolves to the folder
+tree. It checks that `nx show projects` lists every nested project, expands
+`e2es`, and asserts that each parent can be expanded and shows its nested
+projects.
+
+References:
+
+- [Playwright `connectOverCDP`](https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp)
+- [Testing VS Code extensions](https://code.visualstudio.com/api/working-with-extensions/testing-extension)

--- a/apps/vscode-e2e/automation/cli.ts
+++ b/apps/vscode-e2e/automation/cli.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { workspaceRoot } from 'nx/src/devkit-exports';
+import {
+  connectIde,
+  readSession,
+  type ConnectedIde,
+  type IdeSession,
+} from '../fixtures/ide';
+import { EXTENSION_ID } from '../fixtures/vscode-e2e-runtime';
+
+export interface AutomationScriptContext extends ConnectedIde {
+  session: IdeSession;
+  outputDir: string;
+}
+
+const usage = `Usage: yarn nx run vscode-e2e:automation -- <command>
+
+  inspect               Save inspection.txt, ui.html and screenshot.png (default)
+  capture               Save a screenshot
+  eval "<function>"     Run (vscode) => ... in the extension host and print the result
+  run <script.ts>       Run a module whose default export receives { page, evaluator, nxConsole, session, outputDir }`;
+
+async function inspect(
+  ide: ConnectedIde,
+  session: IdeSession,
+  outputDir: string,
+) {
+  const host = await ide.evaluator.evaluate((vscode, id: string) => {
+    const extension = vscode.extensions.getExtension(id);
+    return {
+      vscodeVersion: vscode.version,
+      extensionVersion: extension?.packageJSON.version as string | undefined,
+      extensionActive: extension?.isActive ?? false,
+      workspaceFolders: (vscode.workspace.workspaceFolders ?? []).map(
+        (folder) => folder.uri.fsPath,
+      ),
+      activeEditor: vscode.window.activeTextEditor?.document.uri.fsPath,
+      projectViewingStyle: vscode.workspace
+        .getConfiguration('nxConsole')
+        .get<string>('projectViewingStyle'),
+    };
+  }, EXTENSION_ID);
+  const ui = await ide.page.evaluate(() => ({
+    title: document.title,
+    sidebarRows: Array.from(
+      document.querySelectorAll('.sidebar .monaco-list-row'),
+    ).map((row) => {
+      const depth = Number(row.getAttribute('aria-level') ?? '1') - 1;
+      const expanded = row.getAttribute('aria-expanded');
+      const state =
+        expanded === null
+          ? ''
+          : expanded === 'true'
+            ? ' [expanded]'
+            : ' [collapsed]';
+      return `${'  '.repeat(depth)}${row.getAttribute('aria-label')}${state}`;
+    }),
+    notifications: Array.from(
+      document.querySelectorAll('.notification-list-item-message'),
+    ).map((message) => message.textContent?.trim() ?? ''),
+  }));
+
+  const lines = [
+    `Window: ${ui.title}`,
+    `VS Code: ${host.vscodeVersion}`,
+    `Nx Console: ${host.extensionVersion} (${host.extensionActive ? 'active' : 'inactive'}, ${session.extension.source})`,
+    `Workspace: ${host.workspaceFolders.join(', ')}${session.fixture ? ` (fixture "${session.fixture}")` : ''}`,
+    `Projects view style: ${host.projectViewingStyle}`,
+    `Active editor: ${host.activeEditor ?? 'none'}`,
+    '',
+    'Sidebar rows (rendered):',
+    ...ui.sidebarRows.map((row) => `  ${row}`),
+    '',
+    'Notifications:',
+    ...(ui.notifications.length
+      ? ui.notifications.map((message) => `  ${message}`)
+      : ['  none']),
+  ];
+  writeFileSync(join(outputDir, 'inspection.txt'), `${lines.join('\n')}\n`);
+  writeFileSync(join(outputDir, 'ui.html'), await ide.page.content());
+  await ide.page.screenshot({ path: join(outputDir, 'screenshot.png') });
+  console.log(lines.join('\n'));
+  console.log(
+    `\nSaved inspection.txt, ui.html and screenshot.png in ${outputDir}`,
+  );
+}
+
+async function main() {
+  const [command = 'inspect', ...rest] = process.argv.slice(2);
+  if (command === 'help' || command === '--help') {
+    console.log(usage);
+    return;
+  }
+  const session = readSession();
+  if (!session) {
+    throw new Error(
+      'No automation IDE is running for this worktree. Start one with yarn nx run vscode-e2e:automation-ide.',
+    );
+  }
+  const outputDir = join(
+    workspaceRoot,
+    'dist/apps/vscode-e2e/automation',
+    `${command}-${new Date().toISOString().replace(/[:.]/g, '-')}`,
+  );
+  const ide = await connectIde(session);
+  try {
+    switch (command) {
+      case 'inspect':
+        mkdirSync(outputDir, { recursive: true });
+        await inspect(ide, session, outputDir);
+        break;
+      case 'capture': {
+        mkdirSync(outputDir, { recursive: true });
+        const path = join(outputDir, 'screenshot.png');
+        await ide.page.screenshot({ path });
+        console.log(path);
+        break;
+      }
+      case 'eval': {
+        const source = rest.join(' ');
+        if (!source) throw new Error(usage);
+        // The evaluator serializes functions to source text, so a source string is sent unchanged.
+        const result = await ide.evaluator.evaluate(
+          source as unknown as () => unknown,
+        );
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+      case 'run': {
+        if (!rest[0]) throw new Error(usage);
+        mkdirSync(outputDir, { recursive: true });
+        const module = require(resolve(rest[0]));
+        const script = (module.default ?? module) as (
+          context: AutomationScriptContext,
+        ) => unknown;
+        const result = await script({ ...ide, session, outputDir });
+        if (result !== undefined) console.log(JSON.stringify(result, null, 2));
+        console.log(`Output directory: ${outputDir}`);
+        break;
+      }
+      default:
+        throw new Error(`Unknown command "${command}".\n\n${usage}`);
+    }
+  } finally {
+    await ide.disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/vscode-e2e/automation/launch.ts
+++ b/apps/vscode-e2e/automation/launch.ts
@@ -1,0 +1,113 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import { resolveExtension } from '../fixtures/extension';
+import {
+  AUTOMATION_IDE_DIR,
+  RUNNER_PATH,
+  SESSION_FILE,
+  connectIde,
+  getPersistentSandboxDir,
+  launchIde,
+  prepareVSCode,
+  readSession,
+  writeSession,
+} from '../fixtures/ide';
+import { workspaceFixtures } from '../fixtures/workspaces';
+
+function readOption(args: string[], name: string): string | undefined {
+  const index = args.findIndex(
+    (arg) => arg === `--${name}` || arg.startsWith(`--${name}=`),
+  );
+  if (index === -1) return undefined;
+  const arg = args[index];
+  return arg.includes('=') ? arg.slice(arg.indexOf('=') + 1) : args[index + 1];
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const workspace = readOption(args, 'workspace');
+  const fixture = workspace
+    ? undefined
+    : (readOption(args, 'fixture') ?? 'demo');
+  if (fixture && !workspaceFixtures[fixture]) {
+    throw new Error(
+      `Unknown fixture "${fixture}". Available: ${Object.keys(workspaceFixtures).join(', ')}`,
+    );
+  }
+  const running = readSession();
+  if (running) {
+    throw new Error(
+      `An automation IDE is already running for this worktree (pid ${running.pid}). Close it first.`,
+    );
+  }
+  if (!existsSync(RUNNER_PATH)) {
+    throw new Error(
+      `Missing ${RUNNER_PATH}. Start the IDE through yarn nx run vscode-e2e:automation-ide.`,
+    );
+  }
+
+  mkdirSync(AUTOMATION_IDE_DIR, { recursive: true });
+  const logFile = join(AUTOMATION_IDE_DIR, 'ide.log');
+  writeFileSync(logFile, '');
+  const log = (text: string) =>
+    appendFileSync(logFile, text.endsWith('\n') ? text : `${text}\n`);
+
+  const { executable, vscodeVersion } = await prepareVSCode();
+  const extension = await resolveExtension();
+  const ide = await launchIde({
+    sandboxDir: getPersistentSandboxDir(),
+    executable,
+    vscodeVersion,
+    extension,
+    fixture,
+    workspacePath: workspace ? resolve(workspace) : undefined,
+    log,
+  });
+
+  let stopping: Promise<void> | undefined;
+  const shutdown = (code: number) => {
+    stopping ??= (async () => {
+      rmSync(SESSION_FILE, { force: true });
+      for (const error of await ide.stop()) console.error(error);
+      process.exit(code);
+    })();
+    return stopping;
+  };
+  process.on('SIGINT', () => shutdown(0));
+  process.on('SIGTERM', () => shutdown(0));
+  ide.process.once('exit', () => shutdown(0));
+
+  try {
+    const connected = await connectIde(ide.session);
+    await connected.disconnect();
+  } catch (error) {
+    console.error(error);
+    await shutdown(1);
+    return;
+  }
+  writeSession(ide.session);
+
+  console.log(
+    [
+      `VS Code ${vscodeVersion} automation IDE is running (pid ${ide.session.pid}).`,
+      `Nx Console: ${extension.version} (${extension.source}) from ${extension.path}`,
+      `Workspace: ${ide.session.workspacePath}${fixture ? ` (fixture "${fixture}")` : ''}`,
+      `Log: ${logFile}`,
+      '',
+      'Inspect it:              yarn nx run vscode-e2e:automation',
+      'Run a scenario on it:    VSCODE_E2E_ATTACH=1 yarn nx run vscode-e2e:e2e -- <spec file filter>',
+      'Stop it:                 Ctrl+C here, or close the VS Code window.',
+    ].join('\n'),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/vscode-e2e/base-test.ts
+++ b/apps/vscode-e2e/base-test.ts
@@ -1,246 +1,327 @@
-import { test as base, type Page, _electron } from '@playwright/test';
-import { downloadAndUnzipVSCode } from '@vscode/test-electron';
-import { ChildProcess, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { test as base, type Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  appendFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { workspaceRoot } from 'nx/src/devkit-exports';
+import type { ExtensionInfo } from './fixtures/extension';
 import {
-  newWorkspace,
-  simpleReactWorkspaceOptions,
-  e2eCwd,
-  uniq,
-  cleanupNxWorkspace,
-} from '@nx-console/shared-e2e-utils';
-import {
-  VSCodeEvaluator,
-  cleanupMarkerFile,
-} from './fixtures/vscode-evaluator';
-import { getMarkerId, getWorkerDisplay } from './fixtures/vscode-e2e-runtime';
+  connectIde,
+  createSandboxDir,
+  launchIde,
+  readSession,
+  type ConnectedIde,
+  type IdeSession,
+  type LaunchedIde,
+} from './fixtures/ide';
+import { ProofLog } from './fixtures/proof';
+import { ScreencastRecorder } from './fixtures/screencast';
+import { isEnabled, validateLabel } from './fixtures/vscode-e2e-runtime';
+import type { VSCodeEvaluator } from './fixtures/vscode-evaluator';
+import type { FixtureContext } from './fixtures/workspaces';
 import { NxConsolePage } from './page-objects/nx-console-page';
 
 export interface LaunchOptions {
-  vscodeVersion?: string;
+  /** A fixture from fixtures/workspaces.ts; defaults to `demo`. */
+  fixture?: string;
+  /** Values the fixture needs at creation time. Scenarios that set this always launch their own IDE. */
+  fixtureContext?: FixtureContext;
   userSettings?: Record<string, unknown>;
-  workspacePath?: string;
 }
 
-const RECORD_VSCODE_VIDEO =
-  process.env.PLAYWRIGHT_VSCODE_VIDEO === '1' ||
-  process.env.PLAYWRIGHT_VSCODE_VIDEO === 'true';
-
-const DEFAULT_SETTINGS: Record<string, unknown> = {
-  // Disable VS Code noise
-  'telemetry.telemetryLevel': 'off',
-  'update.mode': 'none',
-  'extensions.autoUpdate': false,
-  'workbench.tips.enabled': false,
-  'workbench.startupEditor': 'none',
-  'workbench.enableExperiments': false,
-  'security.workspace.trust.enabled': false,
-  'window.dialogStyle': 'custom',
-  'window.titleBarStyle': 'custom',
-  // Git must remain enabled — Nx Console depends on the Git extension API
-  'git.autofetch': false,
-};
-
-function ensureXvfb(workerIndex: number): {
-  display?: string;
-  process?: ChildProcess;
-} {
-  if (process.platform !== 'linux' || process.env.DISPLAY) {
-    return {};
-  }
-
-  const display = getWorkerDisplay(workerIndex);
-  const xvfbProcess = spawn('Xvfb', [display, '-screen', '0', '1920x1080x24'], {
-    stdio: 'ignore',
-    detached: true,
-  });
-  xvfbProcess.unref();
-
-  return { display, process: xvfbProcess };
+export interface VSCodeSession {
+  page: Page;
+  nxConsole: NxConsolePage;
+  evaluator: VSCodeEvaluator;
+  workspacePath: string;
+  extension: ExtensionInfo;
+  /** Which Nx Console build is under test, for proof headings. */
+  build: string;
+  label: string;
+  /** Creates the editor that shows a scenario's measured results in its recording. */
+  proof(heading: string[]): ProofLog;
 }
 
-function getVideoRecordingOptions(
-  workerIndex: number,
-  workspaceName: string,
-): {
-  recordVideo?: {
-    dir: string;
-    size: {
-      width: number;
-      height: number;
-    };
-  };
-  savedVideoPath?: string;
-} {
-  if (!RECORD_VSCODE_VIDEO) {
-    return {};
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set. Run scenarios through yarn nx run vscode-e2e:e2e so global setup can prepare VS Code.`,
+    );
   }
+  return value;
+}
 
-  const videoDir = join(
-    workspaceRoot,
-    'dist',
-    'apps',
-    'vscode-e2e',
-    'videos',
-    `worker-${workerIndex}`,
-  );
-  mkdirSync(videoDir, { recursive: true });
-
+function sourceState() {
+  const git = (args: string[]) =>
+    execFileSync('git', args, {
+      cwd: workspaceRoot,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
   return {
-    recordVideo: {
-      dir: videoDir,
-      size: { width: 1920, height: 1080 },
-    },
-    savedVideoPath: join(videoDir, `${workspaceName}.webm`),
+    revision: git(['rev-parse', 'HEAD']).trim(),
+    sourceDirty: git(['status', '--porcelain']).trim().length > 0,
+    sourceDiffSha256: createHash('sha256')
+      .update(git(['diff', 'HEAD']))
+      .digest('hex'),
   };
 }
 
-export const test = base.extend<
-  { nxConsole: NxConsolePage },
-  {
-    vscodeVersion: string;
-    vscode: {
-      page: Page;
-      nxConsole: NxConsolePage;
-      evaluator: VSCodeEvaluator;
-    };
+const stripAnsi = (text: string) => text.replace(/\u001b\[[0-9;]*m/g, '');
+
+function describeBuild(
+  extension: ExtensionInfo,
+  source: { revision: string; sourceDirty: boolean },
+): string {
+  if (extension.source === 'workspace') {
+    return `Nx Console built from ${source.revision.slice(0, 8)}${source.sourceDirty ? ' with uncommitted changes' : ''}`;
   }
->({
-  vscodeVersion: ['stable', { option: true, scope: 'worker' }],
+  if (extension.source === 'marketplace') {
+    return `Nx Console ${extension.version} from the Marketplace`;
+  }
+  return `Nx Console ${extension.version} from ${extension.path}`;
+}
 
-  // Worker-scoped: one VS Code instance per worker
+export const test = base.extend<{
+  vscodeOptions: LaunchOptions;
+  vscode: VSCodeSession;
+  nxConsole: NxConsolePage;
+}>({
+  vscodeOptions: [{}, { option: true }],
+
   vscode: [
-    async ({ vscodeVersion }, use, workerInfo) => {
-      const xvfb = ensureXvfb(workerInfo.workerIndex);
-
-      // Download VS Code
-      const vscodePath = await downloadAndUnzipVSCode(vscodeVersion);
-
-      // Create isolated temp directory for this worker
-      const tmpDir = join(
-        process.platform === 'darwin'
-          ? join('/', 'private', tmpdir())
-          : tmpdir(),
-        `vscode-e2e-worker-${workerInfo.workerIndex}`,
-      );
-      if (existsSync(tmpDir)) {
-        rmSync(tmpDir, { recursive: true, force: true });
-      }
-      mkdirSync(tmpDir, { recursive: true });
-
-      const userDataDir = join(tmpDir, 'user-data');
-      const extensionsDir = join(tmpDir, 'extensions');
-      mkdirSync(join(userDataDir, 'User'), { recursive: true });
-      mkdirSync(extensionsDir, { recursive: true });
-
-      // Write default settings
-      writeFileSync(
-        join(userDataDir, 'User', 'settings.json'),
-        JSON.stringify(DEFAULT_SETTINGS, null, 2),
-      );
-
-      // Create a real Nx workspace for this worker
-      const workspaceName = uniq('e2e');
-      newWorkspace({
-        name: workspaceName,
-        options: simpleReactWorkspaceOptions,
-      });
-      const workspacePath = join(e2eCwd, workspaceName);
-      const { recordVideo, savedVideoPath } = getVideoRecordingOptions(
-        workerInfo.workerIndex,
-        workspaceName,
-      );
-
-      // Extension paths
-      const extensionDevelopmentPath = join(
-        workspaceRoot,
-        'dist',
-        'apps',
-        'vscode',
-      );
-      const extensionTestsPath = join(
-        workspaceRoot,
-        'dist',
-        'apps',
-        'vscode-e2e',
-        'runner',
-        'index.js',
-      );
-
-      // Launch VS Code via Playwright's Electron support
-      const markerId = getMarkerId(workerInfo.workerIndex);
-      const env = { ...process.env };
-      cleanupMarkerFile(markerId);
-      // Critical: unset this when running from within VS Code/Claude Code
-      delete env.ELECTRON_RUN_AS_NODE;
-      env.VSCODE_E2E_MARKER_ID = markerId;
-      if (xvfb.display) {
-        env.DISPLAY = xvfb.display;
-      }
-
-      const electronApp = await _electron.launch({
-        executablePath: vscodePath,
-        args: [
-          '--no-sandbox',
-          '--disable-gpu-sandbox',
-          '--disable-updates',
-          '--skip-welcome',
-          '--skip-release-notes',
-          '--disable-workspace-trust',
-          `--extensionDevelopmentPath=${extensionDevelopmentPath}`,
-          `--extensionTestsPath=${extensionTestsPath}`,
-          `--extensions-dir=${extensionsDir}`,
-          `--user-data-dir=${userDataDir}`,
-          workspacePath,
-        ],
-        env,
-        recordVideo,
-        timeout: 60_000,
-      });
-
-      // Connect to the HTTP test server running inside the extension host.
-      // The runner writes its URL to a temp file; we poll for it.
-      const evaluator = new VSCodeEvaluator(markerId);
-      await evaluator.connect();
-
-      // Get the VS Code window
-      const page = await electronApp.firstWindow();
-      const recordedVideo = page.video();
-      await page.setViewportSize({ width: 1920, height: 1080 });
-
-      // Wait for extension to activate
-      await evaluator.evaluate(async (vscode) => {
-        const ext = vscode.extensions.getExtension('nrwl.angular-console');
-        if (ext && !ext.isActive) {
-          await ext.activate();
+    async ({ vscodeOptions }, use, testInfo) => {
+      const outputDir = testInfo.outputPath();
+      mkdirSync(outputDir, { recursive: true });
+      const log = (text: string) =>
+        appendFileSync(
+          join(outputDir, 'ide.log'),
+          text.endsWith('\n') ? text : `${text}\n`,
+        );
+      const label = validateLabel(process.env.NX_AUTOMATION_LABEL || 'run');
+      const record = isEnabled(process.env.PLAYWRIGHT_VSCODE_VIDEO);
+      const attach = isEnabled(process.env.VSCODE_E2E_ATTACH);
+      const fixture = vscodeOptions.fixture ?? 'demo';
+      const cleanupErrors: string[] = [];
+      const attempt = async (name: string, action: () => unknown) => {
+        try {
+          await action();
+        } catch (error) {
+          cleanupErrors.push(`${name}: ${error}`);
+          log(`${name}: ${error}`);
         }
-      });
+      };
+      const source = sourceState();
+      const metadata: Record<string, unknown> = {
+        label,
+        scenario: testInfo.titlePath.slice(1).join(' › '),
+        mode: attach ? 'attach' : 'launch',
+        fixture,
+        platform: `${process.platform}-${process.arch}`,
+        ...source,
+        startedAt: new Date().toISOString(),
+      };
 
-      const nxConsole = new NxConsolePage(page, evaluator);
+      let setupError: unknown;
+      let launched: LaunchedIde | undefined;
+      let sandboxDir: string | undefined;
+      let session: IdeSession | undefined;
+      let ide: ConnectedIde | undefined;
+      let tracing = false;
+      let recorder: ScreencastRecorder | undefined;
 
-      await use({ page, nxConsole, evaluator });
+      try {
+        if (attach) {
+          session = readSession();
+          if (!session) {
+            throw new Error(
+              'No automation IDE is running for this worktree. Start one with yarn nx run vscode-e2e:automation-ide.',
+            );
+          }
+          if (vscodeOptions.fixtureContext) {
+            throw new Error(
+              `"${testInfo.title}" launches its own IDE. Run it without VSCODE_E2E_ATTACH.`,
+            );
+          }
+          if (session.fixture !== fixture) {
+            throw new Error(
+              `The automation IDE opened ${session.fixture ? `fixture "${session.fixture}"` : session.workspacePath}, but "${testInfo.title}" needs fixture "${fixture}". Relaunch it with --fixture=${fixture}.`,
+            );
+          }
+        } else {
+          sandboxDir = createSandboxDir();
+          launched = await launchIde({
+            sandboxDir,
+            log,
+            fixture,
+            fixtureContext: vscodeOptions.fixtureContext,
+            userSettings: vscodeOptions.userSettings,
+            executable: requiredEnv('VSCODE_E2E_BINARY_PATH'),
+            vscodeVersion: requiredEnv('VSCODE_E2E_VSCODE_VERSION'),
+            extension: JSON.parse(requiredEnv('VSCODE_E2E_EXTENSION_INFO')),
+          });
+          session = launched.session;
+        }
+        Object.assign(metadata, {
+          extension: session.extension,
+          vscodeVersion: session.vscodeVersion,
+          executable: session.executable,
+          workspacePath: session.workspacePath,
+        });
+        writeFileSync(
+          join(outputDir, 'metadata.json'),
+          JSON.stringify(metadata, null, 2),
+        );
 
-      // Cleanup
-      evaluator.close();
-      await electronApp.close();
-      if (recordedVideo && savedVideoPath) {
-        await recordedVideo.saveAs(savedVideoPath);
-        await recordedVideo.delete();
-      }
-      await cleanupNxWorkspace(workspacePath);
-      rmSync(tmpDir, { recursive: true, force: true });
+        ide = await connectIde(session);
+        if (!attach || record) {
+          await ide.page
+            .setViewportSize({ width: 1920, height: 1080 })
+            .catch((error) => log(`set viewport: ${error}`));
+        }
+        await ide.page
+          .context()
+          .tracing.start({ screenshots: true, snapshots: true })
+          .then(
+            () => (tracing = true),
+            (error) => log(`start trace: ${error}`),
+          );
+        if (record) {
+          recorder = await ScreencastRecorder.start(
+            ide.page,
+            join(outputDir, 'frames'),
+          );
+        }
 
-      if (xvfb.process) {
-        xvfb.process.kill();
+        const connected = ide;
+        const connectedSession = session;
+        const pauseMs = Number(
+          process.env.VSCODE_E2E_PROOF_PAUSE_MS ?? (record ? 1500 : 0),
+        );
+        await use({
+          page: connected.page,
+          nxConsole: connected.nxConsole,
+          evaluator: connected.evaluator,
+          workspacePath: connectedSession.workspacePath,
+          extension: connectedSession.extension,
+          build: describeBuild(connectedSession.extension, source),
+          label,
+          proof: (heading) =>
+            new ProofLog(
+              connected.evaluator,
+              join(outputDir, 'proof.txt'),
+              heading,
+              pauseMs,
+            ),
+        });
+      } catch (error) {
+        setupError = error;
+        log(String((error as Error)?.stack ?? error));
+        throw error;
+      } finally {
+        if (recorder) {
+          // Hold the final state so the end of the video is readable.
+          await new Promise((resolve) => setTimeout(resolve, 1500));
+        }
+        const page = ide?.page;
+        if (page && !page.isClosed()) {
+          await attempt('screenshot', () =>
+            page.screenshot({
+              path: join(outputDir, 'final.png'),
+              timeout: 10_000,
+            }),
+          );
+          await attempt('DOM snapshot', async () =>
+            writeFileSync(join(outputDir, 'ui.html'), await page.content()),
+          );
+        }
+        if (recorder) {
+          const activeRecorder = recorder;
+          await attempt('save video', () =>
+            activeRecorder.stop(join(outputDir, `${label}.mp4`)),
+          );
+        }
+        if (page && tracing) {
+          await attempt('trace', () =>
+            page.context().tracing.stop({ path: join(outputDir, 'trace.zip') }),
+          );
+        }
+        if (ide) {
+          const connected = ide;
+          await attempt('disconnect', () => connected.disconnect());
+        }
+        if (launched) {
+          cleanupErrors.push(...(await launched.stop()));
+          const logs = join(launched.session.userDataDir, 'logs');
+          await attempt('copy VS Code logs', () => {
+            if (existsSync(logs)) {
+              cpSync(logs, join(outputDir, 'logs'), { recursive: true });
+            }
+          });
+        }
+        if (sandboxDir) {
+          const dir = sandboxDir;
+          await attempt('remove sandbox', () =>
+            rmSync(dir, { recursive: true, force: true }),
+          );
+        }
+
+        const errors = [
+          ...testInfo.errors.map((error) =>
+            stripAnsi(error.message ?? String(error.value)),
+          ),
+          ...(setupError ? [String(setupError)] : []),
+        ];
+        const status =
+          setupError || cleanupErrors.length ? 'failed' : testInfo.status;
+        writeFileSync(
+          join(outputDir, 'result.json'),
+          JSON.stringify(
+            {
+              ...metadata,
+              status,
+              errors,
+              cleanupErrors,
+              finishedAt: new Date().toISOString(),
+            },
+            null,
+            2,
+          ),
+        );
+        writeFileSync(
+          join(outputDir, 'result.txt'),
+          status === 'passed'
+            ? 'PASS\n'
+            : `FAIL\n\n${[...errors, ...cleanupErrors].join('\n\n')}\n`,
+        );
+        for (const [name, contentType] of [
+          [`${label}.mp4`, 'video/mp4'],
+          ['final.png', 'image/png'],
+          ['proof.txt', 'text/plain'],
+          ['result.txt', 'text/plain'],
+          ['trace.zip', 'application/zip'],
+        ]) {
+          const path = join(outputDir, name);
+          if (existsSync(path)) {
+            await testInfo.attach(name, { path, contentType });
+          }
+        }
+        if (cleanupErrors.length && !setupError) {
+          throw new Error(cleanupErrors.join('\n'));
+        }
       }
     },
-    { scope: 'worker', timeout: 180_000 },
+    { timeout: 300_000 },
   ],
 
-  // Test-scoped: exposes the NxConsolePage for each test
   nxConsole: async ({ vscode }, use) => {
     await use(vscode.nxConsole);
   },

--- a/apps/vscode-e2e/fixtures/display.ts
+++ b/apps/vscode-e2e/fixtures/display.ts
@@ -1,0 +1,47 @@
+import { spawn } from 'node:child_process';
+import type { Readable } from 'node:stream';
+
+export async function startDisplay(
+  log: (text: string) => void,
+): Promise<{ display?: string; close: () => void }> {
+  if (process.platform !== 'linux') return { close() {} };
+  const child = spawn(
+    'Xvfb',
+    ['-displayfd', '3', '-screen', '0', '1920x1080x24', '-nolisten', 'tcp'],
+    {
+      stdio: ['ignore', 'ignore', 'pipe', 'pipe'],
+    },
+  );
+  child.stderr?.on('data', (data) => log(String(data)));
+  const close = () => {
+    child.kill('SIGTERM');
+  };
+  try {
+    const display = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        close();
+        reject(new Error('Xvfb did not become ready in 15 seconds'));
+      }, 15_000);
+      let output = '';
+      (child.stdio[3] as Readable).on('data', (data) => {
+        output += data;
+        if (output.includes('\n')) {
+          clearTimeout(timer);
+          resolve(`:${output.trim()}`);
+        }
+      });
+      child.once('error', (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.once('exit', (code) => {
+        clearTimeout(timer);
+        reject(new Error(`Xvfb exited before startup (${code})`));
+      });
+    });
+    return { display, close };
+  } catch (error) {
+    close();
+    throw error;
+  }
+}

--- a/apps/vscode-e2e/fixtures/extension.ts
+++ b/apps/vscode-e2e/fixtures/extension.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import { gunzipSync } from 'node:zlib';
+import { workspaceRoot } from 'nx/src/devkit-exports';
+import { getMarketplaceVsixUrl } from './vscode-e2e-runtime';
+
+export interface ExtensionInfo {
+  path: string;
+  source: 'workspace' | 'directory' | 'vsix' | 'marketplace';
+  version: string;
+  mainSha256?: string;
+}
+
+const EXTENSIONS_DIR = join(workspaceRoot, 'dist/apps/vscode-e2e/extensions');
+
+/**
+ * Selects the Nx Console build under test: this worktree's build by default,
+ * a released version from the Marketplace, or a given VSIX or extension directory.
+ */
+export async function resolveExtension(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ExtensionInfo> {
+  const version = env.VSCODE_E2E_EXTENSION_VERSION || undefined;
+  const path = env.VSCODE_E2E_EXTENSION_PATH || undefined;
+  if (version && path) {
+    throw new Error(
+      'Set either VSCODE_E2E_EXTENSION_VERSION or VSCODE_E2E_EXTENSION_PATH, not both',
+    );
+  }
+  if (version) {
+    const vsix = join(EXTENSIONS_DIR, `nrwl.angular-console-${version}.vsix`);
+    if (!existsSync(vsix)) {
+      await downloadVsix(getMarketplaceVsixUrl(version), vsix);
+    }
+    return describeExtension(extractVsix(vsix), 'marketplace');
+  }
+  if (path?.endsWith('.vsix')) {
+    return describeExtension(extractVsix(resolve(path)), 'vsix');
+  }
+  if (path) {
+    return describeExtension(resolve(path), 'directory');
+  }
+  return describeExtension(
+    join(workspaceRoot, 'dist/apps/vscode'),
+    'workspace',
+  );
+}
+
+async function downloadVsix(url: string, destination: string): Promise<void> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(180_000) });
+  if (!response.ok) {
+    throw new Error(`Downloading ${url} failed with HTTP ${response.status}`);
+  }
+  let data: Buffer = Buffer.from(await response.arrayBuffer());
+  // The Marketplace can serve the package gzip-compressed without a Content-Encoding header.
+  if (data[0] === 0x1f && data[1] === 0x8b) {
+    data = gunzipSync(data);
+  }
+  if (data.subarray(0, 2).toString() !== 'PK') {
+    throw new Error(`${url} did not return a VSIX archive`);
+  }
+  mkdirSync(EXTENSIONS_DIR, { recursive: true });
+  writeFileSync(destination, data);
+}
+
+function extractVsix(vsix: string): string {
+  const hash = sha256(vsix).slice(0, 12);
+  const target = join(EXTENSIONS_DIR, `${basename(vsix, '.vsix')}-${hash}`);
+  const extension = join(target, 'extension');
+  if (!existsSync(join(extension, 'package.json'))) {
+    rmSync(target, { recursive: true, force: true });
+    mkdirSync(target, { recursive: true });
+    execFileSync('unzip', ['-q', vsix, '-d', target], { stdio: 'pipe' });
+  }
+  return extension;
+}
+
+function describeExtension(
+  path: string,
+  source: ExtensionInfo['source'],
+): ExtensionInfo {
+  const packageJsonPath = join(path, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    throw new Error(
+      `No VS Code extension at ${path}${source === 'workspace' ? '. Build it with yarn nx run vscode:build.' : ''}`,
+    );
+  }
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const main = join(path, packageJson.main ?? 'main.js');
+  return {
+    path,
+    source,
+    version: packageJson.version,
+    mainSha256: existsSync(main) ? sha256(main) : undefined,
+  };
+}
+
+function sha256(file: string): string {
+  return createHash('sha256').update(readFileSync(file)).digest('hex');
+}

--- a/apps/vscode-e2e/fixtures/ide.ts
+++ b/apps/vscode-e2e/fixtures/ide.ts
@@ -1,0 +1,386 @@
+import { chromium, type Browser, type Page } from '@playwright/test';
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { workspaceRoot } from 'nx/src/devkit-exports';
+import { NxConsolePage } from '../page-objects/nx-console-page';
+import { startDisplay } from './display';
+import type { ExtensionInfo } from './extension';
+import {
+  DEFAULT_VSCODE_VERSION,
+  EXTENSION_ID,
+  parseDevToolsUrl,
+  resolveVSCodeExecutable,
+} from './vscode-e2e-runtime';
+import { VSCodeEvaluator, cleanupMarkerFile } from './vscode-evaluator';
+import {
+  getWorkspaceFixture,
+  stopNxDaemon,
+  type FixtureContext,
+} from './workspaces';
+
+export const AUTOMATION_IDE_DIR = join(
+  workspaceRoot,
+  'dist/apps/vscode-e2e/automation-ide',
+);
+export const SESSION_FILE = join(AUTOMATION_IDE_DIR, 'session.json');
+export const RUNNER_PATH = join(
+  workspaceRoot,
+  'dist/apps/vscode-e2e/runner/index.js',
+);
+
+const DEFAULT_SETTINGS = {
+  'telemetry.telemetryLevel': 'off',
+  'update.mode': 'none',
+  'extensions.autoUpdate': false,
+  'workbench.tips.enabled': false,
+  'workbench.startupEditor': 'none',
+  'workbench.enableExperiments': false,
+  'security.workspace.trust.enabled': false,
+  'window.dialogStyle': 'custom',
+  'window.titleBarStyle': 'custom',
+  // Git must remain enabled: Nx Console depends on the Git extension API.
+  'git.autofetch': false,
+  // Proof files live in the Nx Console repository; don't offer to open it.
+  'git.openRepositoryInParentFolders': 'never',
+  'workbench.colorTheme': 'Default Dark Modern',
+  'editor.fontSize': 18,
+  'editor.minimap.enabled': false,
+  'window.zoomLevel': 0,
+  'chat.disableAIFeatures': true,
+};
+
+export interface IdeSession {
+  pid: number;
+  cdpUrl: string;
+  markerId: string;
+  token: string;
+  worktree: string;
+  workspacePath: string;
+  fixture?: string;
+  extension: ExtensionInfo;
+  vscodeVersion: string;
+  executable: string;
+  userDataDir: string;
+  startedAt: string;
+}
+
+export interface LaunchIdeOptions {
+  /** Keep this path short: VS Code creates IPC sockets under it, and macOS limits socket paths to 104 bytes. */
+  sandboxDir: string;
+  executable: string;
+  vscodeVersion: string;
+  extension: ExtensionInfo;
+  fixture?: string;
+  fixtureContext?: FixtureContext;
+  workspacePath?: string;
+  userSettings?: Record<string, unknown>;
+  log: (text: string) => void;
+}
+
+export interface LaunchedIde {
+  session: IdeSession;
+  process: ChildProcess;
+  /** Stops VS Code and everything the launch created; returns cleanup failures. */
+  stop(): Promise<string[]>;
+}
+
+export interface ConnectedIde {
+  browser: Browser;
+  page: Page;
+  evaluator: VSCodeEvaluator;
+  nxConsole: NxConsolePage;
+  disconnect(): Promise<void>;
+}
+
+export async function prepareVSCode(): Promise<{
+  executable: string;
+  vscodeVersion: string;
+}> {
+  const vscodeVersion =
+    process.env.VSCODE_E2E_VERSION || DEFAULT_VSCODE_VERSION;
+  const executable = resolveVSCodeExecutable(
+    process.env.VSCODE_E2E_BINARY_PATH ||
+      (await downloadAndUnzipVSCode(vscodeVersion)),
+  );
+  return { executable, vscodeVersion };
+}
+
+function shortTempRoot(): string {
+  return process.platform === 'darwin' ? '/tmp' : tmpdir();
+}
+
+export function createSandboxDir(): string {
+  return realpathSync(mkdtempSync(join(shortTempRoot(), 'nxc-')));
+}
+
+export function getPersistentSandboxDir(): string {
+  const hash = createHash('sha256').update(workspaceRoot).digest('hex');
+  const dir = join(shortTempRoot(), `nxc-ide-${hash.slice(0, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  return realpathSync(dir);
+}
+
+export async function launchIde(
+  options: LaunchIdeOptions,
+): Promise<LaunchedIde> {
+  const { sandboxDir, log } = options;
+  const userDataDir = join(sandboxDir, 'user-data');
+  const extensionsDir = join(sandboxDir, 'extensions');
+  mkdirSync(join(userDataDir, 'User'), { recursive: true });
+  mkdirSync(extensionsDir, { recursive: true });
+
+  const fixtureName = options.workspacePath
+    ? undefined
+    : (options.fixture ?? 'demo');
+  const fixture = fixtureName ? getWorkspaceFixture(fixtureName) : undefined;
+  const workspacePath = options.workspacePath ?? join(sandboxDir, 'workspace');
+  if (fixture) {
+    rmSync(workspacePath, { recursive: true, force: true });
+    mkdirSync(workspacePath, { recursive: true });
+    fixture.create(workspacePath, options.fixtureContext ?? {});
+  }
+  if (!existsSync(join(workspacePath, 'node_modules', 'nx'))) {
+    throw new Error(
+      `The workspace needs its dependencies installed: ${workspacePath}`,
+    );
+  }
+  writeFileSync(
+    join(userDataDir, 'User', 'settings.json'),
+    JSON.stringify(
+      { ...DEFAULT_SETTINGS, ...fixture?.settings, ...options.userSettings },
+      null,
+      2,
+    ),
+  );
+
+  const markerId = randomUUID();
+  const token = randomUUID();
+  cleanupMarkerFile(markerId);
+  const display = await startDisplay(log);
+
+  // The IDE should behave like a user's editor, not inherit the Nx task or agent environment of the caller.
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!/^(NX_|CLAUDECODE|OPENCODE|ELECTRON_RUN_AS_NODE$|CI$)/.test(key)) {
+      env[key] = value;
+    }
+  }
+  Object.assign(env, { NX_NO_CLOUD: 'true' }, fixture?.env, {
+    VSCODE_E2E_MARKER_ID: markerId,
+    VSCODE_E2E_TOKEN: token,
+  });
+  if (display.display) env.DISPLAY = display.display;
+
+  const child = spawn(
+    options.executable,
+    [
+      '--no-sandbox',
+      '--disable-gpu-sandbox',
+      '--disable-updates',
+      '--skip-welcome',
+      '--skip-release-notes',
+      '--disable-workspace-trust',
+      '--remote-debugging-port=0',
+      `--extensionDevelopmentPath=${options.extension.path}`,
+      `--extensionTestsPath=${RUNNER_PATH}`,
+      `--extensions-dir=${extensionsDir}`,
+      `--user-data-dir=${userDataDir}`,
+      workspacePath,
+    ],
+    {
+      env,
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const exited = new Promise<void>((resolve) =>
+    child.once('exit', () => resolve()),
+  );
+
+  const signal = (name: NodeJS.Signals, group: boolean) => {
+    if (!child.pid) return;
+    try {
+      // VS Code's helpers, extension host and language server share its process group.
+      process.kill(
+        group && process.platform !== 'win32' ? -child.pid : child.pid,
+        name,
+      );
+    } catch {
+      // Already exited.
+    }
+  };
+  const waitForExit = (timeout: number) =>
+    Promise.race([
+      exited.then(() => true),
+      new Promise<boolean>((resolve) =>
+        setTimeout(() => resolve(false), timeout),
+      ),
+    ]);
+
+  const stop = async (): Promise<string[]> => {
+    const errors: string[] = [];
+    if (child.exitCode === null && child.signalCode === null) {
+      // Signal only the main process first so VS Code stops its extension host and flushes logs.
+      signal('SIGTERM', false);
+      if (!(await waitForExit(10_000))) {
+        signal('SIGKILL', true);
+        await waitForExit(5_000);
+      }
+    }
+    signal('SIGTERM', true);
+    if (fixture) {
+      try {
+        stopNxDaemon(workspacePath);
+      } catch (error) {
+        errors.push(`stop Nx daemon: ${error}`);
+      }
+    }
+    display.close();
+    cleanupMarkerFile(markerId);
+    return errors;
+  };
+
+  try {
+    const cdpUrl = await new Promise<string>((resolve, reject) => {
+      let output = '';
+      let found = false;
+      const timer = setTimeout(
+        () =>
+          reject(
+            new Error(
+              'VS Code did not open a DevTools endpoint within 60 seconds',
+            ),
+          ),
+        60_000,
+      );
+      const onData = (data: Buffer) => {
+        const text = data.toString();
+        log(text);
+        if (found) return;
+        output += text;
+        const url = parseDevToolsUrl(output);
+        if (url) {
+          found = true;
+          clearTimeout(timer);
+          resolve(url);
+        }
+      };
+      child.stdout?.on('data', onData);
+      child.stderr?.on('data', onData);
+      child.once('error', (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.once('exit', (code, signalName) => {
+        clearTimeout(timer);
+        reject(
+          new Error(`VS Code exited during startup (${code ?? signalName})`),
+        );
+      });
+    });
+
+    return {
+      process: child,
+      stop,
+      session: {
+        pid: child.pid!,
+        cdpUrl,
+        markerId,
+        token,
+        worktree: workspaceRoot,
+        workspacePath,
+        fixture: fixtureName,
+        extension: options.extension,
+        vscodeVersion: options.vscodeVersion,
+        executable: options.executable,
+        userDataDir,
+        startedAt: new Date().toISOString(),
+      },
+    };
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+}
+
+export async function connectIde(
+  session: IdeSession,
+  timeout = 90_000,
+): Promise<ConnectedIde> {
+  const browser = await chromium.connectOverCDP(session.cdpUrl, {
+    timeout: 30_000,
+  });
+  try {
+    const page = await findWorkbench(browser, timeout);
+    const evaluator = new VSCodeEvaluator(session.markerId, session.token);
+    await evaluator.connect();
+    await evaluator.evaluate(async (vscode, id: string) => {
+      const extension = vscode.extensions.getExtension(id);
+      if (!extension) {
+        throw new Error(`${id} is not loaded in this VS Code window`);
+      }
+      await extension.activate();
+    }, EXTENSION_ID);
+    return {
+      browser,
+      page,
+      evaluator,
+      nxConsole: new NxConsolePage(page, evaluator),
+      disconnect: async () => {
+        // Closing a browser obtained through connectOverCDP only disconnects from it.
+        await browser.close();
+      },
+    };
+  } catch (error) {
+    await browser.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function findWorkbench(browser: Browser, timeout: number): Promise<Page> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const context of browser.contexts()) {
+      const page = context
+        .pages()
+        .find((candidate) => candidate.url().includes('workbench'));
+      if (page) return page;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error('The VS Code workbench window did not open');
+}
+
+export function writeSession(session: IdeSession): void {
+  mkdirSync(AUTOMATION_IDE_DIR, { recursive: true });
+  writeFileSync(SESSION_FILE, JSON.stringify(session, null, 2));
+}
+
+/** Returns the running automation IDE of this worktree, if any. */
+export function readSession(): IdeSession | undefined {
+  if (!existsSync(SESSION_FILE)) return undefined;
+  const session = JSON.parse(readFileSync(SESSION_FILE, 'utf8')) as IdeSession;
+  try {
+    process.kill(session.pid, 0);
+  } catch {
+    return undefined;
+  }
+  if (session.worktree !== workspaceRoot) {
+    throw new Error(
+      `${SESSION_FILE} belongs to ${session.worktree}, not ${workspaceRoot}`,
+    );
+  }
+  return session;
+}

--- a/apps/vscode-e2e/fixtures/proof.ts
+++ b/apps/vscode-e2e/fixtures/proof.ts
@@ -1,0 +1,62 @@
+import { writeFileSync } from 'node:fs';
+import type { VSCodeEvaluator } from './vscode-evaluator';
+
+/**
+ * A text file shown in an editor next to the UI under test, so a recording
+ * carries the measured facts behind each assertion.
+ */
+export class ProofLog {
+  private readonly lines: string[];
+
+  constructor(
+    private readonly evaluator: VSCodeEvaluator,
+    private readonly file: string,
+    heading: string[],
+    private readonly pauseMs: number,
+  ) {
+    this.lines = [...heading];
+  }
+
+  get text(): string {
+    return `${this.lines.join('\n')}\n`;
+  }
+
+  async show(line: string): Promise<void> {
+    this.lines.push(line);
+    const expected = this.text;
+    writeFileSync(this.file, expected);
+    const updated = await this.evaluator.evaluate(
+      async (vscode, path: string, content: string) => {
+        const document = await vscode.workspace.openTextDocument(
+          vscode.Uri.file(path),
+        );
+        const editor = await vscode.window.showTextDocument(document, {
+          preview: false,
+          preserveFocus: true,
+        });
+        for (
+          let attempt = 0;
+          attempt < 50 && editor.document.getText() !== content;
+          attempt++
+        ) {
+          await vscode.commands.executeCommand('workbench.action.files.revert');
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        const last = editor.document.lineCount - 1;
+        editor.revealRange(
+          new vscode.Range(last, 0, last, 0),
+          vscode.TextEditorRevealType.InCenterIfOutsideViewport,
+        );
+        return editor.document.getText() === content;
+      },
+      this.file,
+      expected,
+    );
+    if (!updated) {
+      throw new Error(`The proof editor did not show "${line}"`);
+    }
+    if (this.pauseMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.pauseMs));
+    }
+  }
+}

--- a/apps/vscode-e2e/fixtures/screencast.ts
+++ b/apps/vscode-e2e/fixtures/screencast.ts
@@ -1,0 +1,82 @@
+import type { CDPSession, Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createConcatList, type ScreencastFrame } from './vscode-e2e-runtime';
+
+/**
+ * Records the VS Code window through the DevTools screencast, which works both
+ * for an IDE launched by the test and for an already running automation IDE.
+ */
+export class ScreencastRecorder {
+  private readonly frames: ScreencastFrame[] = [];
+  private readonly acknowledgements: Promise<unknown>[] = [];
+
+  private constructor(
+    private readonly session: CDPSession,
+    private readonly framesDir: string,
+  ) {}
+
+  static async start(
+    page: Page,
+    framesDir: string,
+  ): Promise<ScreencastRecorder> {
+    mkdirSync(framesDir, { recursive: true });
+    const session = await page.context().newCDPSession(page);
+    const recorder = new ScreencastRecorder(session, framesDir);
+    session.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
+      const file = `${String(recorder.frames.length).padStart(6, '0')}.jpg`;
+      writeFileSync(join(framesDir, file), Buffer.from(data, 'base64'));
+      recorder.frames.push({
+        file,
+        timestamp: metadata.timestamp ?? Date.now() / 1000,
+      });
+      recorder.acknowledgements.push(
+        session
+          .send('Page.screencastFrameAck', { sessionId })
+          .catch(() => undefined),
+      );
+    });
+    await session.send('Page.startScreencast', {
+      format: 'jpeg',
+      quality: 80,
+      maxWidth: 1920,
+      maxHeight: 1080,
+    });
+    return recorder;
+  }
+
+  async stop(output: string): Promise<void> {
+    const end = Date.now() / 1000;
+    await this.session.send('Page.stopScreencast').catch(() => undefined);
+    await Promise.all(this.acknowledgements);
+    await this.session.detach().catch(() => undefined);
+    const list = join(this.framesDir, 'frames.ffconcat');
+    writeFileSync(list, createConcatList(this.frames, end));
+    execFileSync(
+      'ffmpeg',
+      [
+        '-y',
+        '-loglevel',
+        'error',
+        '-f',
+        'concat',
+        '-safe',
+        '0',
+        '-i',
+        list,
+        '-vf',
+        'scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,format=yuv420p',
+        '-r',
+        '25',
+        '-c:v',
+        'libx264',
+        '-movflags',
+        '+faststart',
+        output,
+      ],
+      { stdio: 'pipe', timeout: 300_000 },
+    );
+    rmSync(this.framesDir, { recursive: true, force: true });
+  }
+}

--- a/apps/vscode-e2e/fixtures/vscode-e2e-runtime.spec.ts
+++ b/apps/vscode-e2e/fixtures/vscode-e2e-runtime.spec.ts
@@ -1,30 +1,88 @@
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 import {
+  createConcatList,
   getCommandPaletteShortcut,
   getMarkerFilePath,
-  getMarkerId,
-  getWorkerDisplay,
+  getMarketplaceVsixUrl,
+  parseDevToolsUrl,
+  resolveVSCodeExecutable,
+  validateLabel,
 } from './vscode-e2e-runtime.ts';
 
-test('marker ids and file paths are worker-specific', () => {
-  const firstWorkerId = getMarkerId(0);
-  const secondWorkerId = getMarkerId(1);
-
-  assert.notStrictEqual(firstWorkerId, secondWorkerId);
-  assert.notStrictEqual(
-    getMarkerFilePath(firstWorkerId),
-    getMarkerFilePath(secondWorkerId),
-  );
+test('marker files are unique per marker id', () => {
+  assert.notEqual(getMarkerFilePath('a'), getMarkerFilePath('b'));
 });
 
 test('command palette shortcut matches host platform conventions', () => {
-  assert.strictEqual(getCommandPaletteShortcut('darwin'), 'Meta+Shift+P');
-  assert.strictEqual(getCommandPaletteShortcut('linux'), 'Control+Shift+P');
-  assert.strictEqual(getCommandPaletteShortcut('win32'), 'Control+Shift+P');
+  assert.equal(getCommandPaletteShortcut('darwin'), 'Meta+Shift+P');
+  assert.equal(getCommandPaletteShortcut('linux'), 'Control+Shift+P');
+  assert.equal(getCommandPaletteShortcut('win32'), 'Control+Shift+P');
 });
 
-test('linux workers receive unique displays', () => {
-  assert.strictEqual(getWorkerDisplay(0), ':99');
-  assert.strictEqual(getWorkerDisplay(3), ':102');
+test('resolves the renamed macOS binary, keeps the legacy binary and rejects missing installs', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vscode-binary-test-'));
+  try {
+    const legacy = join(dir, 'Electron');
+    assert.throws(() => resolveVSCodeExecutable(legacy), /does not exist/);
+    writeFileSync(join(dir, 'Code'), '');
+    assert.equal(resolveVSCodeExecutable(legacy), join(dir, 'Code'));
+    writeFileSync(legacy, '');
+    assert.equal(resolveVSCodeExecutable(legacy), legacy);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('labels must be usable as directory names', () => {
+  assert.equal(validateLabel('issue-3193-repro'), 'issue-3193-repro');
+  assert.equal(validateLabel('nx-console-18.101.1'), 'nx-console-18.101.1');
+  assert.throws(() => validateLabel('../escape'), /NX_AUTOMATION_LABEL/);
+  assert.throws(() => validateLabel('with space'), /NX_AUTOMATION_LABEL/);
+});
+
+test('marketplace downloads require an exact release', () => {
+  assert.equal(
+    getMarketplaceVsixUrl('18.101.1'),
+    'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/nrwl/vsextensions/angular-console/18.101.1/vspackage',
+  );
+  assert.throws(() => getMarketplaceVsixUrl('latest'), /exact release/);
+});
+
+test('finds the DevTools endpoint in VS Code startup output', () => {
+  assert.equal(
+    parseDevToolsUrl(
+      'Warning\nDevTools listening on ws://127.0.0.1:53811/devtools/browser/5b1f\n',
+    ),
+    'ws://127.0.0.1:53811/devtools/browser/5b1f',
+  );
+  assert.equal(parseDevToolsUrl('DevTools listening on'), undefined);
+});
+
+test('screencast frames keep their capture timing', () => {
+  assert.equal(
+    createConcatList(
+      [
+        { file: '000000.jpg', timestamp: 10 },
+        { file: '000001.jpg', timestamp: 10.5 },
+        { file: '000002.jpg', timestamp: 10.51 },
+      ],
+      12,
+    ),
+    [
+      'ffconcat version 1.0',
+      "file '000000.jpg'",
+      'duration 0.500',
+      "file '000001.jpg'",
+      'duration 0.040',
+      "file '000002.jpg'",
+      'duration 1.490',
+      "file '000002.jpg'",
+      '',
+    ].join('\n'),
+  );
+  assert.throws(() => createConcatList([], 1), /No screencast frames/);
 });

--- a/apps/vscode-e2e/fixtures/vscode-e2e-runtime.ts
+++ b/apps/vscode-e2e/fixtures/vscode-e2e-runtime.ts
@@ -1,10 +1,14 @@
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 export const MARKER_DIR = join(tmpdir(), 'vscode-e2e-test-server');
+export const DEFAULT_VSCODE_VERSION = '1.137.0';
+export const EXTENSION_ID = 'nrwl.angular-console';
 
-export function getMarkerId(workerIndex: number): string {
-  return `worker-${workerIndex}`;
+export interface ScreencastFrame {
+  file: string;
+  timestamp: number;
 }
 
 export function getMarkerFilePath(markerId: string): string {
@@ -17,6 +21,58 @@ export function getCommandPaletteShortcut(
   return platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P';
 }
 
-export function getWorkerDisplay(workerIndex: number): string {
-  return `:${99 + workerIndex}`;
+export function isEnabled(value: string | undefined): boolean {
+  return value === '1' || value === 'true';
+}
+
+export function resolveVSCodeExecutable(downloadedPath: string): string {
+  if (existsSync(downloadedPath)) return downloadedPath;
+  // Newer macOS bundles renamed Electron to Code; older downloaders return the old name.
+  const codePath = join(dirname(downloadedPath), 'Code');
+  if (existsSync(codePath)) return codePath;
+  throw new Error(`VS Code executable does not exist: ${downloadedPath}`);
+}
+
+export function validateLabel(label: string): string {
+  if (!/^[\w.-]+$/.test(label)) {
+    throw new Error(
+      `NX_AUTOMATION_LABEL "${label}" may only contain letters, numbers, dots, underscores and hyphens`,
+    );
+  }
+  return label;
+}
+
+export function getMarketplaceVsixUrl(version: string): string {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(
+      `Nx Console version must be an exact release such as 18.101.1, got "${version}"`,
+    );
+  }
+  return `https://marketplace.visualstudio.com/_apis/public/gallery/publishers/nrwl/vsextensions/angular-console/${version}/vspackage`;
+}
+
+export function parseDevToolsUrl(output: string): string | undefined {
+  return /DevTools listening on (ws:\/\/\S+)/.exec(output)?.[1];
+}
+
+/**
+ * Chromium only emits a screencast frame when the page changes, so each frame
+ * is held until the next one (or the end of the recording) to keep real time.
+ */
+export function createConcatList(
+  frames: ScreencastFrame[],
+  endTimestamp: number,
+): string {
+  if (frames.length === 0) throw new Error('No screencast frames to encode');
+  const lines = ['ffconcat version 1.0'];
+  frames.forEach((frame, index) => {
+    const next = frames[index + 1]?.timestamp ?? endTimestamp;
+    lines.push(
+      `file '${frame.file}'`,
+      `duration ${Math.max(next - frame.timestamp, 0.04).toFixed(3)}`,
+    );
+  });
+  // The concat demuxer ignores the duration of the final entry unless it is repeated.
+  lines.push(`file '${frames[frames.length - 1].file}'`);
+  return `${lines.join('\n')}\n`;
 }

--- a/apps/vscode-e2e/fixtures/vscode-evaluator.ts
+++ b/apps/vscode-e2e/fixtures/vscode-evaluator.ts
@@ -9,7 +9,10 @@ export function cleanupMarkerFile(markerId: string): void {
 }
 
 export class VSCodeEvaluator {
-  constructor(private readonly markerId: string) {}
+  constructor(
+    private readonly markerId: string,
+    private readonly token: string,
+  ) {}
 
   private serverUrl: string | undefined;
 
@@ -21,6 +24,7 @@ export class VSCodeEvaluator {
     this.serverUrl = await new Promise<string>((resolve, reject) => {
       const markerFilePath = getMarkerFilePath(this.markerId);
       const timeout = setTimeout(() => {
+        clearInterval(poll);
         reject(
           new Error(
             `Timed out waiting for VSCodeTestServer URL at ${markerFilePath}`,
@@ -49,9 +53,16 @@ export class VSCodeEvaluator {
 
     const response = await fetch(`${this.serverUrl}/invoke`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.token}`,
+      },
       body: JSON.stringify({ fn: fn.toString(), params: args }),
+      signal: AbortSignal.timeout(60_000),
     });
+
+    if (!response.ok)
+      throw new Error(`VS Code evaluator returned HTTP ${response.status}`);
 
     const data = (await response.json()) as {
       result?: T;

--- a/apps/vscode-e2e/fixtures/workspaces.ts
+++ b/apps/vscode-e2e/fixtures/workspaces.ts
@@ -1,0 +1,204 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { workspaceRoot } from 'nx/src/devkit-exports';
+
+export interface FixtureContext {
+  nxCloudUrl?: string;
+}
+
+export interface WorkspaceFixture {
+  description: string;
+  /** VS Code user settings applied on top of the harness defaults. */
+  settings?: Record<string, unknown>;
+  /** Environment variables for the VS Code process. */
+  env?: Record<string, string>;
+  create(path: string, context: FixtureContext): void;
+}
+
+interface ProjectConfiguration {
+  name: string;
+  targets?: Record<string, unknown>;
+}
+
+const nxVersion: string = require('nx/package.json').version;
+
+function runCommand(command: string) {
+  return { executor: 'nx:run-commands', cache: false, options: { command } };
+}
+
+export function writeWorkspace(
+  path: string,
+  {
+    projects,
+    files = {},
+    nxJson = {},
+  }: {
+    projects: Record<string, ProjectConfiguration>;
+    files?: Record<string, string>;
+    nxJson?: Record<string, unknown>;
+  },
+): void {
+  const write = (file: string, content: string) => {
+    mkdirSync(dirname(join(path, file)), { recursive: true });
+    writeFileSync(join(path, file), content);
+  };
+  const json = (file: string, value: unknown) =>
+    write(file, `${JSON.stringify(value, null, 2)}\n`);
+
+  json('package.json', {
+    name: 'vscode-automation-fixture',
+    private: true,
+    devDependencies: { nx: nxVersion },
+  });
+  json('package-lock.json', {
+    name: 'vscode-automation-fixture',
+    lockfileVersion: 3,
+    packages: { '': { devDependencies: { nx: nxVersion } } },
+  });
+  json('nx.json', { analytics: false, defaultBase: 'main', ...nxJson });
+  for (const [root, project] of Object.entries(projects)) {
+    json(join(root, 'project.json'), project);
+  }
+  for (const [file, content] of Object.entries(files)) {
+    write(file, content);
+  }
+  write('.gitignore', 'node_modules\n.nx\n');
+  // Fixtures reuse the repository's installed packages; each one owns its graph, files and Git repository.
+  symlinkSync(
+    join(workspaceRoot, 'node_modules'),
+    join(path, 'node_modules'),
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+  for (const args of [
+    ['init', '-b', 'main'],
+    ['config', 'user.name', 'Nx Console Automation'],
+    ['config', 'user.email', 'automation@example.invalid'],
+    ['add', '.'],
+    ['-c', 'commit.gpgsign=false', 'commit', '-m', 'Automation fixture'],
+  ]) {
+    execFileSync('git', args, { cwd: path, stdio: 'pipe' });
+  }
+}
+
+function nxEnv(workspacePath: string): NodeJS.ProcessEnv {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('NX_')),
+  );
+  return { ...env, NX_WORKSPACE_ROOT_PATH: workspacePath };
+}
+
+/** Runs the fixture's Nx CLI without its daemon, e.g. to read the graph Nx Console should render. */
+export function runNx(workspacePath: string, args: string[]): string {
+  return execFileSync(
+    process.execPath,
+    [require.resolve('nx/bin/nx'), ...args],
+    {
+      cwd: workspacePath,
+      env: { ...nxEnv(workspacePath), NX_DAEMON: 'false', NX_NO_CLOUD: 'true' },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    },
+  );
+}
+
+export function stopNxDaemon(workspacePath: string): void {
+  execFileSync(
+    process.execPath,
+    [require.resolve('nx/bin/nx'), 'daemon', '--stop'],
+    {
+      cwd: workspacePath,
+      env: nxEnv(workspacePath),
+      stdio: 'pipe',
+      timeout: 30_000,
+    },
+  );
+}
+
+export const nestedProjectParents = [
+  {
+    name: 'parent-e2e',
+    root: 'e2es/parent',
+    targets: [] as string[],
+    children: [
+      { name: 'parent-child-a-e2e', root: 'e2es/parent/child-a-e2e' },
+      { name: 'parent-child-b-e2e', root: 'e2es/parent/child-b-e2e' },
+    ],
+  },
+  {
+    name: 'parent-with-target-e2e',
+    root: 'e2es/parent-with-target',
+    targets: ['e2e'],
+    children: [
+      {
+        name: 'parent-with-target-child-c-e2e',
+        root: 'e2es/parent-with-target/child-c-e2e',
+      },
+    ],
+  },
+];
+
+export const workspaceFixtures: Record<string, WorkspaceFixture> = {
+  demo: {
+    description: 'One project, `demo`, with `hello` and `check` targets.',
+    create: (path) =>
+      writeWorkspace(path, {
+        projects: {
+          demo: {
+            name: 'demo',
+            targets: {
+              hello: runCommand('node demo/hello.cjs'),
+              check: runCommand('node demo/hello.cjs'),
+            },
+          },
+        },
+        files: {
+          'demo/hello.cjs':
+            'console.log("Hello from the automation fixture");\n',
+        },
+      }),
+  },
+  'nested-projects': {
+    description:
+      'Projects nested inside other projects under `e2es` (one parent without targets, one with an `e2e` target), plus ten libraries so the automatic Projects view style resolves to the folder tree.',
+    create: (path) => {
+      const projects: Record<string, ProjectConfiguration> = {};
+      for (const parent of nestedProjectParents) {
+        projects[parent.root] = {
+          name: parent.name,
+          targets: Object.fromEntries(
+            parent.targets.map((target) => [
+              target,
+              runCommand(`echo ${target}`),
+            ]),
+          ),
+        };
+        for (const child of parent.children) {
+          projects[child.root] = {
+            name: child.name,
+            targets: { e2e: runCommand('echo e2e') },
+          };
+        }
+      }
+      for (let index = 1; index <= 10; index++) {
+        const name = `lib-${String(index).padStart(2, '0')}`;
+        projects[`libs/${name}`] = {
+          name,
+          targets: { build: runCommand('echo build') },
+        };
+      }
+      writeWorkspace(path, { projects });
+    },
+  },
+};
+
+export function getWorkspaceFixture(name: string): WorkspaceFixture {
+  const fixture = workspaceFixtures[name];
+  if (!fixture) {
+    throw new Error(
+      `Unknown workspace fixture "${name}". Available: ${Object.keys(workspaceFixtures).join(', ')}`,
+    );
+  }
+  return fixture;
+}

--- a/apps/vscode-e2e/page-objects/nx-console-page.ts
+++ b/apps/vscode-e2e/page-objects/nx-console-page.ts
@@ -16,7 +16,8 @@ export class NxConsolePage extends VSCodePage {
   }
 
   async openNxConsoleSidebar(): Promise<void> {
-    await this.activityBar.openTab('Nx Console');
+    // Clicking the activity bar tab would hide the sidebar when it is already open.
+    await this.executeCommand('workbench.view.extension.nx-console');
   }
 
   async waitForNxConsoleReady(timeout = 60_000): Promise<void> {
@@ -39,6 +40,31 @@ export class NxConsolePage extends VSCodePage {
     return this.projectsSection.locator(
       `.monaco-list-row[aria-label*="${name}"]`,
     );
+  }
+
+  /** A Projects view row whose label is exactly `label`. */
+  getTreeRow(label: string): Locator {
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return this.projectsSection.locator('.monaco-list-row').filter({
+      has: this.page.locator('.label-name', {
+        hasText: new RegExp(`^${escaped}$`),
+      }),
+    });
+  }
+
+  /** Leaf rows have no aria-expanded attribute. */
+  async isTreeRowExpandable(label: string): Promise<boolean> {
+    return (
+      (await this.getTreeRow(label).getAttribute('aria-expanded')) !== null
+    );
+  }
+
+  async expandTreeRow(label: string): Promise<void> {
+    const row = this.getTreeRow(label);
+    if ((await row.getAttribute('aria-expanded')) === 'false') {
+      await row.locator('.monaco-tl-twistie').click();
+    }
+    await row.and(this.page.locator('[aria-expanded="true"]')).waitFor();
   }
 
   async expandProject(name: string): Promise<void> {

--- a/apps/vscode-e2e/playwright.config.ts
+++ b/apps/vscode-e2e/playwright.config.ts
@@ -1,39 +1,34 @@
 import { defineConfig } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { workspaceRoot } from 'nx/src/devkit-exports';
+import { validateLabel } from './fixtures/vscode-e2e-runtime';
 
-type VSCodeE2EWorkerOptions = {
-  vscodeVersion: string;
-};
+const label = validateLabel(process.env.NX_AUTOMATION_LABEL || 'run');
+// Set once in the runner process; workers inherit the same run directory.
+process.env.VSCODE_E2E_RUN_ID ??= `${label}-${new Date().toISOString().replace(/[:.]/g, '-')}-${randomUUID().slice(0, 8)}`;
+process.env.VSCODE_E2E_OUTPUT_DIR ??= join(
+  workspaceRoot,
+  'dist/apps/vscode-e2e/automation',
+  process.env.VSCODE_E2E_RUN_ID,
+);
+const outputDir = process.env.VSCODE_E2E_OUTPUT_DIR;
 
-export default defineConfig<{}, VSCodeE2EWorkerOptions>({
+export default defineConfig({
   testDir: './specs',
-  outputDir: '../../dist/apps/vscode-e2e/test-results',
+  outputDir: join(outputDir, 'tests'),
   globalSetup: './setup',
-  timeout: 120_000,
+  timeout: 180_000,
   expect: { timeout: 30_000 },
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : 4,
-  fullyParallel: true,
+  // Evidence comes from the first attempt; retries would hide a flaky reproduction.
+  retries: 0,
+  workers: 1,
+  preserveOutput: 'always',
   reporter: [
     ['list'],
-    [
-      'html',
-      {
-        outputFolder: '../../dist/apps/vscode-e2e/playwright-report',
-        open: 'never',
-      },
-    ],
+    ['html', { outputFolder: join(outputDir, 'report'), open: 'never' }],
+    ['json', { outputFile: join(outputDir, 'results.json') }],
+    ['junit', { outputFile: join(outputDir, 'junit.xml') }],
   ],
-  use: {
-    trace: 'on-first-retry',
-    video: 'on-first-retry',
-    screenshot: 'only-on-failure',
-  },
-  projects: [
-    {
-      name: 'VS Code Stable',
-      use: {
-        vscodeVersion: 'stable',
-      },
-    },
-  ],
+  projects: [{ name: 'VS Code' }],
 });

--- a/apps/vscode-e2e/project.json
+++ b/apps/vscode-e2e/project.json
@@ -9,27 +9,47 @@
     "e2e": {
       "command": "playwright test -c apps/vscode-e2e/playwright.config.ts",
       "dependsOn": [
-        {
-          "projects": "vscode",
-          "target": "build",
-          "params": "forward"
-        },
+        { "projects": "vscode", "target": "build" },
         "build-runner"
-      ]
+      ],
+      "cache": false
     },
     "e2e-local": {
       "command": "playwright test -c apps/vscode-e2e/playwright.config.ts",
       "dependsOn": [
-        {
-          "projects": "vscode",
-          "target": "build",
-          "params": "forward"
-        },
+        { "projects": "vscode", "target": "build" },
         "build-runner"
-      ]
+      ],
+      "cache": false
+    },
+    "record": {
+      "command": "playwright test -c apps/vscode-e2e/playwright.config.ts",
+      "dependsOn": [
+        { "projects": "vscode", "target": "build" },
+        "build-runner"
+      ],
+      "cache": false,
+      "options": {
+        "env": {
+          "PLAYWRIGHT_VSCODE_VIDEO": "1"
+        }
+      }
+    },
+    "automation-ide": {
+      "command": "node --require @swc-node/register apps/vscode-e2e/automation/launch.ts",
+      "dependsOn": [
+        { "projects": "vscode", "target": "build" },
+        "build-runner"
+      ],
+      "cache": false
+    },
+    "automation": {
+      "command": "node --require @swc-node/register apps/vscode-e2e/automation/cli.ts",
+      "cache": false
     },
     "test": {
-      "command": "node --require @swc-node/register --test apps/vscode-e2e/fixtures/vscode-e2e-runtime.spec.ts"
+      "command": "node --require @swc-node/register --test apps/vscode-e2e/fixtures/vscode-e2e-runtime.spec.ts",
+      "dependsOn": []
     },
     "build-runner": {
       "command": "esbuild apps/vscode-e2e/runner/src/index.ts --bundle --outfile=dist/apps/vscode-e2e/runner/index.js --platform=node --external:vscode --format=cjs",

--- a/apps/vscode-e2e/runner/src/index.ts
+++ b/apps/vscode-e2e/runner/src/index.ts
@@ -23,7 +23,17 @@ interface InvokeResponse {
  */
 export function run(): Promise<void> {
   return new Promise<void>((_resolve, reject) => {
+    const token = process.env.VSCODE_E2E_TOKEN;
+    if (!token) {
+      reject(new Error('Missing VSCODE_E2E_TOKEN'));
+      return;
+    }
     const server = http.createServer((req, res) => {
+      if (req.headers.authorization !== `Bearer ${token}`) {
+        res.writeHead(403);
+        res.end();
+        return;
+      }
       if (req.method !== 'POST' || req.url !== '/invoke') {
         res.writeHead(404);
         res.end();
@@ -54,10 +64,10 @@ export function run(): Promise<void> {
       });
     });
 
-    server.listen(0, () => {
+    server.listen(0, '127.0.0.1', () => {
       const address = server.address();
       if (address && typeof address !== 'string') {
-        const url = `http://localhost:${address.port}`;
+        const url = `http://127.0.0.1:${address.port}`;
         const markerId = process.env.VSCODE_E2E_MARKER_ID ?? `${process.pid}`;
         const markerFilePath = getMarkerFilePath(markerId);
 

--- a/apps/vscode-e2e/setup.ts
+++ b/apps/vscode-e2e/setup.ts
@@ -1,18 +1,71 @@
-import { downloadAndUnzipVSCode } from '@vscode/test-electron';
-import { execSync } from 'node:child_process';
-import { workspaceRoot } from 'nx/src/devkit-exports';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveExtension } from './fixtures/extension';
+import { RUNNER_PATH, prepareVSCode, readSession } from './fixtures/ide';
+import { isEnabled } from './fixtures/vscode-e2e-runtime';
 
 export default async function globalSetup() {
-  // Download VS Code stable for tests
-  const vscodePath = await downloadAndUnzipVSCode('stable');
-  process.env.VSCODE_E2E_BINARY_PATH = vscodePath;
+  const outputDir = process.env.VSCODE_E2E_OUTPUT_DIR!;
+  mkdirSync(outputDir, { recursive: true });
+  try {
+    if (isEnabled(process.env.PLAYWRIGHT_VSCODE_VIDEO)) {
+      try {
+        execFileSync('ffmpeg', ['-version'], {
+          stdio: 'pipe',
+          timeout: 10_000,
+        });
+      } catch {
+        throw new Error('Recording VS Code needs ffmpeg on the PATH');
+      }
+    }
 
-  execSync('yarn nx run vscode:build', {
-    cwd: workspaceRoot,
-    stdio: 'inherit',
-  });
-  execSync('yarn nx run vscode-e2e:build-runner', {
-    cwd: workspaceRoot,
-    stdio: 'inherit',
-  });
+    if (isEnabled(process.env.VSCODE_E2E_ATTACH)) {
+      const session = readSession();
+      if (!session) {
+        throw new Error(
+          'No automation IDE is running for this worktree. Start one with yarn nx run vscode-e2e:automation-ide.',
+        );
+      }
+      const { token: _token, ...details } = session;
+      writeFileSync(
+        join(outputDir, 'setup.json'),
+        JSON.stringify({ mode: 'attach', session: details }, null, 2),
+      );
+      return;
+    }
+
+    if (!existsSync(RUNNER_PATH)) {
+      throw new Error(
+        `Missing ${RUNNER_PATH}. Run scenarios through yarn nx run vscode-e2e:e2e.`,
+      );
+    }
+    const { executable, vscodeVersion } = await prepareVSCode();
+    const extension = await resolveExtension();
+    // Workers inherit environment variables set during global setup.
+    process.env.VSCODE_E2E_BINARY_PATH = executable;
+    process.env.VSCODE_E2E_VSCODE_VERSION = vscodeVersion;
+    process.env.VSCODE_E2E_EXTENSION_INFO = JSON.stringify(extension);
+    writeFileSync(
+      join(outputDir, 'setup.json'),
+      JSON.stringify(
+        {
+          mode: 'launch',
+          vscodeVersion,
+          executable,
+          extension,
+          nodeVersion: process.version,
+          platform: `${process.platform}-${process.arch}`,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    writeFileSync(
+      join(outputDir, 'setup-error.txt'),
+      String((error as Error)?.stack ?? error),
+    );
+    throw error;
+  }
 }

--- a/apps/vscode-e2e/specs/nested-projects-tree.test.ts
+++ b/apps/vscode-e2e/specs/nested-projects-tree.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '../base-test';
+import { nestedProjectParents, runNx } from '../fixtures/workspaces';
+
+test.use({ vscodeOptions: { fixture: 'nested-projects' } });
+
+// https://github.com/nrwl/nx-console/issues/3193
+test('nested projects are reachable in the Projects tree', async ({
+  vscode,
+}, testInfo) => {
+  const { nxConsole, workspacePath } = vscode;
+  const proof = vscode.proof([
+    'Nested projects in the Projects tree (#3193)',
+    vscode.build,
+    'nxConsole.projectViewingStyle: automatic, 15 projects → folder tree',
+    '',
+  ]);
+
+  const graph: string[] = JSON.parse(
+    runNx(workspacePath, ['show', 'projects', '--json']),
+  );
+  const nested = nestedProjectParents.flatMap((parent) => [
+    parent.name,
+    ...parent.children.map((child) => child.name),
+  ]);
+  await proof.show(
+    `nx show projects: ${nested.filter((name) => graph.includes(name)).length}/${nested.length} nested projects in the graph`,
+  );
+  expect(graph).toEqual(expect.arrayContaining(nested));
+
+  await nxConsole.openNxConsoleSidebar();
+  await nxConsole.waitForNxConsoleReady();
+  await nxConsole.expandTreeRow('e2es');
+
+  for (const parent of nestedProjectParents) {
+    await test.step(parent.name, async () => {
+      await expect(nxConsole.getTreeRow(parent.name)).toBeVisible();
+      const expandable = await nxConsole.isTreeRowExpandable(parent.name);
+      if (expandable) {
+        await nxConsole.expandTreeRow(parent.name);
+      }
+      const shown: string[] = [];
+      for (const child of parent.children) {
+        const visible = await nxConsole
+          .getTreeRow(child.name)
+          .waitFor({ timeout: 5_000 })
+          .then(
+            () => true,
+            () => false,
+          );
+        if (visible) shown.push(child.name);
+      }
+      const targets = parent.targets.length
+        ? `target ${parent.targets.join(', ')}`
+        : 'no targets';
+      await proof.show(
+        `${parent.name} (${targets}): ${expandable ? 'expandable' : 'LEAF'}, nested projects shown ${shown.length}/${parent.children.length}`,
+      );
+      expect.soft(expandable, `${parent.name} can be expanded`).toBe(true);
+      expect
+        .soft(shown, `${parent.name} shows its nested projects`)
+        .toEqual(parent.children.map((child) => child.name));
+    });
+  }
+
+  await proof.show(
+    testInfo.errors.length
+      ? 'RESULT: FAIL — nested projects are unreachable in the tree'
+      : 'RESULT: PASS — nested projects are reachable in the tree',
+  );
+});

--- a/apps/vscode-e2e/specs/smoke.test.ts
+++ b/apps/vscode-e2e/specs/smoke.test.ts
@@ -37,6 +37,8 @@ test('Nx Console smoke test', async ({ nxConsole }) => {
     })
     .toBeGreaterThan(2);
 
+  await expect(nxConsole.getTreeRow('demo')).toBeVisible({ timeout: 5000 });
+
   // Expanded project shows target items
   const rowCount = await projectsSection.locator('.monaco-list-row').count();
   expect(rowCount).toBeGreaterThan(2);

--- a/apps/vscode-e2e/tsconfig.json
+++ b/apps/vscode-e2e/tsconfig.json
@@ -4,14 +4,12 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
+    "outDir": "out-tsc/vscode-e2e",
+    "lib": ["es2022", "dom"],
     "types": ["node"],
     "ignoreDeprecations": "6.0"
   },
   "include": ["**/*.ts"],
-  "exclude": ["runner"],
-  "references": [
-    {
-      "path": "../../libs/shared/e2e-utils"
-    }
-  ]
+  "exclude": ["runner", "out-tsc"],
+  "references": []
 }


### PR DESCRIPTION
Brings the IntelliJ before/after automation workflow from #3209 to VS Code. Setup, commands and scenario guidance are in `apps/vscode-e2e/AUTOMATION.md`.

The existing VS Code E2E suite could no longer start: `@vscode/test-electron` 2.5.2 looks for `Contents/MacOS/Electron`, but VS Code 1.137 ships `Contents/MacOS/Code`. The last manual CI runs failed and produced no videos.

## Changes

- **Persistent automation IDE.** `yarn nx run vscode-e2e:automation-ide --fixture=<name>` opens a fixture in VS Code and keeps it running. `yarn nx run vscode-e2e:automation` inspects it (versions, rendered sidebar rows, notifications, DOM, screenshot), evaluates code in the extension host, or runs a script. With `VSCODE_E2E_ATTACH=1`, Playwright scenarios run against it instead of launching VS Code.
- **Evidence for every run.** `yarn nx run vscode-e2e:record` writes a labeled directory under `dist/apps/vscode-e2e/automation` with an MP4 (DevTools screencast), a proof text shown next to the UI, the final screenshot, DOM, trace, VS Code logs, metadata (revision, build under test) and a PASS/FAIL result. Evidence is kept when startup or an assertion fails.
- **Build under test.** This worktree's build by default, a Marketplace release with `VSCODE_E2E_EXTENSION_VERSION`, or a VSIX or extension directory with `VSCODE_E2E_EXTENSION_PATH`.
- **Fixtures.** Small workspaces in `fixtures/workspaces.ts` replace generating a React workspace per worker. Each links the repository's `node_modules` and owns its Git repository and Nx daemon.
- **Isolation.** Every launch gets its own profile, marker file and extension-host token, and a short socket path on macOS. The IDE doesn't inherit `NX_*` or `CI` from the caller.
- **CI.** The workflow runs on pull requests that change VS Code sources, on Ubuntu and macOS. It runs the harness unit tests, records every scenario, then runs the smoke scenario against a persistent IDE and uploads the evidence. Manual runs accept `extension-version`, `label` and `grep`.
- **Scenario for #3193**, nested projects in the Projects tree.

## Verification

- Harness unit tests (7) and `tsc` pass.
- Local runs on macOS with VS Code 1.137.0:
  - Smoke: PASS, with a recording.
  - #3193 on Nx Console 18.101.1 from the Marketplace: FAIL. `parent-e2e`, a project without targets, renders as a leaf, so 0 of its 2 nested projects are reachable. A parent with a target works.
  - #3193 on this branch's build: PASS, 2/2 and 1/1. #3170 fixed it on master, but no release contains that fix yet.
  - Persistent IDE: `inspect`, `eval`, two consecutive attached recordings, the fixture-mismatch error, and shutdown with no VS Code process or Nx daemon left behind.
- CI: pending on this PR.

## Notes

- Adding the `pull_request` trigger makes this workflow a PR check for VS Code changes. It can stay manual-only if the runtime is too high.
- #3111 changes the same harness files and relies on the previous React workspace fixture, so it will need rework on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoMLSrStmMG2UL991VjYLL
